### PR TITLE
Correctly handle missing values when spreading nested columns

### DIFF
--- a/R/spread.R
+++ b/R/spread.R
@@ -98,7 +98,7 @@ spread.data.frame <- function(data, key, value, fill = NA, convert = FALSE,
 
   value <- data[[value_var]]
   ordered <- value[overall]
-  if (all(!is.na(fill))) {
+  if (any(!is.na(fill))) {
     if (class(ordered) == "list") {
       ordered[ordered == "NULL"] <- list(fill)
     }

--- a/R/spread.R
+++ b/R/spread.R
@@ -98,7 +98,10 @@ spread.data.frame <- function(data, key, value, fill = NA, convert = FALSE,
 
   value <- data[[value_var]]
   ordered <- value[overall]
-  if (!is.na(fill)) {
+  if (all(!is.na(fill))) {
+    if (class(ordered) == "list") {
+      ordered[ordered == "NULL"] <- list(fill)
+    }
     ordered[is.na(ordered)] <- fill
   }
 


### PR DESCRIPTION
This PR attempts to fix #522 by adding an extra condition for list columns when using the `fill=` argument inside `spread()`. Because the fill value is likely to be more than just a scalar, I wrapped `!is.na(fill)` inside `any()`.