### PR TITLE
Update to PR #504. Use anonymous function instead of compose

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 
 * `crossing()` now takes the unique values of data frame inputs, not just
   vector inputs (#490).
+  
+* `fill()` now accepts `downup` and `updown` as fill directions. (@coolbutuseless #505)
 
 # tidyr 0.8.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # tidyr (development version)
+  
+* `fill()` now accepts `downup` and `updown` as fill directions. (@coolbutuseless #505)
 
 * `pivot()`
 
@@ -28,8 +30,6 @@
 
 * `crossing()` now takes the unique values of data frame inputs, not just
   vector inputs (#490).
-  
-* `fill()` now accepts `downup` and `updown` as fill directions. (@coolbutuseless #505)
 
 # tidyr 0.8.3
 

--- a/R/dep-lazyeval.R
+++ b/R/dep-lazyeval.R
@@ -116,7 +116,7 @@ extract_.data.frame <- function(data, col, into, regex = "([[:alnum:]]+)",
 }
 
 #' @export
-fill.default <- function(data, ..., .direction = c("down", "up")) {
+fill.default <- function(data, ..., .direction = c("down", "up", "downup", "updown")) {
   fill_(data, fill_cols = compat_as_lazy_dots(...), .direction = .direction)
 }
 #' @rdname deprecated-se
@@ -127,7 +127,7 @@ fill_ <- function(data, fill_cols, .direction = c("down", "up")) {
   UseMethod("fill_")
 }
 #' @export
-fill_.data.frame <- function(data, fill_cols, .direction = c("down", "up")) {
+fill_.data.frame <- function(data, fill_cols, .direction = c("down", "up", "downup", "updown")) {
   vars <- syms(fill_cols)
   fill(data, !!! vars, .direction = .direction)
 }

--- a/R/fill.R
+++ b/R/fill.R
@@ -34,8 +34,8 @@ fill.data.frame <- function(data, ..., .direction = c("down", "up", "downup", "u
     .direction,
     down = fillDown,
     up = fillUp,
-    downup = function(x) {fillUp(fillDown(x))},
-    updown = function(x) {fillDown(fillUp(x))}
+    downup = function(x) fillUp(fillDown(x)),
+    updown = function(x) fillDown(fillUp(x))
   )
 
   for (col in fill_cols) {

--- a/R/fill.R
+++ b/R/fill.R
@@ -16,20 +16,23 @@ NULL
 #'   with `x:z`, exclude `y` with `-y`. For more selection options, see the
 #'   [dplyr::select()] documentation.
 #' @param .direction Direction in which to fill missing values. Currently
-#'   either "down" (the default) or "up".
+#'   either "down" (the default), "up", "downup" (i.e. first down and then up)
+#'   or "updown" (first up and then down).
 #' @export
 #' @examples
 #' df <- data.frame(Month = 1:12, Year = c(2000, rep(NA, 11)))
 #' df %>% fill(Year)
-fill <- function(data, ..., .direction = c("down", "up")) {
+fill <- function(data, ..., .direction = c("down", "up", "downup", "updown")) {
   UseMethod("fill")
 }
 #' @export
-fill.data.frame <- function(data, ..., .direction = c("down", "up")) {
+fill.data.frame <- function(data, ..., .direction = c("down", "up", "downup", "updown")) {
   fill_cols <- unname(tidyselect::vars_select(names(data), ...))
 
   .direction <- match.arg(.direction)
-  fillVector <- switch(.direction, down = fillDown, up = fillUp)
+  fillVector <- switch(.direction, down = fillDown, up = fillUp,
+                       downup = function(x) {fillUp(fillDown(x))},
+                       updown = function(x) {fillDown(fillUp(x))})
 
   for (col in fill_cols) {
     data[[col]] <- fillVector(data[[col]])
@@ -38,6 +41,6 @@ fill.data.frame <- function(data, ..., .direction = c("down", "up")) {
   data
 }
 #' @export
-fill.grouped_df <- function(data, ..., .direction = c("down", "up")) {
+fill.grouped_df <- function(data, ..., .direction = c("down", "up", "downup", "updown")) {
   dplyr::do(data, fill(., ..., .direction = .direction))
 }

--- a/R/fill.R
+++ b/R/fill.R
@@ -30,9 +30,13 @@ fill.data.frame <- function(data, ..., .direction = c("down", "up", "downup", "u
   fill_cols <- unname(tidyselect::vars_select(names(data), ...))
 
   .direction <- match.arg(.direction)
-  fillVector <- switch(.direction, down = fillDown, up = fillUp,
-                       downup = function(x) {fillUp(fillDown(x))},
-                       updown = function(x) {fillDown(fillUp(x))})
+  fillVector <- switch(
+    .direction,
+    down = fillDown,
+    up = fillUp,
+    downup = function(x) {fillUp(fillDown(x))},
+    updown = function(x) {fillDown(fillUp(x))}
+  )
 
   for (col in fill_cols) {
     data[[col]] <- fillVector(data[[col]])

--- a/man/deprecated-se.Rd
+++ b/man/deprecated-se.Rd
@@ -94,7 +94,8 @@ columns are integer, numeric or logical.}
 \item{fill_cols}{Character vector of column names.}
 
 \item{.direction}{Direction in which to fill missing values. Currently
-either "down" (the default) or "up".}
+either "down" (the default), "up", "downup" (i.e. first down and then up)
+or "updown" (first up and then down).}
 
 \item{key_col, value_col}{Strings giving names of key and value columns to
 create.}

--- a/man/fill.Rd
+++ b/man/fill.Rd
@@ -4,7 +4,7 @@
 \alias{fill}
 \title{Fill in missing values.}
 \usage{
-fill(data, ..., .direction = c("down", "up"))
+fill(data, ..., .direction = c("down", "up", "downup", "updown"))
 }
 \arguments{
 \item{data}{A data frame.}
@@ -15,7 +15,8 @@ with \code{x:z}, exclude \code{y} with \code{-y}. For more selection options, se
 \code{\link[dplyr:select]{dplyr::select()}} documentation.}
 
 \item{.direction}{Direction in which to fill missing values. Currently
-either "down" (the default) or "up".}
+either "down" (the default), "up", "downup" (i.e. first down and then up)
+or "updown" (first up and then down).}
 }
 \description{
 Fills missing values in selected columns using the previous entry. This is useful in the

--- a/tests/testthat/test-fill.R
+++ b/tests/testthat/test-fill.R
@@ -15,25 +15,23 @@ test_that("all missings left unchanged", {
   expect_identical(up, df)
 })
 
-test_that("missings filled down from last non-missing", {
+test_that("missings are filled correctly", {
+  # filled down from last non-missing
   df <- tibble(x = c(1, NA, NA))
   out <- fill(df, x)
   expect_equal(out$x, c(1, 1, 1))
-})
 
-test_that("missings filled up from last non-missing", {
+  # filled up from last non-missing
   df <- tibble(x = c(NA, NA, 1))
   out <- fill(df, x, .direction = "up")
   expect_equal(out$x, c(1, 1, 1))
-})
 
-test_that("missings filled down-and-then-up from last non-missing", {
+  # filled down-and-then-up from last non-missing
   df <- tibble(x = c(NA, 1, NA, 2, NA, NA))
   out <- fill(df, x, .direction = 'downup')
   expect_equal(out$x, c(1, 1, 1, 2, 2, 2))
-})
 
-test_that("missings filled up-and-then-down from last non-missing", {
+  # filled up-and-then-down from last non-missing
   df <- tibble(x = c(NA, 1, NA, 2, NA, NA))
   out <- fill(df, x, .direction = 'updown')
   expect_equal(out$x, c(1, 1, 2, 2, 2, 2))

--- a/tests/testthat/test-fill.R
+++ b/tests/testthat/test-fill.R
@@ -17,22 +17,17 @@ test_that("all missings left unchanged", {
 
 test_that("missings are filled correctly", {
   # filled down from last non-missing
-  df <- tibble(x = c(1, NA, NA))
-  out <- fill(df, x)
-  expect_equal(out$x, c(1, 1, 1))
-
-  # filled up from last non-missing
-  df <- tibble(x = c(NA, NA, 1))
-  out <- fill(df, x, .direction = "up")
-  expect_equal(out$x, c(1, 1, 1))
-
-  # filled down-and-then-up from last non-missing
   df <- tibble(x = c(NA, 1, NA, 2, NA, NA))
+
+  out <- fill(df, x)
+  expect_equal(out$x, c(NA, 1, 1, 2, 2, 2))
+
+  out <- fill(df, x, .direction = "up")
+  expect_equal(out$x, c(1, 1, 2, 2, NA, NA))
+
   out <- fill(df, x, .direction = 'downup')
   expect_equal(out$x, c(1, 1, 1, 2, 2, 2))
 
-  # filled up-and-then-down from last non-missing
-  df <- tibble(x = c(NA, 1, NA, 2, NA, NA))
   out <- fill(df, x, .direction = 'updown')
   expect_equal(out$x, c(1, 1, 2, 2, 2, 2))
 })

--- a/tests/testthat/test-fill.R
+++ b/tests/testthat/test-fill.R
@@ -27,6 +27,18 @@ test_that("missings filled up from last non-missing", {
   expect_equal(out$x, c(1, 1, 1))
 })
 
+test_that("missings filled down-and-then-up from last non-missing", {
+  df <- tibble(x = c(NA, 1, NA, 2, NA, NA))
+  out <- fill(df, x, .direction = 'downup')
+  expect_equal(out$x, c(1, 1, 1, 2, 2, 2))
+})
+
+test_that("missings filled up-and-then-down from last non-missing", {
+  df <- tibble(x = c(NA, 1, NA, 2, NA, NA))
+  out <- fill(df, x, .direction = 'updown')
+  expect_equal(out$x, c(1, 1, 2, 2, 2, 2))
+})
+
 test_that("missings filled down for each atomic vector", {
   df <- tibble(
     lgl = c(T, NA),


### PR DESCRIPTION
Add option to fill() to both fill-down-then-up and fill-up-then-down. (Issue: https://github.com/tidyverse/tidyr/issues/505)

(Note: This is a replacement for PR #504 which I broke oh-so-hard.)

This is to replace a common idiom of mine, i.e.

```r
df %>%
  group_by(group) %>%
  tidyr::fill(value, .direction = 'down') %>%
  tidyr::fill(value, .direction = 'up') %>%
  ungroup()
```

which could become

```r
df %>%
  group_by(group) %>%
  tidyr::fill(value, .direction = 'downup') %>%
  ungroup()
```

Depending upon number of groups and number of variables to replace, the current duplicate call to fill() can be avoided, giving significant speed savings.




### A situation where I do this

I have values only known at some particular time and I need to fill this value both forwards and backwards in time.

### A particular example

I work with clinical trial data, which is often provided in multiple files.

In the process of making a data set for analysis, particular information may only be recorded at certain events/times, but need to be filled forward/back in time throughout a related time period.  

It is only valid to fill up/down within certain groupings (e.g. subjects, day, part of study) - with lots of subjects and lots of groups, this filling can take a noticeable amount of time.

Also filling may be done within different groupings for different variables.

### A simplified concrete example:

``` r
suppressPackageStartupMessages({
  library(dplyr)
})

# Weight only recorded at event_type = 1, but considered
# valid across the entire event_num.
# If 'wt' not defined for a given event num, it may be
# carried forwards from a prior run, or backwards from a following run
df <- tibble::tribble(
  ~subject, ~time, ~event_type, ~event_num,  ~wt,
  1       ,     1,           0,          1,   NA,
  1       ,     2,           0,          1,   NA,
  1       ,     3,           1,          1,   20,
  1       ,     4,           0,          1,   NA,
  1       ,     5,           0,          1,   NA,
  1       ,     1,           0,          2,   NA,
  1       ,     2,           0,          2,   NA,
  1       ,     3,           1,          2,   NA,
  1       ,     4,           0,          2,   NA,
  1       ,     5,           0,          2,   NA,
  1       ,     1,           0,          3,   NA,
  1       ,     2,           0,          3,   NA,
  1       ,     3,           1,          3,   30,
  1       ,     4,           0,          3,   NA,
  1       ,     5,           0,          3,   NA,
)

# fill wt down/up within the event_num for each subject,
# then down/up within subject only.
df %>%
  group_by(subject, event_num) %>%
  tidyr::fill(wt, .direction = 'down') %>%
  tidyr::fill(wt, .direction = 'up'  ) %>%
  group_by(subject) %>%
  tidyr::fill(wt, .direction = 'down') %>%
  tidyr::fill(wt, .direction = 'up'  ) %>%
  ungroup()
#> # A tibble: 15 x 5
#>    subject  time event_type event_num    wt
#>      <dbl> <dbl>      <dbl>     <dbl> <dbl>
#>  1       1     1          0         1    20
#>  2       1     2          0         1    20
#>  3       1     3          1         1    20
#>  4       1     4          0         1    20
#>  5       1     5          0         1    20
#>  6       1     1          0         2    20
#>  7       1     2          0         2    20
#>  8       1     3          1         2    20
#>  9       1     4          0         2    20
#> 10       1     5          0         2    20
#> 11       1     1          0         3    30
#> 12       1     2          0         3    30
#> 13       1     3          1         3    30
#> 14       1     4          0         3    30
#> 15       1     5          0         3    30
```

Created on 2018-10-24 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).
