### PR TITLE
Fix corner case for unnest

### DIFF
--- a/R/unnest.R
+++ b/R/unnest.R
@@ -131,7 +131,7 @@ unnest.data.frame <- function(data, ..., .drop = NA, .id = NULL,
   }
   group_vars <- setdiff(group_vars, names(nested))
 
-  rest <- data[rep(1:nrow(data), n[[1]]), group_vars, drop = FALSE]
+  rest <- data[rep(seq_len(nrow(data)), n[[1]]), group_vars, drop = FALSE]
   out <- dplyr::bind_cols(rest, unnested_atomic, unnested_dataframe)
   reconstruct_tibble(data, out)
 }

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -78,6 +78,12 @@ test_that("can handle collapsed rows", {
   expect_equal(separate_rows(df, y)$y, unlist(strsplit(df$y, "\\,")))
 })
 
+test_that("can handle empty data frames (#308)", {
+  df <- tibble(a = character(), b = character())
+  skip("Currently failing")
+  expect_equal(separate_rows(df, b), df)
+})
+
 test_that("default pattern does not split decimals in nested strings", {
   df <- dplyr::tibble(x = 1:3, y = c("1", "1.0,1.1", "2.1"))
   expect_equal(separate_rows(df, y)$y, unlist(strsplit(df$y, ",")))

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -101,6 +101,13 @@ test_that("sep combines column names", {
     expect_named(c("x_x", "y_x"))
 })
 
+test_that("can unnest empty data frame", {
+  df <- data_frame(x = integer(), y = list())
+  out <- unnest(df, y)
+  expect_equal(out, data_frame(x = integer()))
+})
+
+
 # Drop --------------------------------------------------------------------
 
 test_that("unnest drops list cols if expanding", {


### PR DESCRIPTION
Closes #253.

For #308, more work is needed, because this PR loses columns of empty data frames when calling `separate_rows()`.