### PR TITLE
Don't apply name repair when building spec

### DIFF
--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -215,7 +215,7 @@ build_wider_spec <- function(data,
     row_ids <- vec_repeat(row_ids, times = vec_size(values_from))
   }
 
-  vec_cbind(out, row_ids)
+  vec_cbind(out, row_ids, .name_repair = "minimal")
 }
 
 # quiet R CMD check

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -47,8 +47,8 @@ test_that("grouping is preserved", {
 
 # https://github.com/tidyverse/tidyr/issues/804
 test_that("column with `...j` name can be used as `names_from`", {
-  df <- tibble("...8" = c("x", "y", "z"), val = 1:3)
-  pv <- pivot_wider(df, names_from = "...8", values_from = val)
+  df <- tibble(...8 = c("x", "y", "z"), val = 1:3)
+  pv <- pivot_wider(df, names_from = ...8, values_from = val)
   expect_named(pv, c("x", "y", "z"))
   expect_equal(nrow(pv), 1)
 })

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -25,7 +25,7 @@ test_that("implicit missings turn into explicit missings", {
   expect_equal(pv$y, c(NA, 2))
 })
 
-test_that("warn when overwriting existing column", {
+test_that("error when overwriting existing column", {
   df <- tibble(
     a = c(1, 1),
     key = c("a", "b"),
@@ -43,6 +43,14 @@ test_that("grouping is preserved", {
     dplyr::group_by(g) %>%
     pivot_wider(names_from = k, values_from = v)
   expect_equal(dplyr::group_vars(out), "g")
+})
+
+# https://github.com/tidyverse/tidyr/issues/804
+test_that("column with `...j` name can be used as `names_from`", {
+  df <- tibble("...8" = c("x", "y", "z"), val = 1:3)
+  pv <- pivot_wider(df, names_from = "...8", values_from = val)
+  expect_named(pv, c("x", "y", "z"))
+  expect_equal(nrow(pv), 1)
 })
 
 # keys ---------------------------------------------------------


### PR DESCRIPTION
Fixes #804 

I don't think name repair should happen when building the spec. The real application of name repair comes when the spec is used to do the actual pivot.

---

Sidebar: I still think explicit use of `pivot_wider(df, names_from = "...1")` falls under this from [our name repair principles](https://principles.tidyverse.org/names-attribute.html#unique-names):

> When unique-ifying names, we assume that the input names have been repaired by the same strategy, i.e. that we are consuming dogfood. Therefore, pre-existing suffixes of the form `...j` are stripped, prior to (re-)constructing the suffixes. If this interacts poorly with your names, you need to take control of name repair.

It seems pretty artificial (and risky) to hard-code a column name (`"...1"`) that was created through automatic name repair. If a column is important enough to use as `names_from`, it deserves a real name.