### PR TITLE
Preserve emptiness in hoisted and unnested list-cols

### DIFF
--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -47,6 +47,16 @@ test_that("input validation catches problems", {
   expect_error(df %>% hoist(x, "a"), "named")
 })
 
+# https://github.com/tidyverse/tidyr/issues/806
+test_that("hoisted list-col represents emptiness with a length-0 element", {
+  df <- tibble(x = list(
+    list(universal = "a", patchy = 1:2),
+    list(universal = "b")
+  ))
+  out <- df %>% hoist(x, patchy = "patchy")
+  expect_length(out$patchy[[2]], 0)
+})
+
 # strike ------------------------------------------------------------------
 
 test_that("strike can remove using a character vector", {
@@ -153,6 +163,16 @@ test_that("list_of columns can be unnested", {
 
   df <- tibble(x = 1:2, y = list_of(c(a = 1L), c(b = 1:2)))
   expect_named(unnest_wider(df, y), c("x", "a", "b1", "b2"))
+})
+
+# https://github.com/tidyverse/tidyr/issues/806
+test_that("unnested list-col represents emptiness with a length-0 element", {
+  df <- tibble(x = list(
+    list(universal = "a", patchy = 1:2),
+    list(universal = "b")
+  ))
+  out <- df %>% unnest_wider(x)
+  expect_length(out$patchy[[2]], 0)
 })
 
 # unnest_longer -----------------------------------------------------------


### PR DESCRIPTION
Closes #806. Rather, ideally, it would.

I'm not going to finish this. Everything I do to fix it, causes trouble elsewhere. I think you @hadley have to decide how you want to fix it. >= 3 helpers are interacting, which are also used in other functions.

Diagnosis:

`simplify_col()` calls `init_col()`:

https://github.com/tidyverse/tidyr/blob/cb512471f2a38871fa168c21590925364a3e5c4a/R/rectangle.R#L327-L329

`init_col()` turns `NULL`s and anything of size 0 into something of size 1.

https://github.com/tidyverse/tidyr/blob/c73979dbe0bc88a8855cf4dc6a6cc9bdb7c2ecfe/R/utils.R#L102-L110

But that's delicate to change that because `vec_simplify()` won't simplify unless every element has size 1.

https://github.com/tidyverse/tidyr/blob/cb512471f2a38871fa168c21590925364a3e5c4a/R/rectangle.R#L340-L344