### PR TITLE
Add missing backtick + fix spelling error

### DIFF
--- a/R/uncount.R
+++ b/R/uncount.R
@@ -1,6 +1,6 @@
 #' "Uncount" a data frame
 #'
-#' Performs the opposite opperation to [dplyr::count()], duplicating rows
+#' Performs the opposite operation to [dplyr::count()], duplicating rows
 #' acoording to a weighting variable (or expression).
 #'
 #' @param data A data frame, tibble, or grouped tibble.
@@ -8,7 +8,7 @@
 #'   supports quasiquotation.
 #' @param .id Supply a string to create a new variable which gives a unique
 #'   identifier for each created row.
-#' @param .remove If `TRUE`, and `weights` is a single `
+#' @param .remove If `TRUE`, and `weights` is a `single`
 #' @export
 #' @examples
 #' df <- tibble::tibble(x = c("a", "b"), n = c(1, 2))

--- a/man/uncount.Rd
+++ b/man/uncount.Rd
@@ -12,13 +12,13 @@ uncount(data, weights, .remove = TRUE, .id = NULL)
 \item{weights}{A vector of weights. Evaluated in the context of \code{data};
 supports quasiquotation.}
 
-\item{.remove}{If \code{TRUE}, and \code{weights} is a signle `}
+\item{.remove}{If \code{TRUE}, and \code{weights} is a \code{single}}
 
 \item{.id}{Supply a string to create a new variable which gives a unique
 identifier for each created row.}
 }
 \description{
-Performs the opposite opperation to \code{\link[dplyr:count]{dplyr::count()}}, duplicating rows
+Performs the opposite operation to \code{\link[dplyr:count]{dplyr::count()}}, duplicating rows
 acoording to a weighting variable (or expression).
 }
 \examples{


### PR DESCRIPTION
Presumes `opperation` is _not_ an alternate spelling that I can't find. 😉