### PR TITLE
pivot_longer(cols = NULL) as default

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -95,7 +95,7 @@
 #'    names_pattern = "(.)(.)"
 #'  )
 pivot_longer <- function(data,
-                         cols,
+                         cols = NULL,
                          names_to = "name",
                          names_prefix = NULL,
                          names_sep = NULL,


### PR DESCRIPTION
- It returns error if cols nor spec is specified by user.
- It avoids RStudio IDE saying "argument 'cols' is missing. with no default" when using manual spec

Fixes #661