### PR TITLE
Dory is not a clownfish

### DIFF
--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -64,7 +64,7 @@
 #'        )
 #'     ),
 #'     list(
-#'       species = "clownfish",
+#'       species = "blue tang",
 #'       color = "blue",
 #'       films = c("Finding Nemo", "Finding Dory")
 #'     )

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -135,7 +135,7 @@ df <- tibble(
        )
     ),
     list(
-      species = "clownfish",
+      species = "blue tang",
       color = "blue",
       films = c("Finding Nemo", "Finding Dory")
     )


### PR DESCRIPTION
For the examples for hoist, the species for Dory is listed as clownfish. Marlin and Nemo are clownfish while Dory is a blue tang, or a Pacific Regal Blue Tang. I went with the shorter version.