### PR TITLE
library reference corrected in section Examples

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -34,7 +34,7 @@
 #'   completing a data frame with missing combinations.
 #' @export
 #' @examples
-#' library(dplyr)
+#' library(tidyr)
 #' # All possible combinations of vs & cyl, even those that aren't
 #' # present in the data
 #' expand(mtcars, vs, cyl)


### PR DESCRIPTION
changed library reference from `dplyr` to `tidyr` in Examples section