### PR TITLE
Correct typo in expand() example

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -60,8 +60,8 @@
 #'   name = rep(c("Alex", "Robert", "Sam"), c(3, 2, 1)),
 #'   trt  = rep(c("a", "b", "a"), c(3, 2, 1)),
 #'   rep = c(1, 2, 3, 1, 2, 1),
-#'   measurment_1 = runif(6),
-#'   measurment_2 = runif(6)
+#'   measurement_1 = runif(6),
+#'   measurement_2 = runif(6)
 #' )
 #'
 #' # We can figure out the complete set of data with expand()

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -73,8 +73,8 @@ experiment <- tibble(
   name = rep(c("Alex", "Robert", "Sam"), c(3, 2, 1)),
   trt  = rep(c("a", "b", "a"), c(3, 2, 1)),
   rep = c(1, 2, 3, 1, 2, 1),
-  measurment_1 = runif(6),
-  measurment_2 = runif(6)
+  measurement_1 = runif(6),
+  measurement_2 = runif(6)
 )
 
 # We can figure out the complete set of data with expand()


### PR DESCRIPTION
I noticed a small typo in the examples of `tidyr` it is the only occurrence of 'measurment' across the whole package. I couldn't update the .Rd file due to `vctrs` install issues on my machine.