### PR TITLE
Perform direct column replacements in `unnest_longer()` / `unnest_wider()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # tidyr (development version)
 
+## Bug fixes and minor improvements
+
+* `unnest_wider()` and `unnest_longer()` can now unnest `list_of` columns. This
+  is important for unnesting columns created from `nest()`, which are always
+  `list_of` columns, and for usage after `pivot_wider()`, which, by default, 
+  will create `list_of` columns when duplicates arise (#741).
+
 # tidyr 1.0.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # tidyr (development version)
 
-## Bug fixes and minor improvements
-
 * `unnest_wider()` and `unnest_longer()` can now unnest `list_of` columns. This
   is important for unnesting columns created from `nest()`, which are always
   `list_of` columns, and for usage after `pivot_wider()`, which, by default, 

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -209,7 +209,7 @@ unnest_wider <- function(data, col,
                          ptype = list()) {
   col <- tidyselect::vars_select(tbl_vars(data), !!enquo(col))
 
-  data[[col]][] <- map(data[[col]], vec_to_wide, col = col)
+  data[[col]] <- map(data[[col]], vec_to_wide, col = col)
   data <- unchop(data, !!col, keep_empty = TRUE)
   inner_cols <- names(data[[col]])
 

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -178,7 +178,7 @@ unnest_longer <- function(data, col,
     indices_to <- paste0(col, "_id")
   }
 
-  data[[col]][] <- map(
+  data[[col]] <- map(
     data[[col]], vec_to_long,
     col = col,
     values_to = values_to,

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -202,6 +202,17 @@ test_that("bad inputs generate errors", {
   expect_error(unnest_longer(df, y), "must be list of vectors")
 })
 
+test_that("list_of columns can be unnested", {
+  df <- tibble(x = 1:2, y = list_of(1L, 1:2))
+  out <- unnest_longer(df, y)
+
+  expect_named(out, c("x", "y"))
+  expect_equal(nrow(out), 3)
+
+  # With id column
+  df <- tibble(x = 1:2, y = list_of(c(a = 1L), c(b = 1:2)))
+  expect_named(unnest_longer(df, y), c("x", "y", "y_id"))
+})
 
 # unnest_auto -------------------------------------------------------------
 

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -148,8 +148,8 @@ test_that("list of 0-length vectors yields no new columns", {
 })
 
 test_that("list_of columns can be unnested", {
-  df <- tibble(x = 1:2, y = list_of(1L, 1:2))
-  expect_named(unnest_wider(df, y), c("x", "...1", "...2"))
+  df <- tibble(x = 1:2, y = list_of(c(a = 1L), c(a = 1L, b = 2L)))
+  expect_named(unnest_wider(df, y), c("x", "a", "b"))
 
   df <- tibble(x = 1:2, y = list_of(c(a = 1L), c(b = 1:2)))
   expect_named(unnest_wider(df, y), c("x", "a", "b1", "b2"))

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -147,6 +147,14 @@ test_that("list of 0-length vectors yields no new columns", {
   expect_named(unnest_wider(df, y), "x")
 })
 
+test_that("list_of columns can be unnested", {
+  df <- tibble(x = 1:2, y = list_of(1L, 1:2))
+  expect_named(unnest_wider(df, y), c("x", "...1", "...2"))
+
+  df <- tibble(x = 1:2, y = list_of(c(a = 1L), c(b = 1:2)))
+  expect_named(unnest_wider(df, y), c("x", "a", "b1", "b2"))
+})
+
 # unnest_longer -----------------------------------------------------------
 
 test_that("uses input for default column names", {


### PR DESCRIPTION
Fixes #741.

This was a similar problem to a previous issue, where we were assigning to `data[[col]][] <-` when it just needed to be `data[[col]] <- `.

I also changed this for `unnest_longer()`.

Note that there is still another place in `unnest_longer/wider()` where the `data[[col]][] <- ` assignment is used. That one was not adjusted, as it broke tests. I think it makes sense there because at that point `data[[col]]` is often a tibble itself (it was a df-col), and we want to use `data[[col]][] <-` there to perform the assignment, rather than replace the tibble.

``` r
library(tidyr)

df1 <- tibble::tribble(
  ~type,          ~name, ~var1,
  "Country",   "Norway", 169L, 
  "Sport",     "Skii", 169L, 
  "Country",    "Spain", 150L, 
  "Sport",     "Bike", 150L, 
  "Sport",   "Soccer", 150L, 
  "Sport",   "Basket", 150L, 
  "Country",      "USA",   0L, 
  "Sport", "Baseball",   0L, 
)

df2 <- pivot_wider(df1, names_from = "type", values_from = "name") 
#> Warning: Values in `name` are not uniquely identified; output will contain list-cols.
#> * Use `values_fn = list(name = list)` to suppress this warning.
#> * Use `values_fn = list(name = length)` to identify where the duplicates arise
#> * Use `values_fn = list(name = summary_fun)` to summarise duplicates
```

```r
# before
unnest_wider(df2, Sport)
#> New names:
#> * `` -> ...1
#> New names:
#> * `` -> ...1
#> * `` -> ...2
#> * `` -> ...3
#> New names:
#> * `` -> ...1
#> No common type for `x` <tbl_df<...1:character>> and `y` <character>.

# after
unnest_wider(df2, Sport)
#> New names:
#> * `` -> ...1
#> New names:
#> * `` -> ...1
#> * `` -> ...2
#> * `` -> ...3
#> New names:
#> * `` -> ...1
#> # A tibble: 3 x 5
#>    var1     Country ...1     ...2   ...3  
#>   <int> <list<chr>> <chr>    <chr>  <chr> 
#> 1   169         [1] Skii     <NA>   <NA>  
#> 2   150         [1] Bike     Soccer Basket
#> 3     0         [1] Baseball <NA>   <NA>
```

```r
# before
unnest_longer(df2, Sport)
#> No common type for `x` <tbl_df<Sport:character>> and `y` <character>.

# after
unnest_longer(df2, Sport)
#> # A tibble: 5 x 3
#>    var1     Country Sport   
#>   <int> <list<chr>> <chr>   
#> 1   169         [1] Skii    
#> 2   150         [1] Bike    
#> 3   150         [1] Soccer  
#> 4   150         [1] Basket  
#> 5     0         [1] Baseball
```

<sup>Created on 2019-09-16 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>