### PR TITLE
Fixed unnest .sep used on empty tibbles

### DIFF
--- a/R/unnest.R
+++ b/R/unnest.R
@@ -126,7 +126,7 @@ unnest.data.frame <- function(data, ..., .drop = NA, .id = NULL,
     unnested_dataframe <- imap(
       unnested_dataframe,
       function(df, name) {
-        set_names(df, paste(name, names(df), sep = .sep))
+        set_names(df, sprintf("%s%s%s", name, .sep, names(df)))
       }
     )
   }


### PR DESCRIPTION
## About

Unnesting an empty tibble errors when a separator is specified, as `paste("a", chr(), sep = "_")` gives `"a_"` not `chr()`.

## Before
``` r
library(tidyr)
tibble(data = list(tibble())) %>% 
  unnest(data, .sep = "_")
#> `nm` must be `NULL` or a character vector the same length as `x`
```

<sup>Created on 2019-04-24 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

---

## After

``` r
library(tidyr)
tibble(data = list(tibble())) %>% 
  unnest(data, .sep = "_")
#> # A tibble: 0 x 0
```

<sup>Created on 2019-04-24 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>