### PR TITLE
fix typo in example section of tidyr's `extract()`

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -23,7 +23,7 @@
 #'   how the regular expression is processed.
 #' @export
 #' @examples
-#' library(dplyr)
+#' library(tidyr)
 #' df <- data.frame(x = c(NA, "a-b", "a-d", "b-c", "d-e"))
 #' df %>% extract(x, "A")
 #' df %>% extract(x, c("A", "B"), "([[:alnum:]]+)-([[:alnum:]]+)")


### PR DESCRIPTION
In the example for tidyr's `extract()`, it is written `library(dplyr)` rather than `library(tidyr)`. I'm using tidyr version 0.8.3