### PR TITLE
Add mention of `extract` in `separate` docs

### DIFF
--- a/R/separate.R
+++ b/R/separate.R
@@ -32,7 +32,8 @@
 #'   `as.is = TRUE` on new columns. This is useful if the component
 #'   columns are integer, numeric or logical.
 #' @param ... Additional arguments passed on to methods.
-#' @seealso [unite()], the complement.
+#' @seealso [unite()], the complement, [extract()] which uses regular
+#'   expression capturing groups.
 #' @export
 #' @examples
 #' library(dplyr)

--- a/man/separate.Rd
+++ b/man/separate.Rd
@@ -77,5 +77,6 @@ df <- data.frame(x = c("x: 123", "y: error: 7"))
 df \%>\% separate(x, c("key", "value"), ": ", extra = "merge")
 }
 \seealso{
-\code{\link[=unite]{unite()}}, the complement.
+\code{\link[=unite]{unite()}}, the complement, \code{\link[=extract]{extract()}} which uses regular
+expression capturing groups.
 }


### PR DESCRIPTION
This is a suggestion to help improve the discoverability of `extract` by adding an @seealso entry to `separate`.  

I thought this might be worth suggesting after responding to a question on the RStudio community site where a user was aware of `separate` but not `extract` (see https://community.rstudio.com/t/getting-parts-of-string-using-regex-and-capturing-parens-in-mutate). This was very similar to my own experience before discovering `extract` existed.

I also thought this might be helpful as `extract` is not currently included on the RStudio `tidyr` cheatsheet while `separate` is. 
