### PR TITLE
#272 (unnest preserves top-level attributes) fix and test

### DIFF
--- a/R/unnest.R
+++ b/R/unnest.R
@@ -136,7 +136,18 @@ unnest_.data.frame <- function(data, unnest_cols, .drop = NA, .id = NULL,
 
   rest <- data[rep(1:nrow(data), n[[1]]), group_cols, drop = FALSE]
 
-  dplyr::bind_cols(compact(list(rest, unnested_atomic, unnested_dataframe)))
+  df <- dplyr::bind_cols(compact(list(rest, unnested_atomic, unnested_dataframe)))
+
+  allattrs <- attributes(data)
+  customattr <- allattrs[!(names(allattrs) %in% c("class",
+                                                  "dim", "dimnames",
+                                                  "names", "row.names"))]
+  mapply(function(x, y) { attr(df, x) <<- y }, names(customattr), customattr)
+
+  #class handled separately, assign the superset
+  class(df) <- unique(c(class(df), class(data)))
+
+  df
 }
 
 list_col_type <- function(x) {

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -114,3 +114,20 @@ test_that("grouping is preserved", {
   expect_equal(class(df), class(rs))
   expect_equal(dplyr::groups(df), dplyr::groups(rs))
 })
+
+test_that("unnest preserves top-level attributes(#272)", {
+  test.nest <- tibble::tibble(x = c(1, 2),
+                              y = list(data.frame(z = 2), data.frame(z = 4)))
+  classlist <- sort(c("testclass", class(test.nest)))
+  class(test.nest) <- classlist
+  comment(test.nest) <- "test comment"
+  attr(test.nest, "single") <- 456
+  attr(test.nest, "multi")  <- c("ABC", "xyz", "123")
+
+  test.unnest <- unnest(test.nest, y)
+
+  expect_equal(attr(test.unnest, "single"),  456)
+  expect_equal(attr(test.unnest, "multi"),   c("ABC", "xyz", "123"))
+  expect_equal(sort(class(test.unnest)), classlist)
+  expect_equal(comment(test.unnest), "test comment")
+})


### PR DESCRIPTION
Issue #272 Resolved - unnest now preserves all top-level attributes EXCEPT (dim, dim names, names, row.names).

Notes on changes:
- mapply is used to assign additional attributes to the output object without unassigning all attributes
- the class attribute is handled separately and is set as a superset of the classes of the original object and the result object.