### PR TITLE
Fix #254.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
   unquote symbols or strings). This type of NSE is now strongly
   discouraged in the tidyverse; symbols should represent real objects.
 
+* Fixed that `spread()` fails when the `key` column includes `NA` and `drop` is `FALSE` (#254).
 
 # tidyr 0.6.3
 

--- a/R/id.R
+++ b/R/id.R
@@ -41,8 +41,9 @@ id_var <- function(x, drop = FALSE) {
   if (!is_null(attr(x, "n")) && !drop) return(x)
 
   if (is.factor(x) && !drop) {
-    id <- as.integer(addNA(x, ifany = TRUE))
-    n <- length(levels(x))
+    x_na <- addNA(x, ifany = TRUE)
+    id <- as.integer(x_na)
+    n <- length(levels(x_na))
   } else if (length(x) == 0) {
     id <- integer()
     n <- 0L

--- a/tests/testthat/test-spread.R
+++ b/tests/testthat/test-spread.R
@@ -69,6 +69,19 @@ test_that("drop = FALSE keeps missing combinations of 0-length factors (#56)", {
   expect_equal(out$b, c(NA, NA))
 })
 
+test_that("drop = FALSE spread all levels including NA (#254)", {
+  l <- c("a", "b", "c", "d")
+  df <- data.frame(
+    x = factor(c("a", "b", "c", NA), levels = l),
+    y = c("a", "b", "c", "d"),
+    z = c("a", "b", "a", "b"))
+  out <- df %>% spread(x, y, drop = FALSE)
+  expect_equal(nrow(out), 2)
+  expect_equal(ncol(out), 6)
+  expect_equal(out$d, factor(c(NA, NA), levels = l))
+  expect_equal(out[["<NA>"]], factor(c(NA, "d"), levels = l))
+})
+
 test_that("preserve class of input", {
   dat <- data.frame(
     x = c("a", "a", "b", "b"),


### PR DESCRIPTION
This is a draft PR to fix #254 .
It seems that the problem is caused by that the `n` attribute in the return value of `id_var()` is different from the expected value when it's called with `x` including `NA` and `drop = FALSE`. It doesn't count `NA`.
This leads to wrong code path in if clause at https://github.com/tidyverse/tidyr/blob/master/R/spread.R#L100. I think we have to enter L101 if we have missing values in `key`, but we enter `else` clause now (if `drop = FALSE` is given).

I modified `id()` to count `NA` when `drop = FALSE` is given.

Thanks.