### PR TITLE
Fix #407. unnest works with S3 vectors.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     dplyr (>= 0.7.0),
     glue,
     magrittr,
+    pillar,
     purrr,
     Rcpp,
     rlang,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidyr 0.8.0.9000
 
+## Bug fixes and minor improvements
+
+* `unnest()` works again with factors and Dates (#407, @zeehio).
+
 # tidyr 0.8.0
 
 ## Breaking changes

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -35,7 +35,7 @@ test_that("elements must all be of same type", {
 
 test_that("can't combine vectors and data frames", {
   df <- tibble(x = list(1, tibble(1)))
-  expect_error(unnest(df), "a list of vectors or a list of data frames")
+  expect_error(unnest(df), "must have compatible types")
 })
 
 test_that("multiple columns must be same length", {
@@ -161,4 +161,14 @@ test_that("grouping is preserved", {
   expect_equal(rs$x, 1:3)
   expect_equal(class(df), class(rs))
   expect_equal(dplyr::groups(df), dplyr::groups(rs))
+})
+
+test_that("unnest works with factors (#407)", {
+  df <- tibble(x = as.list(as.factor(letters[1:3])))
+  expect_equal(unnest(df), tibble(x = as.factor(letters[1:3])))
+})
+
+test_that("unnest works with dates (#407)", {
+  df <- tibble(x = as.list(as.Date(c("2018-01-01", "2018-02-01"))))
+  expect_equal(unnest(df), tibble(x = as.Date(c("2018-01-01", "2018-02-01"))))
 })

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -35,7 +35,7 @@ test_that("elements must all be of same type", {
 
 test_that("can't combine vectors and data frames", {
   df <- tibble(x = list(1, tibble(1)))
-  expect_error(unnest(df), "must have compatible types")
+  expect_error(unnest(df), "a list of vectors or a list of data frames")
 })
 
 test_that("multiple columns must be same length", {
@@ -171,4 +171,18 @@ test_that("unnest works with factors (#407)", {
 test_that("unnest works with dates (#407)", {
   df <- tibble(x = as.list(as.Date(c("2018-01-01", "2018-02-01"))))
   expect_equal(unnest(df), tibble(x = as.Date(c("2018-01-01", "2018-02-01"))))
+})
+
+test_that("unnest preserves column order with atomic and S3 vectors", {
+  df <- tibble(z = letters[1:2],
+               x = as.list(as.Date(c("2018-01-01", "2018-02-01"))),
+               y = as.list(1:2))
+  expect_equal(unnest(df), tibble(z = letters[1:2],
+                                  x = as.Date(c("2018-01-01", "2018-02-01")),
+                                  y = 1:2))
+})
+
+test_that("unnest fails with incompatible S3 vector types (#407)", {
+  df <- tibble(x = list(as.Date("2018-01-01"), factor("a")))
+  expect_error(unnest(df), "elements are not compatible")
 })


### PR DESCRIPTION
This PR fixes #407 by using `dplyr::combine()` to combine factors, dates and other supported S3 vector types.

`dplyr` does not offer a way to know if `dplyr::combine()` will succeed based on the types of the vector given, so we use a `tryCatch` to capture the error and report accordingly. Maybe a better solution will appear when https://github.com/hadley/vctrs/issues/7 comes to reality.

Apologies if anyone else was working on this issue. I was affected by it, and given my previous work on `dplyr::combine()` and the `Collecter` class from `dplyr` (https://github.com/tidyverse/dplyr/pull/2209, https://github.com/tidyverse/dplyr/pull/2487) I thought this was a low hanging fruit for me. I can close the PR if anyone has a better solution in mind.

Thanks for your time 😄 

