### PR TITLE
WIP: Enhance gather() to support data.frame columns

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,10 @@ rep_ <- function(x, n, var_name) {
     .Call(`_tidyr_rep_`, x, n, var_name)
 }
 
+concatenate <- function(x, ind, factorsAsStrings) {
+    .Call(`_tidyr_concatenate`, x, ind, factorsAsStrings)
+}
+
 melt_dataframe <- function(data, id_ind, measure_ind, variable_name, value_name, attrTemplate, factorsAsStrings, valueAsFactor, variableAsFactor) {
     .Call(`_tidyr_melt_dataframe`, data, id_ind, measure_ind, variable_name, value_name, attrTemplate, factorsAsStrings, valueAsFactor, variableAsFactor)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,6 +9,10 @@ fillUp <- function(x) {
     .Call(`_tidyr_fillUp`, x)
 }
 
+rep_ <- function(x, n, var_name) {
+    .Call(`_tidyr_rep_`, x, n, var_name)
+}
+
 melt_dataframe <- function(data, id_ind, measure_ind, variable_name, value_name, attrTemplate, factorsAsStrings, valueAsFactor, variableAsFactor) {
     .Call(`_tidyr_melt_dataframe`, data, id_ind, measure_ind, variable_name, value_name, attrTemplate, factorsAsStrings, valueAsFactor, variableAsFactor)
 }

--- a/R/gather.R
+++ b/R/gather.R
@@ -141,10 +141,18 @@ gather.data.frame <- function(data, key = "key", value = "value", ...,
 
 # Functions from reshape2 -------------------------------------------------
 
+attributes_rec <- function(x) {
+  if (is.list(x)) {
+    map(sort(names(x)), ~ attributes_rec(x[[.]]))
+  } else {
+    attributes(x)
+  }
+}
+
 ## Get the attributes if common, NULL if not.
 normalize_melt_arguments <- function(data, measure.ind) {
   measure.attributes <- map(measure.ind, function(i) {
-    attributes(data[[i]])
+    attributes_rec(data[[i]])
   })
 
   ## Determine if all measure.attributes are equal

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -40,6 +40,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// concatenate
+SEXP concatenate(const DataFrame& x, IntegerVector ind, bool factorsAsStrings);
+RcppExport SEXP _tidyr_concatenate(SEXP xSEXP, SEXP indSEXP, SEXP factorsAsStringsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const DataFrame& >::type x(xSEXP);
+    Rcpp::traits::input_parameter< IntegerVector >::type ind(indSEXP);
+    Rcpp::traits::input_parameter< bool >::type factorsAsStrings(factorsAsStringsSEXP);
+    rcpp_result_gen = Rcpp::wrap(concatenate(x, ind, factorsAsStrings));
+    return rcpp_result_gen;
+END_RCPP
+}
 // melt_dataframe
 List melt_dataframe(const DataFrame& data, const IntegerVector& id_ind, const IntegerVector& measure_ind, String variable_name, String value_name, SEXP attrTemplate, bool factorsAsStrings, bool valueAsFactor, bool variableAsFactor);
 RcppExport SEXP _tidyr_melt_dataframe(SEXP dataSEXP, SEXP id_indSEXP, SEXP measure_indSEXP, SEXP variable_nameSEXP, SEXP value_nameSEXP, SEXP attrTemplateSEXP, SEXP factorsAsStringsSEXP, SEXP valueAsFactorSEXP, SEXP variableAsFactorSEXP) {
@@ -77,6 +90,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tidyr_fillDown", (DL_FUNC) &_tidyr_fillDown, 1},
     {"_tidyr_fillUp", (DL_FUNC) &_tidyr_fillUp, 1},
     {"_tidyr_rep_", (DL_FUNC) &_tidyr_rep_, 3},
+    {"_tidyr_concatenate", (DL_FUNC) &_tidyr_concatenate, 3},
     {"_tidyr_melt_dataframe", (DL_FUNC) &_tidyr_melt_dataframe, 9},
     {"_tidyr_simplifyPieces", (DL_FUNC) &_tidyr_simplifyPieces, 3},
     {NULL, NULL, 0}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -27,6 +27,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// rep_
+SEXP rep_(SEXP x, int n, std::string var_name);
+RcppExport SEXP _tidyr_rep_(SEXP xSEXP, SEXP nSEXP, SEXP var_nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type x(xSEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    Rcpp::traits::input_parameter< std::string >::type var_name(var_nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(rep_(x, n, var_name));
+    return rcpp_result_gen;
+END_RCPP
+}
 // melt_dataframe
 List melt_dataframe(const DataFrame& data, const IntegerVector& id_ind, const IntegerVector& measure_ind, String variable_name, String value_name, SEXP attrTemplate, bool factorsAsStrings, bool valueAsFactor, bool variableAsFactor);
 RcppExport SEXP _tidyr_melt_dataframe(SEXP dataSEXP, SEXP id_indSEXP, SEXP measure_indSEXP, SEXP variable_nameSEXP, SEXP value_nameSEXP, SEXP attrTemplateSEXP, SEXP factorsAsStringsSEXP, SEXP valueAsFactorSEXP, SEXP variableAsFactorSEXP) {
@@ -63,6 +76,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_tidyr_fillDown", (DL_FUNC) &_tidyr_fillDown, 1},
     {"_tidyr_fillUp", (DL_FUNC) &_tidyr_fillUp, 1},
+    {"_tidyr_rep_", (DL_FUNC) &_tidyr_rep_, 3},
     {"_tidyr_melt_dataframe", (DL_FUNC) &_tidyr_melt_dataframe, 9},
     {"_tidyr_simplifyPieces", (DL_FUNC) &_tidyr_simplifyPieces, 3},
     {NULL, NULL, 0}

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -23,8 +23,23 @@ SEXP rep_(SEXP x, int n, std::string var_name) {
   }
 
   int xn = Rf_length(x);
-  int nout = xn * n;
 
+  if (Rf_inherits(x, "data.frame")) {
+    List output_ = no_init(xn);
+    DataFrame output = DataFrame(output_);
+    DataFrame data = DataFrame(x);
+
+    CharacterVector data_names = as<CharacterVector>(data.attr("names"));
+    for (int i = 0; i < xn; ++i) {
+      SEXP object = data[i];
+      std::string var_name = std::string(data_names[i]);
+      output[i] = rep_(object, n, var_name);
+    }
+
+    return output;
+  }
+
+  int nout = xn * n;
   Shield<SEXP> output(Rf_allocVector(TYPEOF(x), nout));
   switch (TYPEOF(x)) {
     case INTSXP:

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -180,7 +180,9 @@ SEXP concatenate(const DataFrame& x, IntegerVector ind, bool factorsAsStrings) {
       }
     }
 
+    // TODO: sort in the original order
     CharacterVector sub_data_names_unique = unique(sub_data_names_all);
+    sub_data_names_unique.sort();
 
     List output = no_init(sub_data_names_unique.size());
     output.attr("names") = sub_data_names_unique;

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -14,6 +14,7 @@ using namespace Rcpp;
     }                                                          \
   }
 
+// [[Rcpp::export]]
 SEXP rep_(SEXP x, int n, std::string var_name) {
   if (!Rf_isVectorAtomic(x) && TYPEOF(x) != VECSXP)
     stop("'%s' must be an atomic vector or list", var_name);
@@ -25,17 +26,18 @@ SEXP rep_(SEXP x, int n, std::string var_name) {
   int xn = Rf_length(x);
 
   if (Rf_inherits(x, "data.frame")) {
-    List output_ = no_init(xn);
-    DataFrame output = DataFrame(output_);
+    List output = no_init(xn);
     DataFrame data = DataFrame(x);
 
     CharacterVector data_names = as<CharacterVector>(data.attr("names"));
+    output.attr("names") = data_names;
+
     for (int i = 0; i < xn; ++i) {
       SEXP object = data[i];
-      std::string var_name = std::string(data_names[i]);
-      output[i] = rep_(object, n, var_name);
+      output[i] = rep_(object, n, std::string(data_names[i]));
     }
 
+    Rf_copyMostAttrib(x, output);
     return output;
   }
 

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -14,6 +14,7 @@ using namespace Rcpp;
     }                                                          \
   }
 
+// FIXME: this export is just for debugging purposes
 // [[Rcpp::export]]
 SEXP rep_(SEXP x, int n, std::string var_name) {
   if (!Rf_isVectorAtomic(x) && TYPEOF(x) != VECSXP)
@@ -125,6 +126,7 @@ CharacterVector make_variable_column_character(CharacterVector x, int nrow) {
     break;                                                   \
   }
 
+// FIXME: this export is just for debugging purposes
 // [[Rcpp::export]]
 SEXP concatenate(const DataFrame& x, IntegerVector ind, bool factorsAsStrings) {
 

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -183,7 +183,10 @@ SEXP concatenate(const DataFrame& x, IntegerVector ind, bool factorsAsStrings) {
       for (int i = 0; i < n_ind; ++i) {
         List col = List(x[ind[i]]);
         CharacterVector sub_data_names = as<CharacterVector>(col.attr("names"));
-        //LogicalVector idx = in(sub_col, sub_data_names);
+
+        // TODO: fill non-existent columns.
+        // LogicalVector idx = in(sub_col, sub_data_names);
+
         SET_VECTOR_ELT(tmp, i, col[sub_col]);
       }
       SEXP out = concatenate(tmp, seq(0, ind.size() - 1), factorsAsStrings);
@@ -192,7 +195,8 @@ SEXP concatenate(const DataFrame& x, IntegerVector ind, bool factorsAsStrings) {
 
     Rf_copyMostAttrib(x, output);
 
-    // Set the row names
+    // TODO: as long as used in melt_dataframes(), concatinate() doesn't need to
+    //       set row.names here since this will be overwritten by Rf_copyMostAttrib().
     output.attr("row.names") =
       IntegerVector::create(IntegerVector::get_na(), -(nrow * n_ind));
 
@@ -323,7 +327,7 @@ List melt_dataframe(const DataFrame& data,
 
   // Make the List more data.frame like
 
-  // Set the row names
+  // Set the row names recursively, as Rf_copyMostAttrib does that recursively.
   set_rownames(output, nrow * n_measure);
 
   // Set the names

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -185,8 +185,8 @@ SEXP concatenate(const DataFrame& x, IntegerVector ind, bool factorsAsStrings) {
     List output = no_init(sub_data_names_unique.size());
     output.attr("names") = sub_data_names_unique;
     for (int j = 0; j < sub_data_names_unique.size(); j++) {
-      List tmp = no_init(n_ind);
-      tmp.attr("names") = data_names;
+      List tmp_df = no_init(n_ind);
+      tmp_df.attr("names") = data_names;
       for (int i = 0; i < n_ind; ++i) {
         List col = List(x[ind[i]]);
         CharacterVector sub_data_names = as<CharacterVector>(col.attr("names"));
@@ -194,15 +194,16 @@ SEXP concatenate(const DataFrame& x, IntegerVector ind, bool factorsAsStrings) {
         // TODO: fill non-existent columns.
         // LogicalVector idx = in(sub_col, sub_data_names);
 
-        SET_VECTOR_ELT(tmp, i, VECTOR_ELT(col, j));
+        SET_VECTOR_ELT(tmp_df, i, VECTOR_ELT(col, j));
+        Rf_copyMostAttrib(col, tmp_df);
       }
-      SEXP out = concatenate(tmp, seq(0, n_ind - 1), factorsAsStrings);
+      SEXP out = concatenate(tmp_df, seq(0, n_ind - 1), factorsAsStrings);
       SET_VECTOR_ELT(output, j, out);
     }
 
     Rf_copyMostAttrib(x, output);
 
-    // TODO: as long as used in melt_dataframes(), concatinate() doesn't need to
+    // TODO: as long as used in melt_dataframes(), concatenate() doesn't need to
     //       set row.names here since this will be overwritten by Rf_copyMostAttrib().
     output.attr("row.names") =
       IntegerVector::create(IntegerVector::get_na(), -(nrow * n_ind));
@@ -270,6 +271,22 @@ void set_rownames(List x, int n) {
   }
 }
 
+void copy_most_attrib(SEXP tmpl, SEXP x) {
+  if (!Rf_isNull(tmpl)) {
+    Rf_copyMostAttrib(tmpl, x);
+  }
+
+  if (Rf_inherits(x, "data.frame")) {
+    List data(x);
+    List data_tmpl(tmpl);
+    for (int i = 0; i < data.size(); i++) {
+      SEXP tmpl_col = data_tmpl[i];
+      SEXP col = data[i];
+      copy_most_attrib(tmpl_col, col);
+    }
+  }
+}
+
 
 // [[Rcpp::export]]
 List melt_dataframe(const DataFrame& data,
@@ -329,9 +346,7 @@ List melt_dataframe(const DataFrame& data,
   // TODO: do not add a value column when we gather data.frame columns?
   // 'value' is made by concatenating each of the 'value' variables
   output[n_id + 1] = concatenate(data, measure_ind, factorsAsStrings);
-  if (!Rf_isNull(attrTemplate)) {
-    Rf_copyMostAttrib(attrTemplate, output[n_id + 1]);
-  }
+  copy_most_attrib(attrTemplate, output[n_id + 1]);
 
   // Make the List more data.frame like
 

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -297,13 +297,14 @@ void copy_most_attrib(SEXP tmpl, SEXP x) {
     List data(x);
     List data_tmpl(tmpl);
 
-    CharacterVector data_names_tmpl = as<CharacterVector>(data_tmpl.attr("names"));
     CharacterVector data_names = as<CharacterVector>(data.attr("names"));
+    CharacterVector data_names_tmpl = as<CharacterVector>(data_tmpl.attr("names"));
     IntegerVector indices = match(data_names_tmpl, data_names);
 
     for (int i = 0; i < data.size(); i++) {
       SEXP col = data[i];
-      int idx = indices[i];
+      // match() returns 1-origin indices
+      int idx = indices[i] - 1;
 
       // TODO: handle missing columns
       if (idx < 0) continue;

--- a/src/melt.cpp
+++ b/src/melt.cpp
@@ -321,6 +321,7 @@ List melt_dataframe(const DataFrame& data,
     output[n_id] = make_variable_column_character(id_names, nrow);
   }
 
+  // TODO: do not add a value column when we gather data.frame columns?
   // 'value' is made by concatenating each of the 'value' variables
   output[n_id + 1] = concatenate(data, measure_ind, factorsAsStrings);
   if (!Rf_isNull(attrTemplate)) {


### PR DESCRIPTION
Related: #150 

(This is mainly for PoC. I'm not sure I can finish this PR with my poor C++ skill...)

`gather()` seems to support data.frame column if we modify C++ functions `rep_()` and `concatinate()` to support data.frame. It might be just doing recursion, but I might oversee something.

current progress:

``` r
library(tibble)
library(tidyr)

d <- tibble(id = 1:2,
            x = tibble(a = c("a", "b"), b = 1:2, c = Sys.Date() + b),
            y = tibble(a = c("c", "d"), b = 3:4, c = Sys.Date() + b))

gather(d, k, v, x:y)
#> # A tibble: 4 x 3
#>      id k     v$a      $b $c        
#>   <int> <chr> <chr> <int> <date>    
#> 1     1 x     a         1 2019-02-06
#> 2     2 x     b         2 2019-02-07
#> 3     1 y     c         3 2019-02-08
#> 4     2 y     d         4 2019-02-09
```

<sup>Created on 2019-02-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>