### PR TITLE
Fix lifecycle macro on R 3.2

### DIFF
--- a/R/chop.R
+++ b/R/chop.R
@@ -1,7 +1,7 @@
 #' Chop and unchop
 #'
 #' @description
-#' \lifecycle{maturing}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 #'
 #' Chopping and unchopping preserve the width of a data frame, changing its
 #' length. `chop()` makes `df` shorter by converting rows within each group

--- a/R/dep-lazyeval.R
+++ b/R/dep-lazyeval.R
@@ -3,7 +3,7 @@
 #' Deprecated SE versions of main verbs
 #'
 #' @description
-#' \lifecycle{deprecated}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}
 #'
 #' tidyr used to offer twin versions of each verb suffixed with an
 #' underscore. These versions had standard evaluation (SE) semantics:

--- a/R/gather.R
+++ b/R/gather.R
@@ -1,7 +1,7 @@
 #' Gather columns into key-value pairs
 #'
 #' @description
-#' \lifecycle{retired}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("retired")}
 #'
 #' Development on `gather()` is complete, and for new code we recommend
 #' switching to `pivot_longer()`, which is easier to use, more featureful, and

--- a/R/nest-legacy.R
+++ b/R/nest-legacy.R
@@ -1,7 +1,7 @@
 #' Legacy versions of `nest()` and `unnest()`
 #'
 #' @description
-#' \lifecycle{retired}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("retired")}
 #'
 #' tidyr 1.0.0 introduced a new syntax for [nest()] and [unnest()]. The majority
 #' of existing usage should be automatically translated to the new syntax with a

--- a/R/nest.R
+++ b/R/nest.R
@@ -37,15 +37,19 @@
 #'   that describe how you wish to nest existing columns into new columns.
 #'   The right hand side can be any expression supported by tidyselect.
 #'
-#'   \lifecycle{deprecated}: previously you could write `df %>% nest(x, y, z)`
-#'   and `df %>% unnest(x, y, z)`. Convert to `df %>% nest(data = c(x, y, z))`.
+#'
+#'   \Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+#'   previously you could write `df %>% nest(x, y, z)` and `df %>%
+#'   unnest(x, y, z)`. Convert to `df %>% nest(data = c(x, y, z))`.
 #'   and `df %>% unnest(c(x, y, z))`.
 #'
 #'   If you previously created new variable in `unnest()` you'll now need to
 #'   do it explicitly with `mutate()`. Convert `df %>% unnest(y = fun(x, y, z))`
 #'   to `df %>% mutate(y = fun(x, y, z)) %>% unnest(y)`.
-#' @param .key \lifecycle{deprecated}: No longer needed because of the new
-#'   `new_col = c(col1, col2, col3)` syntax.
+#' @param .key
+#'   \Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+#'   No longer needed because of the new `new_col = c(col1, col2,
+#'   col3)` syntax.
 #' @export
 #' @examples
 #' df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
@@ -186,12 +190,18 @@ check_key <- function(.key) {
 #'   If you `unnest()` multiple columns, parallel entries must compatible
 #'   sizes, i.e. they're either equal or length 1 (following the standard
 #'   tidyverse recycling rules).
-#' @param .drop,.preserve \lifecycle{deprecated} all list-columns are now preserved;
-#'   If there are any that you don't want in the output use `select()` to
-#'   remove them prior to unnesting.
-#' @param .id \lifecycle{deprecated}: convert `df %>% unnest(x, .id = "id")` to
-#'   `df %>% mutate(id = names(x)) %>% unnest(x))`.
-#' @param .sep \lifecycle{deprecated}: use `names_sep` instead.
+#' @param .drop,.preserve
+#'   \Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+#'   all list-columns are now preserved; If there are any that you
+#'   don't want in the output use `select()` to remove them prior to
+#'   unnesting.
+#' @param .id
+#'   \Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+#'   convert `df %>% unnest(x, .id = "id")` to `df %>% mutate(id =
+#'   names(x)) %>% unnest(x))`.
+#' @param .sep
+#'   \Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+#'   use `names_sep` instead.
 #' @export
 #' @rdname nest
 unnest <- function(data,

--- a/R/pack.R
+++ b/R/pack.R
@@ -1,7 +1,7 @@
 #' Pack and unpack
 #'
 #' @description
-#' \lifecycle{maturing}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 #'
 #' Packing and unpacking preserve the length of a data frame, changing its
 #' width. `pack()` makes `df` narrow by collapsing a set of columns into a

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -1,7 +1,7 @@
 #' Pivot data from wide to long
 #'
 #' @description
-#' \lifecycle{maturing}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 #'
 #' `pivot_longer()` "lengthens" data, increasing the number of rows and
 #' decreasing the number of columns. The inverse transformation. in

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -1,7 +1,7 @@
 #' Pivot data from long to wide
 #
 #' @description
-#' \lifecycle{maturing}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 #'
 #' `pivot_wider()` "widens" data, increasing the number of columns and
 #' decreasing the number of rows. The inverse transformation is

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -1,7 +1,7 @@
 #' Rectangle a nested list into a tidy tibble
 #'
 #' @description
-#' \lifecycle{maturing}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 #'
 #' `hoist()`, `unnest_longer()`, and `unnest_wider()` provide tools for
 #' rectangling, collapsing deeply nested lists into regular columns.

--- a/R/spread.R
+++ b/R/spread.R
@@ -1,7 +1,7 @@
 #' Spread a key-value pair across multiple columns
 #'
 #' @description
-#' \lifecycle{retired}
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("retired")}
 #'
 #' Development on `spread()` is complete, and for new code we recommend
 #' switching to `pivot_wider()`, which is easier to use, more featureful, and

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -26,7 +26,7 @@ overriding the default that will be guessed from the combination of
 individual values.}
 }
 \description{
-\lifecycle{maturing}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 
 Chopping and unchopping preserve the width of a data frame, changing its
 length. \code{chop()} makes \code{df} shorter by converting rows within each group

--- a/man/deprecated-se.Rd
+++ b/man/deprecated-se.Rd
@@ -132,7 +132,7 @@ data, filling in missing combinations with \code{fill}.}
 \item{key_col, value_col}{Strings giving names of key and value cols.}
 }
 \description{
-\lifecycle{deprecated}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}
 
 tidyr used to offer twin versions of each verb suffixed with an
 underscore. These versions had standard evaluation (SE) semantics:

--- a/man/gather.Rd
+++ b/man/gather.Rd
@@ -38,7 +38,7 @@ stored as a character vector. If \code{TRUE}, will be stored as a factor,
 which preserves the original ordering of the columns.}
 }
 \description{
-\lifecycle{retired}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("retired")}
 
 Development on \code{gather()} is complete, and for new code we recommend
 switching to \code{pivot_longer()}, which is easier to use, more featureful, and

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -77,7 +77,7 @@ together the outer column name with the inner names, separated by
 \code{names_sep}.}
 }
 \description{
-\lifecycle{maturing}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 
 \code{hoist()}, \code{unnest_longer()}, and \code{unnest_wider()} provide tools for
 rectangling, collapsing deeply nested lists into regular columns.

--- a/man/macros/lifecycle.Rd
+++ b/man/macros/lifecycle.Rd
@@ -1,1 +1,0 @@
-\newcommand{\lifecycle}{\Sexpr[results=rd, stage=render]{lifecycle::badge("#1")}}

--- a/man/nest.Rd
+++ b/man/nest.Rd
@@ -19,16 +19,16 @@ unnest(data, cols, ..., keep_empty = FALSE, ptype = NULL,
 that describe how you wish to nest existing columns into new columns.
 The right hand side can be any expression supported by tidyselect.
 
-\lifecycle{deprecated}: previously you could write \code{df \%>\% nest(x, y, z)}
-and \code{df \%>\% unnest(x, y, z)}. Convert to \code{df \%>\% nest(data = c(x, y, z))}.
+\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+previously you could write \code{df \%>\% nest(x, y, z)} and \code{df \%>\% unnest(x, y, z)}. Convert to \code{df \%>\% nest(data = c(x, y, z))}.
 and \code{df \%>\% unnest(c(x, y, z))}.
 
 If you previously created new variable in \code{unnest()} you'll now need to
 do it explicitly with \code{mutate()}. Convert \code{df \%>\% unnest(y = fun(x, y, z))}
 to \code{df \%>\% mutate(y = fun(x, y, z)) \%>\% unnest(y)}.}
 
-\item{.key}{\lifecycle{deprecated}: No longer needed because of the new
-\code{new_col = c(col1, col2, col3)} syntax.}
+\item{.key}{\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+No longer needed because of the new \code{new_col = c(col1, col2, col3)} syntax.}
 
 \item{data}{A data frame.}
 
@@ -68,14 +68,16 @@ names. Must be one of the following options:
 See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on these terms and the
 strategies used to enforce them.}
 
-\item{.drop, .preserve}{\lifecycle{deprecated} all list-columns are now preserved;
-If there are any that you don't want in the output use \code{select()} to
-remove them prior to unnesting.}
+\item{.drop, .preserve}{\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+all list-columns are now preserved; If there are any that you
+don't want in the output use \code{select()} to remove them prior to
+unnesting.}
 
-\item{.id}{\lifecycle{deprecated}: convert \code{df \%>\% unnest(x, .id = "id")} to
-\code{df \%>\% mutate(id = names(x)) \%>\% unnest(x))}.}
+\item{.id}{\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+convert \code{df \%>\% unnest(x, .id = "id")} to \code{df \%>\% mutate(id = names(x)) \%>\% unnest(x))}.}
 
-\item{.sep}{\lifecycle{deprecated}: use \code{names_sep} instead.}
+\item{.sep}{\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}:
+use \code{names_sep} instead.}
 }
 \description{
 Nesting creates a list-column of data frames; unnesting flattens it back out

--- a/man/nest_legacy.Rd
+++ b/man/nest_legacy.Rd
@@ -42,7 +42,7 @@ will be duplicated in the same way as atomic vectors. This has
 \code{.preserve = c(x, y)} or \code{.preserve = starts_with("list")}.}
 }
 \description{
-\lifecycle{retired}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("retired")}
 
 tidyr 1.0.0 introduced a new syntax for \code{\link[=nest]{nest()}} and \code{\link[=unnest]{unnest()}}. The majority
 of existing usage should be automatically translated to the new syntax with a

--- a/man/pack.Rd
+++ b/man/pack.Rd
@@ -41,7 +41,7 @@ See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on 
 strategies used to enforce them.}
 }
 \description{
-\lifecycle{maturing}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 
 Packing and unpacking preserve the length of a data frame, changing its
 width. \code{pack()} makes \code{df} narrow by collapsing a set of columns into a

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -64,7 +64,7 @@ to implicit missing values, and should generally be used only when missing
 values in \code{data} were created by its structure.}
 }
 \description{
-\lifecycle{maturing}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 
 \code{pivot_longer()} "lengthens" data, increasing the number of rows and
 decreasing the number of columns. The inverse transformation. in

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -46,7 +46,7 @@ use this when the combination of \code{id_cols} and \code{value} column does not
 uniquely identify an observation.}
 }
 \description{
-\lifecycle{maturing}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 
 \code{pivot_wider()} "widens" data, increasing the number of columns and
 decreasing the number of rows. The inverse transformation is

--- a/man/spread.Rd
+++ b/man/spread.Rd
@@ -37,7 +37,7 @@ data, filling in missing combinations with \code{fill}.}
 by "<key_name><sep><key_value>".}
 }
 \description{
-\lifecycle{retired}
+\Sexpr[results=rd, stage=render]{lifecycle::badge("retired")}
 
 Development on \code{spread()} is complete, and for new code we recommend
 switching to \code{pivot_wider()}, which is easier to use, more featureful, and

--- a/man/tidyr-package.Rd
+++ b/man/tidyr-package.Rd
@@ -8,12 +8,13 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right'}}
 
-tidyr helps to create tidy data, where each
-    column is a variable, each row is an observation, and each cell
-    contains a single value.  tidyr contains tools for changing the shape
-    (pivoting) and hierarchy (nesting and unnesting) of a dataset, as well
-    as extracting values out of string columns. It also includes tools for
-    working with missing values (both implicit and explicit).
+Tools to help to create tidy data, where each column is a 
+    variable, each row is an observation, and each cell contains a single value.  
+    'tidyr' contains tools for changing the shape (pivoting) and hierarchy
+    (nesting and 'unnesting') of a dataset, turning deeply nested lists
+    into rectangular data frames ('rectangling'), and extracting values out 
+    of string columns. It also includes tools for working with missing values 
+    (both implicit and explicit).
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Unfortunately it seems there is no way to use the macro on R 3.2.