### PR TITLE
Leave list columns intact after separate_rows()

### DIFF
--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -35,7 +35,7 @@ separate_rows.data.frame <- function(data, ..., sep = "[^[:alnum:].]+",
   vars <- unname(tidyselect::vars_select(names(data), ...))
 
   data[vars] <- map(data[vars], stringi::stri_split_regex, sep)
-  data <- unnest(data, !!! syms(vars))
+  data <- unnest(data, !!! syms(vars), .drop = FALSE)
 
   if (convert) {
     data[vars] <- map(data[vars], type.convert, as.is = TRUE)

--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -36,6 +36,7 @@ separate_rows.data.frame <- function(data, ..., sep = "[^[:alnum:].]+",
 
   data[vars] <- map(data[vars], stringi::stri_split_regex, sep)
   data <- unnest(data, !!! syms(vars), .drop = FALSE)
+  data <- dplyr::select(data, !!!names(orig))
 
   if (convert) {
     data[vars] <- map(data[vars], type.convert, as.is = TRUE)

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -110,3 +110,13 @@ test_that("convert produces integers etc", {
   expect_equal(class(out$y), "logical")
   expect_equal(class(out$z), "character")
 })
+
+test_that("leaves list columns intact (#300)", {
+  df <- tibble(x = "1,2,3", y = list(1))
+
+  out <- separate_rows(df, x)
+  # Can't compare tibbles with list columns directly
+  expect_equal(names(out), c("x", "y"))
+  expect_equal(out$x, as.character(1:3))
+  expect_equal(out$y, rep(list(1), 3))
+})

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -116,7 +116,7 @@ test_that("leaves list columns intact (#300)", {
 
   out <- separate_rows(df, x)
   # Can't compare tibbles with list columns directly
-  expect_equal(names(out), c("x", "y"))
+  expect_equal(names(out), c("y", "x"))
   expect_equal(out$x, as.character(1:3))
   expect_equal(out$y, rep(list(1), 3))
 })

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -116,7 +116,7 @@ test_that("leaves list columns intact (#300)", {
 
   out <- separate_rows(df, x)
   # Can't compare tibbles with list columns directly
-  expect_equal(names(out), c("y", "x"))
+  expect_equal(names(out), c("x", "y"))
   expect_equal(out$x, as.character(1:3))
   expect_equal(out$y, rep(list(1), 3))
 })


### PR DESCRIPTION
Fixes #300.