### PR TITLE
fix typo in warning message

### DIFF
--- a/R/nest.R
+++ b/R/nest.R
@@ -230,7 +230,7 @@ unnest <- function(data,
   }
 
   if (!missing(.sep)) {
-    warn(glue("`.sep` is deprecated. Use `name_sep = {.sep}` instead."))
+    warn(glue("`.sep` is deprecated. Use `names_sep = '{.sep}'` instead."))
     deprecated <- TRUE
     names_sep <- .sep
   }

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -234,7 +234,7 @@ test_that("need supply column names", {
 
 test_that("sep combines column names", {
   df <- tibble(x = list(tibble(x = 1)), y = list(tibble(x = 1)))
-  out <- expect_warning(df %>% unnest(c(x, y), .sep = "_"), "name_sep")
+  out <- expect_warning(df %>% unnest(c(x, y), .sep = "_"), "names_sep")
   expect_named(out, c("x_x", "y_x"))
 })
 


### PR DESCRIPTION
Copy/pasting the current warning throws an unrelated error message, because `unnest()` looks for a column named `name_sep` (instead of recognizing the argument `names_sep`).