### PR TITLE
Add replacement to levels when replacing NA in factor

### DIFF
--- a/R/replace_na.R
+++ b/R/replace_na.R
@@ -18,6 +18,8 @@ replace_na.data.frame <- function(data, replace = list(), ...) {
   stopifnot(is.list(replace))
 
   for (var in names(replace)) {
+    if (is.factor(data[[var]]))
+      levels(data[[var]]) <- c(levels(data[[var]]), replace[[var]])
     data[[var]][is.na(data[[var]])] <- replace[[var]]
   }
 


### PR DESCRIPTION
Solves warning (and bug):
1: In `[<-.factor`(`*tmp*`, is.na(data[[var]]), value = structure(c(1L,  ... :
  invalid factor level, NA generated
