### PR TITLE
Preserve order of rows in spread() (#453)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr 0.8.1.9000
 
+* `spread()` now always preserves row order (@mikmart, #453).
+
 # tidyr 0.8.1
 
 * `unnest()` weakens test of "atomicity" to restore previous behaviour when

--- a/R/id.R
+++ b/R/id.R
@@ -1,4 +1,4 @@
-id <- function(.variables, drop = FALSE) {
+id <- function(.variables, drop = FALSE, match_order = TRUE) {
   if (length(.variables) == 0) {
     n <- nrow(.variables) %||% 0L
     return(structure(seq_len(n), n = n))
@@ -6,11 +6,11 @@ id <- function(.variables, drop = FALSE) {
 
   # Special case for single variable
   if (length(.variables) == 1) {
-    return(id_var(.variables[[1]], drop = drop))
+    return(id_var(.variables[[1]], drop = drop, match_order = match_order))
   }
 
   # Calculate individual ids
-  ids <- rev(map(.variables, id_var, drop = drop))
+  ids <- rev(map(.variables, id_var, drop = drop, match_order = match_order))
   p <- length(ids)
 
   # Calculate dimensions
@@ -31,13 +31,13 @@ id <- function(.variables, drop = FALSE) {
 
 
   if (drop) {
-    id_var(res, drop = TRUE)
+    id_var(res, drop = TRUE, match_order = match_order)
   } else {
     structure(as.integer(res), n = attr(res, "n"))
   }
 }
 
-id_var <- function(x, drop = FALSE) {
+id_var <- function(x, drop = FALSE, match_order = TRUE) {
   if (!is_null(attr(x, "n")) && !drop) return(x)
 
   if (is.factor(x) && !drop) {
@@ -53,7 +53,9 @@ id_var <- function(x, drop = FALSE) {
     id <- match(x, levels)
     n <- max(id)
   } else {
-    levels <- sort(unique(x), na.last = TRUE)
+    levels <- unique(x)
+    if (match_order)
+      levels <- sort(levels, na.last = TRUE)
     id <- match(x, levels)
     n <- max(id)
   }

--- a/R/spread.R
+++ b/R/spread.R
@@ -65,7 +65,7 @@ spread.data.frame <- function(data, key, value, fill = NA, convert = FALSE,
     row_id <- structure(1L, n = 1L)
     row_labels <- as.data.frame(matrix(nrow = 1, ncol = 0))
   } else {
-    row_id <- id(rows, drop = drop)
+    row_id <- id(rows, drop = drop, match_order = FALSE)
     row_labels <- split_labels(rows, row_id, drop = drop)
     rownames(row_labels) <- NULL
   }

--- a/tests/testthat/test-spread.R
+++ b/tests/testthat/test-spread.R
@@ -15,6 +15,28 @@ test_that("order doesn't matter", {
   expect_identical(one, two)
 })
 
+test_that("preserves row order (#453)", {
+  df <- data.frame(z = c("b", "a"), x = c("a", "b"), y = 1:2)
+  out <- spread(df, x, y)
+  expect_identical(out$z, df$z)
+
+  n <- 1200 # 1200^3 < 2^31 so this tests integer ids
+  i <- n:1
+
+  df <- data.frame(i = i, j = i, k = i, x = c("a", "b"), y = 1:n)
+  out <- spread(df, x, y)
+
+  expect_identical(order(df$i), order(out$i))
+
+  n <- 1300 # 1300^3 > 2^31 so this tests character ids
+  i <- n:1
+
+  df <- data.frame(i = i, j = i, k = i, x = c("a", "b"), y = 1:n)
+  out <- spread(df, x, y)
+
+  expect_identical(order(df$i), order(out$i))
+})
+
 test_that("convert turns strings into integers", {
   df <- tibble(key = "a", value = "1")
   out <- spread(df, key, value, convert = TRUE)


### PR DESCRIPTION
Added an option to `id()` and `id_var()` that allows creating identifiers that do not get ordered in the same way as the original values, but are instead ordered by the order of appearance of unique levels of the original variable. Using this for row identifiers in `spread()` preserves row order, and thus closes #453.