### PR TITLE
Preserve column order after unnesting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@
 * `crossing()` now takes the unique values of data frame inputs, not just
   vector inputs (#490).
 
+* `unnest()` now preserves column order (#406, @aaronwolen).
+
 # tidyr 0.8.3
 
 * `crossing()` preserves factor levels (#410), now works with list-columns 
@@ -62,7 +64,6 @@
 
 * `unnest()` weakens test of "atomicity" to restore previous behaviour when
   unnesting factors and dates (#407).
-* `unnest()` now preserves column order (#406, @aaronwolen)
 
 # tidyr 0.8.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,7 @@
 
 * `unnest()` weakens test of "atomicity" to restore previous behaviour when
   unnesting factors and dates (#407).
+* `unnest()` now preserves column order (#406, @aaronwolen)
 
 # tidyr 0.8.0
 

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -157,7 +157,11 @@ unnest.data.frame <- function(data, ..., .drop = NA, .id = NULL,
   rest <- data[rep(seq_nrow(data), n[[1]]), group_vars, drop = FALSE]
   out <- dplyr::bind_cols(rest, unnested_atomic, unnested_dataframe)
 
-  reconstruct_tibble(data, out)
+  # Preserve column order
+  all_vars <- intersect(names(data), names(out))
+  all_vars <- c(all_vars, setdiff(names(out), all_vars))
+
+  reconstruct_tibble(data, out[all_vars])
 }
 
 list_col_type <- function(x) {

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -7,7 +7,7 @@ test_that("gather all columns when ... is empty", {
   )
   out <- gather(df, key, val)
   expect_equal(nrow(out), 10)
-  expect_equal(names(out), c("key", "val"))
+  expect_named(out, c("key", "val"))
 })
 
 test_that("gather returns input if no columns gathered", {
@@ -20,7 +20,7 @@ test_that("if not supply, key and value default to key and value", {
   df <- data.frame(x = 1:2)
   out <- gather(df)
   expect_equal(nrow(out), 2)
-  expect_equal(names(out), c("key", "value"))
+  expect_named(out, c("key", "value"))
 })
 
 test_that("Missing values removed when na.rm = TRUE", {
@@ -58,7 +58,7 @@ test_that("preserve class of input", {
 test_that("additional inputs control which columns to gather", {
   data <- tibble(a = 1, b1 = 1, b2 = 2, b3 = 3)
   out <- gather(data, key, val, b1:b3)
-  expect_equal(names(out), c("a", "key", "val"))
+  expect_named(out, c("a", "key", "val"))
   expect_equal(out$val, 1:3)
 })
 

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -11,7 +11,7 @@ test_that("nest turns grouped values into one list-df", {
 test_that("can control output column name", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
   out <- nest(df, y, .key = y)
-  expect_equal(names(out), c("x", "y"))
+  expect_named(out, c("x", "y"))
 })
 
 test_that("nest doesn't include grouping vars in nested data", {
@@ -23,7 +23,7 @@ test_that("nest doesn't include grouping vars in nested data", {
 test_that("can restrict variables in grouped nest", {
   df <- tibble(x = 1, y = 2, z = 3) %>% dplyr::group_by(x)
   out <- df %>% nest(y)
-  expect_equal(names(out$data[[1]]), "y")
+  expect_named(out$data[[1]], "y")
 })
 
 test_that("puts data into the correct row", {
@@ -58,7 +58,7 @@ test_that("nesting works for empty data frames", {
   df <- tibble(x = 1:3, y = c("B", "A", "A"))[0, ]
 
   out <- nest(df, x)
-  expect_equal(names(out), c("y", "data"))
+  expect_named(out, c("y", "data"))
 
   expect_equal(nrow(out), 0L)
   expect_equal(length(out$data), 0L)

--- a/tests/testthat/test-separate-rows.R
+++ b/tests/testthat/test-separate-rows.R
@@ -49,7 +49,7 @@ test_that("leaves list columns intact (#300)", {
 
   out <- separate_rows(df, x)
   # Can't compare tibbles with list columns directly
-  expect_equal(names(out), c("x", "y"))
+  expect_named(out, c("x", "y"))
   expect_equal(out$x, as.character(1:3))
   expect_equal(out$y, rep(list(1), 3))
 })

--- a/tests/testthat/test-spread.R
+++ b/tests/testthat/test-spread.R
@@ -35,7 +35,7 @@ test_that("factors are spread into columns (#35)", {
   )
 
   out <- data %>% spread(x, z)
-  expect_equal(names(out), c("y", "a", "b"))
+  expect_named(out, c("y", "a", "b"))
   expect_true(all(vapply(out, is.factor, logical(1))))
   expect_identical(levels(out$a), levels(data$z))
   expect_identical(levels(out$b), levels(data$z))
@@ -97,7 +97,7 @@ test_that("dates are spread into columns (#62)", {
     date = Sys.Date() + 0:3
   )
   out <- spread(df, key, date)
-  expect_identical(names(out), c("id", "begin", "end"))
+  expect_named(out, c("id", "begin", "end"))
   expect_is(out$begin, "Date")
   expect_is(out$end, "Date")
 })

--- a/tests/testthat/test-underscored.R
+++ b/tests/testthat/test-underscored.R
@@ -32,7 +32,7 @@ test_that("drop_na_() works with non-syntactic names", {
 test_that("expand_()", {
   df <- data.frame(x = 1:2, y = 1:2)
   out <- expand_(df, list("x", ~y))
-  expect_identical(names(out), c("x", "y"))
+  expect_named(out, c("x", "y"))
   expect_identical(nrow(out), 4L)
 })
 
@@ -57,7 +57,7 @@ test_that("gather_()", {
   df <- data.frame(x = 1:5, y = 6:10)
   out <- gather_(df, "key", "val", c("x", "y"))
   expect_identical(nrow(out), 10L)
-  expect_identical(names(out), c("key", "val"))
+  expect_named(out, c("key", "val"))
 })
 
 test_that("gather_() works with non-syntactic names", {

--- a/tests/testthat/test-unite.R
+++ b/tests/testthat/test-unite.R
@@ -3,14 +3,14 @@ context("unite")
 test_that("unite pastes columns together & removes old col", {
   df <- tibble(x = "a", y = "b")
   out <- unite(df, z, x:y)
-  expect_equal(names(out), "z")
+  expect_named(out, "z")
   expect_equal(out$z, "a_b")
 })
 
 test_that("unite does not remove new col in case of name clash", {
   df <- tibble(x = "a", y = "b")
   out <- unite(df, x, x:y)
-  expect_equal(names(out), "x")
+  expect_named(out, "x")
   expect_equal(out$x, "a_b")
 })
 

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -196,6 +196,6 @@ test_that("column order is preserved", {
   expect_named(unnest(df), c("x", "y", "z"))
 
   df$y <- list(tibble(y1 = "b", y2 = "e"), tibble(y1 = "c", y2 = "f"))
-  expect_named(unnest(df), c("x", "y", "z"))
+  expect_named(unnest(df), c("x", "y1", "y2", "z"))
 })
 

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -195,7 +195,7 @@ test_that("column order is preserved", {
   df <- tibble(x = "a", y = list("b", "c"), z = "d")
   expect_named(unnest(df), c("x", "y", "z"))
 
-  df$y <- list(tibble(y = "b"), tibble(y = "c"))
+  df$y <- list(tibble(y1 = "b", y2 = "e"), tibble(y1 = "c", y2 = "f"))
   expect_named(unnest(df), c("x", "y", "z"))
 })
 

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -190,3 +190,12 @@ test_that("unnest() recognize ptype", {
   res <- unnest(tbl)
   expect_equal(res, tibble(x = integer(), y = double()))
 })
+
+test_that("column order is preserved", {
+  df <- tibble(x = "a", y = list("b", "c"), z = "d")
+  expect_named(unnest(df), c("x", "y", "z"))
+
+  df$y <- list(tibble(y = "b"), tibble(y = "c"))
+  expect_named(unnest(df), c("x", "y", "z"))
+})
+

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -162,6 +162,7 @@ test_that("unnest keeps list cols if not expanding", {
   out <- df %>% unnest(y)
 
   expect_equal(class(out$z), "list")
+  expect_named(out, c("x", "y", "z"))
 })
 
 test_that("unnest respects .drop_lists", {

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -141,11 +141,11 @@ test_that("empty ... returns df if no list-cols", {
 test_that("can optional preserve list cols", {
   df <- tibble(x = list(3, 4), y = list("a", "b"))
   rs <- df %>% unnest(x, .preserve = y)
-  expect_identical(rs, tibble(y = df$y, x = c(3, 4)))
+  expect_identical(rs$y, df$y)
 
   df <- tibble(x = list(c("d", "e")), y = list(1:2))
   rs <- df %>% unnest(.preserve = y)
-  expect_identical(rs, tibble(y = rep(list(1:2), 2), x = c("d", "e")))
+  expect_identical(rs$y, rep(df$y, 2))
 })
 
 # Drop --------------------------------------------------------------------
@@ -161,7 +161,7 @@ test_that("unnest keeps list cols if not expanding", {
   df <- tibble(x = 1:2, y = list(3, 4), z = list(5, 6:7))
   out <- df %>% unnest(y)
 
-  expect_equal(names(out), c("x", "z", "y"))
+  expect_equal(class(out$z), "list")
 })
 
 test_that("unnest respects .drop_lists", {

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -154,7 +154,7 @@ test_that("unnest drops list cols if expanding", {
   df <- tibble(x = 1:2, y = list(3, 4), z = list(5, 6:7))
   out <- df %>% unnest(z)
 
-  expect_equal(names(out), c("x", "z"))
+  expect_named(out, c("x", "z"))
 })
 
 test_that("unnest keeps list cols if not expanding", {
@@ -167,8 +167,8 @@ test_that("unnest keeps list cols if not expanding", {
 test_that("unnest respects .drop_lists", {
   df <- tibble(x = 1:2, y = list(3, 4), z = list(5, 6:7))
 
-  expect_equal(df %>% unnest(y, .drop = TRUE) %>% names(), c("x", "y"))
-  expect_equal(df %>% unnest(z, .drop = FALSE) %>% names(), c("x", "y", "z"))
+  expect_named(df %>% unnest(y, .drop = TRUE), c("x", "y"))
+  expect_named(df %>% unnest(z, .drop = FALSE), c("x", "y", "z"))
 })
 
 test_that("grouping is preserved", {

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -73,7 +73,7 @@ test_that("nested is split as a list (#84)", {
 
 test_that("unnest has mutate semantics", {
   df <- tibble(x = 1:3, y = list(1, 2:3, 4))
-  out <- df %>% unnest(z = map(y, `+`, 1))
+  out <- unnest(df, z = map(y, `+`, 1))
 
   expect_equal(out$z, 2:5)
 })
@@ -140,11 +140,11 @@ test_that("empty ... returns df if no list-cols", {
 
 test_that("can optional preserve list cols", {
   df <- tibble(x = list(3, 4), y = list("a", "b"))
-  rs <- df %>% unnest(x, .preserve = y)
+  rs <- unnest(df, x, .preserve = y)
   expect_identical(rs$y, df$y)
 
   df <- tibble(x = list(c("d", "e")), y = list(1:2))
-  rs <- df %>% unnest(.preserve = y)
+  rs <- unnest(df, .preserve = y)
   expect_identical(rs$y, rep(df$y, 2))
 })
 
@@ -152,14 +152,14 @@ test_that("can optional preserve list cols", {
 
 test_that("unnest drops list cols if expanding", {
   df <- tibble(x = 1:2, y = list(3, 4), z = list(5, 6:7))
-  out <- df %>% unnest(z)
+  out <- unnest(df, z)
 
   expect_named(out, c("x", "z"))
 })
 
 test_that("unnest keeps list cols if not expanding", {
   df <- tibble(x = 1:2, y = list(3, 4), z = list(5, 6:7))
-  out <- df %>% unnest(y)
+  out <- unnest(df, y)
 
   expect_equal(class(out$z), "list")
   expect_named(out, c("x", "y", "z"))
@@ -168,13 +168,13 @@ test_that("unnest keeps list cols if not expanding", {
 test_that("unnest respects .drop_lists", {
   df <- tibble(x = 1:2, y = list(3, 4), z = list(5, 6:7))
 
-  expect_named(df %>% unnest(y, .drop = TRUE), c("x", "y"))
-  expect_named(df %>% unnest(z, .drop = FALSE), c("x", "y", "z"))
+  expect_named(unnest(df, y, .drop = TRUE), c("x", "y"))
+  expect_named(unnest(df, z, .drop = FALSE), c("x", "y", "z"))
 })
 
 test_that("grouping is preserved", {
   df <- tibble(g = 1, x = list(1:3)) %>% dplyr::group_by(g)
-  rs <- df %>% unnest(x)
+  rs <- unnest(df, x)
 
   expect_equal(rs$x, 1:3)
   expect_equal(class(df), class(rs))


### PR DESCRIPTION
I run into this issue frequently enough that I thought I'd take a crack at it. The proposed change is pretty straightforward, so much so that I wonder if I'm overlooking something—especially in light of #145's conclusion. But I haven't found a case where it breaks down and all tests pass after adjusting a few that assumed the columns would be reordered. 