### PR TITLE
Improve error message related to irregular sequences

### DIFF
--- a/R/seq.R
+++ b/R/seq.R
@@ -19,7 +19,7 @@ full_seq <- function(x, period, tol = 1e-6) {
 full_seq.numeric <- function(x, period, tol = 1e-6) {
   rng <- range(x, na.rm = TRUE)
   if (any((x - rng[1]) %% period > tol)) {
-    stop("`x` is not a regular sequence.", call. = FALSE)
+    stop("`x` is not a regular sequence. Change `tol` to `Inf` if this is expected.", call. = FALSE)
   }
 
   seq(rng[1], rng[2], by = period)

--- a/tests/testthat/test-full_seq.R
+++ b/tests/testthat/test-full_seq.R
@@ -4,6 +4,10 @@ test_that("full_seq errors if sequence isn't regular", {
   expect_error(full_seq(c(1, 3, 4), 2), "not a regular sequence")
 })
 
+test_that("full_seq doesn't error if sequence isn't regular and tol is set to Inf", {
+  expect_output(str(full_seq(c(1, 3, 4), 2, tol = Inf)), "num")
+})
+
 test_that("sequences don't have to start at zero", {
   expect_equal(full_seq(c(1, 5), 2), c(1, 3, 5))
 })


### PR DESCRIPTION
If I'd like a full sequence from `2018-11-01` to `2018-11-30` and try,

```r
tibble::tibble(date = c(as.POSIXct("2018-11-01", origin = "1970-01-01"), 
                        as.POSIXct("2018-11-28", origin = "1970-01-01"),
                        as.POSIXct("2018-12-01", origin = "1970-01-01"))) %>% 
    tidyr::complete(date = tidyr::full_seq(date, 60*60*24)) %>%
    print(n = Inf)
```

I'll get `Error: `x` is not a regular sequence. ` as a reply. This is a nice error message, but it took me a bit to learn that `tol` would allow me to proceed having granted the data as an irregular sequence.

```r
tibble::tibble(date = c(as.POSIXct("2018-11-01", origin = "1970-01-01"), 
                        as.POSIXct("2018-11-28", origin = "1970-01-01"),
                        as.POSIXct("2018-12-01", origin = "1970-01-01"))) %>% 
    tidyr::complete(date = tidyr::full_seq(date, 60*60*24, tol = Inf)) %>%
    print(n = Inf)
```
```
# A tibble: 31 x 1
   date               
   <dttm>             
 1 2018-11-01 00:00:00
 2 2018-11-02 00:00:00
 3 2018-11-03 00:00:00
 4 2018-11-04 00:00:00
 5 2018-11-04 23:00:00
 6 2018-11-05 23:00:00
 7 2018-11-06 23:00:00
 8 2018-11-07 23:00:00
 9 2018-11-08 23:00:00
10 2018-11-09 23:00:00
11 2018-11-10 23:00:00
12 2018-11-11 23:00:00
13 2018-11-12 23:00:00
14 2018-11-13 23:00:00
15 2018-11-14 23:00:00
16 2018-11-15 23:00:00
17 2018-11-16 23:00:00
18 2018-11-17 23:00:00
19 2018-11-18 23:00:00
20 2018-11-19 23:00:00
21 2018-11-20 23:00:00
22 2018-11-21 23:00:00
23 2018-11-22 23:00:00
24 2018-11-23 23:00:00
25 2018-11-24 23:00:00
26 2018-11-25 23:00:00
27 2018-11-26 23:00:00
28 2018-11-27 23:00:00
29 2018-11-28 23:00:00
30 2018-11-29 23:00:00
31 2018-11-30 23:00:00
```

This update alerts the user to the `tol` functionality, "`x` is not a regular sequence. Change `tol` to `Inf` if this is expected."