### PR TITLE
Fix use of STRING_PTR() on R devel

### DIFF
--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -33,6 +33,15 @@ SEXP rep_(SEXP x, int n, std::string var_name) {
     case REALSXP:
       DO_REP(REALSXP, double, REAL);
       break;
+    case LGLSXP:
+      DO_REP(LGLSXP, int, LOGICAL);
+      break;
+    case CPLXSXP:
+      DO_REP(CPLXSXP, Rcomplex, COMPLEX);
+      break;
+    case RAWSXP:
+      DO_REP(RAWSXP, Rbyte, RAW);
+      break;
     case STRSXP: {
       int counter = 0;
       for (int i = 0; i < n; ++i) {
@@ -43,18 +52,16 @@ SEXP rep_(SEXP x, int n, std::string var_name) {
       }
       break;
     }
-    case LGLSXP:
-      DO_REP(LGLSXP, int, LOGICAL);
+    case VECSXP: {
+      int counter = 0;
+      for (int i = 0; i < n; ++i) {
+        for (int j = 0; j < xn; ++j) {
+          SET_VECTOR_ELT(output, counter, VECTOR_ELT(x, j));
+          ++counter;
+        }
+      }
       break;
-    case CPLXSXP:
-      DO_REP(CPLXSXP, Rcomplex, COMPLEX);
-      break;
-    case RAWSXP:
-      DO_REP(RAWSXP, Rbyte, RAW);
-      break;
-    case VECSXP:
-      DO_REP(VECSXP, SEXP, STRING_PTR);
-      break;
+    }
     default: {
       stop("Unhandled RTYPE in '%s'", var_name);
       return R_NilValue;

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -122,7 +122,6 @@ test_that("gather preserves OBJECT bit on e.g. POSIXct", {
 test_that("can handle list-columns", {
   df <- tibble(x = 1:2, y = list("a", TRUE))
   out <- gather(df, k, v, -y)
-
   expect_identical(out$y, df$y)
 })
 


### PR DESCRIPTION
`STRING_PTR()` is used in the melting code to access elements of a list. This is no longer allowed on R devel: https://github.com/wch/r-source/commit/6ff8e95674c0437d3de4edc04276327f87c64ca8

This should fix it. cc @kevinushey