### PR TITLE
Clarify pivot docs for pivot_longer when multiple value columns are named

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -12,6 +12,10 @@
 #'   the cell values (`values_to`) turn into in the result.
 #'
 #'   Note that these variables do not exist, so must be specified as strings.
+#'
+#'   If `names_to` contains multiple columns (i.e., `c(".value", "time")`),
+#'   you won't need to specify `values_to` because the special variable name
+#'   `.value` defines the name of the output value columns.
 #' @param names_prefix A regular expression used to remove matching text
 #'   from the start of each variable name.
 #' @param names_sep,names_pattern If `names_to` contains multiple values,

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -23,7 +23,11 @@ specification.}
 the data stored in the column names (\code{names_to}) and the data stored in
 the cell values (\code{values_to}) turn into in the result.
 
-Note that these variables do not exist, so must be specified as strings.}
+Note that these variables do not exist, so must be specified as strings.
+
+If \code{names_to} contains multiple columns (i.e., \code{c(".value", "time")}),
+you won't need to specify \code{values_to} because the special variable name
+\code{.value} defines the name of the output value columns.}
 
 \item{names_prefix}{A regular expression used to remove matching text
 from the start of each variable name.}


### PR DESCRIPTION
In testing out the new `pivot_longer` function in the multiple value columns case, I didn't see immediately (until I referenced the [vignette](https://tidyr.tidyverse.org/dev/articles/pivot.html#multiple-value-columns)) that `values_to` doesn't apply in this case. I tried to add a brief section in the reference doc here that would have helped me, drawing on the helpful portion of text in the existing vignette.