### PR TITLE
Typo in spread documentation

### DIFF
--- a/R/spread.R
+++ b/R/spread.R
@@ -7,7 +7,7 @@
 #' switching to `pivot_wider()`, which is easier to use, more featureful, and
 #' still under active development.
 #' `df %>% spread(key, value)` is equivalent to
-#' `df %>% pivot_wider(names_to = key, values_to = value)`
+#' `df %>% pivot_wider(names_from = key, values_from = value)`
 #'
 #' See more details in `vignette("pivot")`.
 #'

--- a/man/spread.Rd
+++ b/man/spread.Rd
@@ -43,7 +43,7 @@ Development on \code{spread()} is complete, and for new code we recommend
 switching to \code{pivot_wider()}, which is easier to use, more featureful, and
 still under active development.
 \code{df \%>\% spread(key, value)} is equivalent to
-\code{df \%>\% pivot_wider(names_to = key, values_to = value)}
+\code{df \%>\% pivot_wider(names_from = key, values_from = value)}
 
 See more details in \code{vignette("pivot")}.
 }

--- a/man/tidyr-package.Rd
+++ b/man/tidyr-package.Rd
@@ -8,12 +8,13 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right'}}
 
-tidyr helps to create tidy data, where each
-    column is a variable, each row is an observation, and each cell
-    contains a single value.  tidyr contains tools for changing the shape
-    (pivoting) and hierarchy (nesting and unnesting) of a dataset, as well
-    as extracting values out of string columns. It also includes tools for
-    working with missing values (both implicit and explicit).
+Tools to help to create tidy data, where each column is a 
+    variable, each row is an observation, and each cell contains a single value.  
+    'tidyr' contains tools for changing the shape (pivoting) and hierarchy
+    (nesting and 'unnesting') of a dataset, turning deeply nested lists
+    into rectangular data frames ('rectangling'), and extracting values out 
+    of string columns. It also includes tools for working with missing values 
+    (both implicit and explicit).
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Documentation uses wrong argument names when referring to `pivot_wider()`