### PR TITLE
Add drop argument to separate_rows()

### DIFF
--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -19,9 +19,9 @@
 #' )
 #' separate_rows(df, y, z, convert = TRUE)
 separate_rows <- function(data, ..., sep = "[^[:alnum:].]+",
-                          convert = FALSE) {
+                          convert = FALSE, drop = NA) {
   cols <- unname(dplyr::select_vars(names(data), ...))
-  separate_rows_(data, cols, sep, convert)
+  separate_rows_(data, cols, sep, convert, drop)
 }
 
 #' Standard-evaluation version of \code{separate_rows}.
@@ -30,20 +30,22 @@ separate_rows <- function(data, ..., sep = "[^[:alnum:].]+",
 #'
 #' @param cols Name of columns that need to be separated.
 #' @param sep Separator delimiting collapsed values.
+#' @param drop Should list columns be dropped? By default, \code{separate_rows}
+#'   will drop them if specified columns requires the rows to be duplicated.
 #' @inheritParams separate_
 #' @keywords internal
 #' @export
 separate_rows_ <- function(data, cols, sep = "[^[:alnum:].]+",
-                           convert = FALSE) {
+                           convert = FALSE, drop = FALSE) {
   UseMethod("separate_rows_")
 }
 
 #' @export
 separate_rows_.data.frame <- function(data, cols, sep = "[^[:alnum:].]+",
-                                      convert = FALSE) {
+                                      convert = FALSE, drop = FALSE) {
 
   data[cols] <- lapply(data[cols], stringi::stri_split_regex, sep)
-  data <- unnest_(data, cols)
+  data <- unnest_(data, cols, .drop = drop)
 
   if (convert) {
     data[cols] <- lapply(data[cols], type.convert, as.is = TRUE)
@@ -54,13 +56,13 @@ separate_rows_.data.frame <- function(data, cols, sep = "[^[:alnum:].]+",
 
 #' @export
 separate_rows_.tbl_df <- function(data, cols, sep = "[^[:alnum:].]+",
-                                  convert = FALSE) {
+                                  convert = FALSE, drop = FALSE) {
   as_data_frame(NextMethod())
 }
 
 #' @export
 separate_rows_.grouped_df <- function(data, cols, sep = "[^[:alnum:].]+",
-                                  convert = FALSE) {
+                                  convert = FALSE, drop = FALSE) {
 
   regroup(NextMethod(), data, cols)
 }

--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -28,7 +28,6 @@ separate_rows <- function(data, ..., sep = "[^[:alnum:].]+",
 #'
 #' This is a S3 generic.
 #'
-#' @param data A data frame.
 #' @param cols Name of columns that need to be separated.
 #' @param sep Separator delimiting collapsed values.
 #' @inheritParams separate_

--- a/man/separate_rows.Rd
+++ b/man/separate_rows.Rd
@@ -4,7 +4,8 @@
 \alias{separate_rows}
 \title{Separate a collapsed column into multiple rows.}
 \usage{
-separate_rows(data, ..., sep = "[^[:alnum:].]+", convert = FALSE)
+separate_rows(data, ..., sep = "[^[:alnum:].]+", convert = FALSE,
+  drop = NA)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -18,6 +19,9 @@ Select all variables between x and z with \code{x:z}, exclude y with
 \item{convert}{If \code{TRUE}, will run \code{\link{type.convert}} with
 \code{as.is = TRUE} on new columns. This is useful if the component
 columns are integer, numeric or logical.}
+
+\item{drop}{Should list columns be dropped? By default, \code{separate_rows}
+will drop them if specified columns requires the rows to be duplicated.}
 }
 \description{
 If a variable contains observations with multiple delimited values, this

--- a/man/separate_rows_.Rd
+++ b/man/separate_rows_.Rd
@@ -4,7 +4,8 @@
 \alias{separate_rows_}
 \title{Standard-evaluation version of \code{separate_rows}.}
 \usage{
-separate_rows_(data, cols, sep = "[^[:alnum:].]+", convert = FALSE)
+separate_rows_(data, cols, sep = "[^[:alnum:].]+", convert = FALSE,
+  drop = FALSE)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -16,6 +17,9 @@ separate_rows_(data, cols, sep = "[^[:alnum:].]+", convert = FALSE)
 \item{convert}{If \code{TRUE}, will run \code{\link{type.convert}} with
 \code{as.is = TRUE} on new columns. This is useful if the component
 columns are integer, numeric or logical.}
+
+\item{drop}{Should list columns be dropped? By default, \code{separate_rows}
+will drop them if specified columns requires the rows to be duplicated.}
 }
 \description{
 This is a S3 generic.

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -115,3 +115,13 @@ test_that("convert produces integers etc", {
   expect_equal(class(out$y), "logical")
   expect_equal(class(out$z), "character")
 })
+
+test_that("extra list cols can be maintained", {
+  df <- data_frame(x = c("a,b", "c"), y = list(list("a", "b"), "c"))
+
+  out <- separate_rows(df, x)
+  expect_equal(out, data_frame(x = letters[1:3]))
+
+  out <- separate_rows(df, x, drop = FALSE)
+  expect_equal(out$y, c(df$y[1], df$y))
+})


### PR DESCRIPTION
This addresses #300 by exposing `unnest()`'s `.drop` argument. Note, I used `drop` rather than `.drop` to be consistent with `separate()`, which hasn't adopted the `.argument` argument style.