### PR TITLE
Update drop-na.R

### DIFF
--- a/R/drop-na.R
+++ b/R/drop-na.R
@@ -44,9 +44,13 @@ complete_cases <- function(x, fun) {
 }
 
 is_complete <- function(x) {
-  if (typeof(x) == "list") {
+  x_type <- typeof(x)
+  if (x_type == "list") {
     !vapply(x, is_empty, logical(1))
+  } else if (x_type == "NULL") {
+    FALSE
   } else {
     !is.na(x)
   }
 }
+

--- a/R/drop-na.R
+++ b/R/drop-na.R
@@ -48,7 +48,7 @@ is_complete <- function(x) {
   if (x_type == "list") {
     !vapply(x, is_empty, logical(1))
   } else if (x_type == "NULL") {
-    FALSE
+    !is_empty(x)
   } else {
     !is.na(x)
   }


### PR DESCRIPTION
Intuitively, I would have thought `is_complete(NULL)` should return `FALSE`, but the call results in the following error: `"In is.na(x) : is.na() applied to non-(list or vector) of type 'NULL'".` I added an extra branch (instead of say `x_type %in% c("list", "NULL")`) since a call to `vapply()` with `NULL` as its main argument returns a zero-length logical vector.