### PR TITLE
Hotfix release 0.7.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyr
 Title: Easily Tidy Data with 'spread()' and 'gather()' Functions
-Version: 0.7.0.9000
+Version: 0.7.1
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre")),
     person("Lionel", "Henry", , "lionel@rstudio.com", "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 
-# tidyr 0.7.0.9000
+# tidyr 0.7.1
+
+This is a hotfix release to account for some tidyselect changes in the
+unit tests.
+
+Note that the upcoming version of tidyselect backtracks on some of the
+changes announced for 0.7.0. The special evaluation semantics for
+selection have been changed back to the old behaviour because the new
+rules were causing too much trouble and confusion. From now on data
+expressions (symbols and calls to `:` and `c()`) can refer to both
+registered variables and to objects from the context.
+
+However the semantics for context expressions (any calls other than to
+`:` and `c()`) remain the same. Those expressions are evaluated in the
+context only and cannot refer to registered variables. If you're
+writing functions and refer to contextual objects, it is still a good
+idea to avoid data expressions by following the advice of the 0.7.0
+release notes.
 
 
 # tidyr 0.7.0

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,6 @@
+This is a hotfix release to fix tests in prevision of an upcoming
+tidyselect update.
+
 ## Test environments
 
 * local OS X install, R 3.4.1
@@ -12,10 +15,5 @@
 
 ## Reverse dependencies
 
-I have run R CMD check on the 268 downstream dependencies. (Summary at
-https://github.com/tidyverse/tidyr/tree/master/revdep).
-
-There were 9 problematic packages. We carefully reviewed each failure
-and determined that they were due to a deliberate backward
-incompatible change to the tidyr API. Authors were notified on August
-1 (two weeks ago) with a suggested fix for the problem.
+I have not run the reverse dependencies since this release is
+identical to the previous one except for a couple of unit tests.

--- a/man/tidyr-package.Rd
+++ b/man/tidyr-package.Rd
@@ -20,11 +20,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Lionel Henry \email{lionel@rstudio.com}
+\strong{Maintainer}: Hadley Wickham \email{hadley@rstudio.com}
 
 Authors:
 \itemize{
-  \item Hadley Wickham \email{hadley@rstudio.com}
+  \item Lionel Henry \email{lionel@rstudio.com}
 }
 
 Other contributors:

--- a/tests/testthat/test-drop_na.R
+++ b/tests/testthat/test-drop_na.R
@@ -37,6 +37,6 @@ test_that("empty call drops every row", {
 
 test_that("errors are raised", {
   df <- tibble(x = c(1, 2, NA), y = c("a", NA, "b"))
-  expect_error(tidyr::drop_na(df, NULL), "must resolve to integer column positions")
-  expect_error(tidyr::drop_na(df, "z"), "must match column names")
+  expect_error(tidyr::drop_na(df, !! list()))
+  expect_error(tidyr::drop_na(df, "z"))
 })


### PR DESCRIPTION
The next version of tidyselect treats `NULL` as empty inputs, which causes a unit test to fail.

This is also an opportunity to update the NEWS about selection rules backtracking.