### PR TITLE
Improve error message when `matches()` is used for `col` argument in `pivot_longer()`

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -208,6 +208,11 @@ pivot_longer_spec <- function(data, cols,
     names[[col]] <- vec_cast(names[[col]], names_ptypes[[col]])
   }
 
+  # test the value of `col when it` uses `matches()` arg
+  if (length(cols) == 0) {
+    abort(glue::glue("Val ue in `matches()` has no corresponding value in `data`."))
+  }
+
   out <- tibble(.name = cols)
   out[[".value"]] <- values_to
   out <- vec_cbind(out, names)

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -174,6 +174,9 @@ pivot_longer_spec <- function(data, cols,
                               names_pattern = NULL,
                               names_ptypes = NULL) {
   cols <- tidyselect::vars_select(unique(names(data)), !!enquo(cols))
+  if (length(cols) == 0) {
+    abort(glue::glue("`cols` must select at least one column."))
+  }
 
   if (is.null(names_prefix)) {
     names <- cols
@@ -206,11 +209,6 @@ pivot_longer_spec <- function(data, cols,
   cast_cols <- intersect(names(names), names(names_ptypes))
   for (col in cast_cols) {
     names[[col]] <- vec_cast(names[[col]], names_ptypes[[col]])
-  }
-
-  # Error message for `cols` when there is no match using matches()
-  if (length(cols) == 0) {
-    abort(glue::glue("`cols` must select at least one column."))
   }
 
   out <- tibble(.name = cols)

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -208,9 +208,9 @@ pivot_longer_spec <- function(data, cols,
     names[[col]] <- vec_cast(names[[col]], names_ptypes[[col]])
   }
 
-  # test the value of `col when it` uses `matches()` arg
+  # Error message for `cols` when there is no match using matches()
   if (length(cols) == 0) {
-    abort(glue::glue("Val ue in `matches()` has no corresponding value in `data`."))
+    abort(glue::glue("`cols` must select at least one column."))
   }
 
   out <- tibble(.name = cols)

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -173,3 +173,8 @@ test_that("can cast to custom type", {
 
   expect_equal(sp$name, 1L)
 })
+
+test_that("Error if the `col` can't be selected.", {
+  expect_error(pivot_longer(iris, matches("foo")),
+               regexp = "cols` must select at least one column.")
+})

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -175,6 +175,5 @@ test_that("can cast to custom type", {
 })
 
 test_that("Error if the `col` can't be selected.", {
-  expect_error(pivot_longer(iris, matches("foo")),
-               regexp = "cols` must select at least one column.")
+  expect_error(pivot_longer(iris, matches("foo")), "select at least one")
 })


### PR DESCRIPTION
Improve error message when `matches()` is used for `col` argument in `pivot_longer()`, see #665.