### PR TITLE
Typo in unnest docs

### DIFF
--- a/R/unnest.R
+++ b/R/unnest.R
@@ -8,7 +8,7 @@
 #' or number of rows (if a data frame).
 #'
 #' @inheritParams expand
-#' @param ... Specification of columns to nest. Use bare variable names or
+#' @param ... Specification of columns to unnest. Use bare variable names or
 #'   functions of variables. If omitted, defaults to all list-cols.
 #' @param .drop Should additional list columns be dropped? By default,
 #'   `unnest` will drop them if unnesting the specified columns requires

--- a/man/unnest.Rd
+++ b/man/unnest.Rd
@@ -9,7 +9,7 @@ unnest(data, ..., .drop = NA, .id = NULL, .sep = NULL, .preserve = NULL)
 \arguments{
 \item{data}{A data frame.}
 
-\item{...}{Specification of columns to nest. Use bare variable names or
+\item{...}{Specification of columns to unnest. Use bare variable names or
 functions of variables. If omitted, defaults to all list-cols.}
 
 \item{.drop}{Should additional list columns be dropped? By default,


### PR DESCRIPTION
In the docs for `unnest` I thought 

`@param ... Specification of columns to nest.`

should instead be:

`@param ... Specification of columns to unnest.`