### PR TITLE
Add explicit tests for grouped unnests

### DIFF
--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -59,11 +59,30 @@ test_that(".id creates vector of names for vector unnest", {
   expect_equal(out$name, c("a", "b", "b"))
 })
 
+test_that(".id creates vector of names for grouped vector unnest", {
+  df <- data_frame(x = 1:2, y = list(a = 1, b = 1:2)) %>%
+    dplyr::group_by(x)
+  out <- unnest(df, .id = "name")
+
+  expect_equal(out$name, c("a", "b", "b"))
+})
+
 test_that(".id creates vector of names for data frame unnest", {
   df <- data_frame(x = 1:2, y = list(
     a = data_frame(y = 1),
     b = data_frame(y = 1:2)
   ))
+  out <- unnest(df, .id = "name")
+
+  expect_equal(out$name, c("a", "b", "b"))
+})
+
+test_that(".id creates vector of names for grouped data frame unnest", {
+  df <- data_frame(x = 1:2, y = list(
+    a = data_frame(y = 1),
+    b = data_frame(y = 1:2)
+  )) %>%
+    dplyr::group_by(x)
   out <- unnest(df, .id = "name")
 
   expect_equal(out$name, c("a", "b", "b"))


### PR DESCRIPTION
`unnest.grouped_df()` method already implemented.

Do we need a `rowwise_df` method? There seem to be no other methods for `rowwise_df`.