### PR TITLE
Fix compatibility layer of `.key`

### DIFF
--- a/R/nest.R
+++ b/R/nest.R
@@ -136,12 +136,12 @@ nest.data.frame <- function(.data, ..., .key = deprecated()) {
     .data <- as_tibble(.data)
   }
 
-  nest.tbl_df(.data, ..., .key = .key)
+  nest.tbl_df(.data, ..., .key = !!enquo(.key))
 }
 
 #' @export
 nest.tbl_df <- function(.data, ..., .key = deprecated()) {
-  .key <- check_key(.key)
+  .key <- check_key(enquo(.key))
   if (missing(...)) {
     warn(paste0(
       "`...` must not be empty for ungrouped data frames.\n",
@@ -165,7 +165,7 @@ nest.tbl_df <- function(.data, ..., .key = deprecated()) {
 #' @export
 nest.grouped_df <- function(.data, ..., .key = deprecated()) {
   if (missing(...)) {
-    .key <- check_key(.key)
+    .key <- check_key(enquo(.key))
     nest_vars <- setdiff(names(.data), dplyr::group_vars(.data))
     out <- nest.tbl_df(.data, !!.key := !!nest_vars)
   } else {
@@ -177,9 +177,9 @@ nest.grouped_df <- function(.data, ..., .key = deprecated()) {
 }
 
 check_key <- function(.key) {
-  if (!is_missing(.key)) {
+  if (!quo_is_call(.key, "deprecated")) {
     warn("`.key` is deprecated")
-    .key
+    as_name(.key)
   } else {
     "data"
   }

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -297,3 +297,19 @@ test_that("grouping is preserved", {
   expect_equal(class(df), class(rs))
   expect_equal(dplyr::groups(df), dplyr::groups(rs))
 })
+
+test_that("`.key` still works", {
+  df <- tibble(g = 1:3, x = 1:3) %>% dplyr::group_by(g)
+  expect_warning(
+    expect_named(nest(df, .key = foo), c("g", "foo")),
+    "deprecated"
+  )
+
+  method <- function(.data, ..., .key = "data") {
+    nest(.data, ..., .key = !!.key)
+  }
+  expect_warning(
+    expect_named(method(df), c("g", "data")),
+    "deprecated"
+  )
+})


### PR DESCRIPTION
Part of r-spatial/sf#1068

`.key` needs to be quasiquoted for compatibility. Thanks to @yutannihilation for spotting the problem!