### PR TITLE
Speed up nest()

### DIFF
--- a/R/nest.R
+++ b/R/nest.R
@@ -62,9 +62,12 @@ nest.data.frame <- function(data, ..., .key = "data") {
   }
 
   out <- dplyr::select(data, !!! syms(group_vars))
-  out <- dplyr::distinct(out)
 
   idx <- dplyr::group_indices(data, !!! syms(group_vars))
+  representatives <- !duplicated(idx)
+
+  out <- dplyr::slice(out, representatives)
+
   out[[key_var]] <- unname(split(data[nest_vars], idx))[unique(idx)]
 
   out

--- a/R/nest.R
+++ b/R/nest.R
@@ -64,7 +64,7 @@ nest.data.frame <- function(data, ..., .key = "data") {
   out <- dplyr::select(data, !!! syms(group_vars))
 
   idx <- dplyr::group_indices(data, !!! syms(group_vars))
-  representatives <- !duplicated(idx)
+  representatives <- which(!duplicated(idx))
 
   out <- dplyr::slice(out, representatives)
 

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -38,7 +38,7 @@ test_that("nesting everything yields a simple data frame", {
 })
 
 test_that("nesting works for empty data frames", {
-  df <- data_frame(x = 1:3, y = c("B", "A", "A"))[0, ]
+  df <- tibble(x = 1:3, y = c("B", "A", "A"))[0, ]
 
   out <- nest(df, x)
   expect_equal(names(out), c("y", "data"))

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -36,3 +36,16 @@ test_that("nesting everything yields a simple data frame", {
   out <- nest(df, x, y)
   expect_equal(out$data, list(df))
 })
+
+test_that("nesting works for empty data frames", {
+  df <- data_frame(x = 1:3, y = c("B", "A", "A"))[0, ]
+
+  out <- nest(df, x)
+  expect_equal(names(out), c("y", "data"))
+  expect_equal(nrow(out), 0)
+  expect_equal(out$data, list())
+  # unnest(out) is missing the x column
+
+  out <- nest(df, x, y)
+  expect_equal(out$data, list(df))
+})


### PR DESCRIPTION
Speed-up is achieved by calling duplicated() over the index vector instead of dplyr::distinct_() over the raw data. Would be even faster with hadley/dplyr#2121.

Test script:

``` r
library(tibble)
devtools::load_all()

data <- expand.grid(a = 1:150, b = 1:150, c = 1:150)

system.time(tidyr::nest(data, b, c))
system.time(tidyr::nest(data, c))
```

Timing current master:

```
> system.time(tidyr::nest(data, b, c))
   user  system elapsed 
  1.800   0.012   1.814 

> system.time(tidyr::nest(data, c))
   user  system elapsed 
  4.924   0.008   4.931 
```

Timing this PR:

```
> system.time(tidyr::nest(data, b, c))
   user  system elapsed 
  1.212   0.004   1.215 

> system.time(tidyr::nest(data, c))
   user  system elapsed 
  3.968   0.000   3.964 
```
