### PR TITLE
Don't use tidyselect for now

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,7 @@ Imports:
     rlang,
     Rcpp,
     stringi,
-    tibble,
-    tidyselect
+    tibble
 URL: http://tidyr.tidyverse.org,
     https://github.com/tidyverse/tidyr
 BugReports: https://github.com/tidyverse/tidyr/issues
@@ -34,5 +33,4 @@ Suggests:
 VignetteBuilder: knitr
 LinkingTo: Rcpp
 RoxygenNote: 6.0.1
-Remotes: tidyverse/tidyselect
 Roxygen: list(markdown = TRUE)

--- a/R/drop_na.r
+++ b/R/drop_na.r
@@ -20,7 +20,7 @@ drop_na.default <- function(data, ...) {
 }
 #' @export
 drop_na.data.frame <- function(data, ...) {
-  vars <- unname(tidyselect::vars_select(colnames(data), ...))
+  vars <- unname(dplyr::select_vars(colnames(data), ...))
   if (!is_character(vars)) {
     abort("`vars` is not a character vector.")
   }

--- a/R/extract.R
+++ b/R/extract.R
@@ -6,7 +6,7 @@
 #'
 #' @inheritParams expand
 #' @param col Column name or position. This is passed to
-#'   [tidyselect::vars_pull()].
+#'   [dplyr::select_var()].
 #'
 #'   This argument is passed by expression and supports
 #'   [quasiquotation][rlang::quasiquotation] (you can unquote column
@@ -47,7 +47,7 @@ extract.default <- function(data, col, into, regex = "([[:alnum:]]+)",
 #' @export
 extract.data.frame <- function(data, col, into, regex = "([[:alnum:]]+)",
                                remove = TRUE, convert = FALSE, ...) {
-  var <- tidyselect::vars_pull(names(data), !! enquo(col))
+  var <- dplyr::select_var(names(data), !! enquo(col))
   stopifnot(
     is_string(regex),
     is_character(into)

--- a/R/fill.R
+++ b/R/fill.R
@@ -29,7 +29,7 @@ fill.default <- function(data, ..., .direction = c("down", "up")) {
 }
 #' @export
 fill.data.frame <- function(data, ..., .direction = c("down", "up")) {
-  fill_cols <- unname(tidyselect::vars_select(names(data), ...))
+  fill_cols <- unname(dplyr::select_vars(names(data), ...))
 
   .direction <- match.arg(.direction)
   fillVector <- switch(.direction, down = fillDown, up = fillUp)

--- a/R/gather.R
+++ b/R/gather.R
@@ -83,7 +83,7 @@ gather.data.frame <- function(data, key = "key", value = "value", ...,
   if (is_empty(quos)) {
     gather_vars <- setdiff(names(data), c(key_var, value_var))
   } else {
-    gather_vars <- unname(tidyselect::vars_select(names(data), !!! quos))
+    gather_vars <- unname(dplyr::select_vars(names(data), !!! quos))
   }
   if (is_empty(gather_vars)) {
     return(data)

--- a/R/nest.R
+++ b/R/nest.R
@@ -44,7 +44,7 @@ nest.default <- function(data, ..., .key = "data") {
 nest.data.frame <- function(data, ..., .key = "data") {
   key_var <- quo_name(enexpr(.key))
 
-  nest_vars <- unname(tidyselect::vars_select(names(data), ...))
+  nest_vars <- unname(dplyr::select_vars(names(data), ...))
   if (is_empty(nest_vars)) {
     nest_vars <- names(data)
   }

--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -32,7 +32,7 @@ separate_rows.default <- function(data, ..., sep = "[^[:alnum:].]+",
 separate_rows.data.frame <- function(data, ..., sep = "[^[:alnum:].]+",
                                      convert = FALSE) {
   orig <- data
-  vars <- unname(tidyselect::vars_select(names(data), ...))
+  vars <- unname(dplyr::select_vars(names(data), ...))
 
   data[vars] <- map(data[vars], stringi::stri_split_regex, sep)
   data <- unnest(data, !!! syms(vars))

--- a/R/separate.R
+++ b/R/separate.R
@@ -77,7 +77,7 @@ separate.data.frame <- function(data, col, into, sep = "[^[:alnum:]]+",
                                 extra = "warn", fill = "warn", ...) {
   orig <- data
 
-  var <- tidyselect::vars_pull(names(data), !! enquo(col))
+  var <- dplyr::select_var(names(data), !! enquo(col))
   value <- as.character(data[[var]])
 
   if (length(list(...)) != 0) {

--- a/R/spread.R
+++ b/R/spread.R
@@ -2,7 +2,7 @@
 #'
 #' @param data A data frame.
 #' @param key,value Column names or positions. This is passed to
-#'   [tidyselect::vars_pull()].
+#'   [dplyr::select_var()].
 #'
 #'   These arguments are passed by expression and support
 #'   [quasiquotation][rlang::quasiquotation] (you can unquote column
@@ -66,8 +66,8 @@ spread.default <- function(data, key, value, fill = NA, convert = FALSE,
 #' @export
 spread.data.frame <- function(data, key, value, fill = NA, convert = FALSE,
                               drop = TRUE, sep = NULL) {
-  key_var <- tidyselect::vars_pull(names(data), !! enquo(key))
-  value_var <- tidyselect::vars_pull(names(data), !! enquo(value))
+  key_var <- dplyr::select_var(names(data), !! enquo(key))
+  value_var <- dplyr::select_var(names(data), !! enquo(value))
 
   col <- data[key_var]
   col_id <- id(col, drop = drop)

--- a/R/unite.R
+++ b/R/unite.R
@@ -38,7 +38,7 @@ unite.default <- function(data, col, ..., sep = "_", remove = TRUE) {
 #' @export
 unite.data.frame <- function(data, col, ..., sep = "_", remove = TRUE) {
   var <- quo_name(enquo(col))
-  from_vars <- tidyselect::vars_select(colnames(data), ...)
+  from_vars <- dplyr::select_vars(colnames(data), ...)
 
   out <- data
   if (remove) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,6 +74,10 @@ reconstruct_tibble <- function(input, output, ungrouped_vars = chr()) {
 }
 
 
+# Allows tests to work with either dplyr 0.4 (which ignores value of
+# everything), and 0.5 which exports it as a proper function
+everything <- function(...) dplyr::everything(...)
+
 imap <- function(.x, .f, ...) {
   map2(.x, names(.x) %||% character(0), .f, ...)
 }

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -11,7 +11,7 @@ extract(data, col, into, regex = "([[:alnum:]]+)", remove = TRUE,
 \item{data}{A data frame.}
 
 \item{col}{Column name or position. This is passed to
-\code{\link[tidyselect:vars_pull]{tidyselect::vars_pull()}}.
+\code{\link[dplyr:select_var]{dplyr::select_var()}}.
 
 This argument is passed by expression and supports
 \link[rlang:quasiquotation]{quasiquotation} (you can unquote column

--- a/man/separate.Rd
+++ b/man/separate.Rd
@@ -11,7 +11,7 @@ separate(data, col, into, sep = "[^[:alnum:]]+", remove = TRUE,
 \item{data}{A data frame.}
 
 \item{col}{Column name or position. This is passed to
-\code{\link[tidyselect:vars_pull]{tidyselect::vars_pull()}}.
+\code{\link[dplyr:select_var]{dplyr::select_var()}}.
 
 This argument is passed by expression and supports
 \link[rlang:quasiquotation]{quasiquotation} (you can unquote column

--- a/man/spread.Rd
+++ b/man/spread.Rd
@@ -11,7 +11,7 @@ spread(data, key, value, fill = NA, convert = FALSE, drop = TRUE,
 \item{data}{A data frame.}
 
 \item{key, value}{Column names or positions. This is passed to
-\code{\link[tidyselect:vars_pull]{tidyselect::vars_pull()}}.
+\code{\link[dplyr:select_var]{dplyr::select_var()}}.
 
 These arguments are passed by expression and support
 \link[rlang:quasiquotation]{quasiquotation} (you can unquote column

--- a/tests/testthat/test-fill.R
+++ b/tests/testthat/test-fill.R
@@ -37,7 +37,7 @@ test_that("missings filled down for each atomic vector", {
 
   )
 
-  out <- fill(df, tidyselect::everything())
+  out <- fill(df, everything())
   expect_equal(out$lgl, c(TRUE, TRUE))
   expect_equal(out$int, c(1L, 1L))
   expect_equal(out$dbl, c(1, 1))
@@ -54,7 +54,7 @@ test_that("missings filled up for each vector", {
     lst = list(NULL, 1:5)
   )
 
-  out <- fill(df, tidyselect::everything(), .direction = "up")
+  out <- fill(df, everything(), .direction = "up")
   expect_equal(out$lgl, c(TRUE, TRUE))
   expect_equal(out$int, c(1L, 1L))
   expect_equal(out$dbl, c(1, 1))


### PR DESCRIPTION
for a lighter-weight CRAN release. I compared revdepchecks for current master and after removing tidyselect, I got three regressions less and otherwise identical results. I'd argue that we should release a tidyeval version that doesn't use tidyselect yet, this will give us and downstream maintainers more time. Also, a few open PRs and issues are waiting for tidyr's CRAN release.

CC @hadley @lionel-.