### PR TITLE
Fix handling of negative integer values in strsep

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,8 @@
 
 * Fixed that `spread()` fails when the `key` column includes `NA` and `drop` is `FALSE` (#254).
 
-* `separate()` now works as described in documentation when using negative integer values with `sep` argument (#315).
+* `separate()` now works as described in documentation when using negative
+  integer values with `sep` argument (@markdly, #315).
 
 # tidyr 0.7.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@
 
 * Fixed that `spread()` fails when the `key` column includes `NA` and `drop` is `FALSE` (#254).
 
+* `separate()` now works as described in documentation when using negative integer values with `sep` argument (#315).
+
 # tidyr 0.7.2
 
 * The SE variants `gather_()`, `spread_()` and `nest_()` now

--- a/R/separate.R
+++ b/R/separate.R
@@ -104,13 +104,12 @@ separate.data.frame <- function(data, col, into, sep = "[^[:alnum:]]+",
 }
 
 strsep <- function(x, sep) {
-  sep <- c(0, sep, -1)
-
   nchar <- stringi::stri_length(x)
   pos <- map(sep, function(i) {
     if (i >= 0) return(i)
-    nchar + i + 1
+    pmax(0, nchar + i)
   })
+  pos <- c(list(0), pos, list(nchar))
 
   map(1:(length(pos) - 1), function(i) {
     stringi::stri_sub(x, pos[[i]] + 1, pos[[i + 1]])

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -7,10 +7,30 @@ test_that("missing values in input are missing in output", {
   expect_equal(out$y, c(NA, "b"))
 })
 
-test_that("integer values specific position between characters", {
+test_that("positive integer values specific position between characters", {
   df <- tibble(x = c(NA, "ab", "cd"))
   out <- separate(df, x, c("x", "y"), 1)
   expect_equal(out$x, c(NA, "a", "c"))
+  expect_equal(out$y, c(NA, "b", "d"))
+})
+
+test_that("negative integer values specific position between characters", {
+  df <- tibble(x = c(NA, "ab", "cd"))
+  out <- separate(df, x, c("x", "y"), -1)
+  expect_equal(out$x, c(NA, "a", "c"))
+  expect_equal(out$y, c(NA, "b", "d"))
+})
+
+test_that("extreme integer values handled sensibly", {
+  df <- tibble(x = c(NA, "a", "bc", "def"))
+
+  out <- separate(df, x, c("x", "y"), 3)
+  expect_equal(out$x, c(NA, "a", "bc", "def"))
+  expect_equal(out$y, c(NA, "", "", ""))
+
+  out <- separate(df, x, c("x", "y"), -3)
+  expect_equal(out$x, c(NA, "", "", ""))
+  expect_equal(out$y, c(NA, "a", "bc", "def"))
 })
 
 test_that("convert produces integers etc", {


### PR DESCRIPTION
This is a draft PR to Fix #315. All values passed to `stringi::stri_sub` in the `strsep` function are now non-negative as I also noticed a related issue where the use of relatively large negative sep values (relative to the string length) could cause unexpected results.  I'll add a note about this over in the issues section...