### PR TITLE
Add .name_repair to expand functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # tidyr (development version)
 
-* `expand()`, `expand_grid()`, `crossing` and `nesting` gain a `.name_repair`
-  argument allowing them to respect `.name_repair` if it is passed to them
-  (@jeffreypullin, #798).
+* `expand()`, `expand_grid()`, `crossing()`, and `nesting()` gain a 
+  `.name_repair` argument allowing them to respect `.name_repair` if it is 
+  passed to them (@jeffreypullin, #798).
 
 * `pack()` gains a `.names_sep` argument allows you to strip outer names from
   inner names, in symmetrical way to how the same argument to `pack()` combines

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidyr (development version)
 
+* `expand()`, `expand_grid()`, `crossing` and `nesting` gain a `.name_repair`
+  argument allowing them to respect `.name_repair` if it is passed to them
+  (@jeffreypullin, #798).
+
 * `pack()` gains a `.names_sep` argument allows you to strip outer names from
   inner names, in symmetrical way to how the same argument to `pack()` combines
   inner and outer names (#795).

--- a/R/expand.R
+++ b/R/expand.R
@@ -150,19 +150,7 @@ nesting <- function(..., .name_repair = "check_unique") {
 #' * Can expand any generalised vector, including data frames.
 #' @param ... Name-value pairs. The name will become the column name in the
 #'   output.
-#' @param .name_repair Used to check that output data frame has valid
-#'   names. Must be one of the following options:
-#'
-#'   * "minimal": no name repair or checks, beyond basic existence,
-#'   * "unique": make sure names are unique and not empty,
-#'   * "check_unique": (the default), no name repair, but check they are unique,
-#'   * "universal": make the names unique and syntactic
-#'   * a function: apply custom name repair.
-#'   * [tidyr_legacy]: use the name repair from tidyr 0.8.
-#'   * a formula: a purrr-style anonymous function (see [rlang::as_function()])
-#'
-#'   See [vctrs::vec_as_names()] for more details on these terms and the
-#'   strategies used to enforce them.
+#' @inheritParams tibble::as_tibble
 #' @return A tibble with one column for each input in `...`. The output
 #'   will have one row for each combination of the inputs, i.e. the size
 #'   be equal to the product of the sizes of the inputs. This implies

--- a/R/expand.R
+++ b/R/expand.R
@@ -9,6 +9,7 @@
 #' each input. `nesting()` is the complement to `crossing()`: it only keeps
 #' combinations of values that appear in the data.
 #'
+#' @inheritParams expand_grid
 #' @param data A data frame.
 #' @param ... Specification of columns to expand. Columns can be atomic vectors
 #'   or lists.
@@ -28,19 +29,6 @@
 #'   `year = 2010:2020` or `year = \link{full_seq}(year,1)`.
 #'
 #'   Length-zero (empty) elements are automatically dropped.
-#' @param .name_repair Used to check that output data frame has valid
-#'   names. Must be one of the following options:
-#'
-#'   * "minimal": no name repair or checks, beyond basic existence,
-#'   * "unique": make sure names are unique and not empty,
-#'   * "check_unique": (the default), no name repair, but check they are unique,
-#'   * "universal": make the names unique and syntactic
-#'   * a function: apply custom name repair.
-#'   * [tidyr_legacy]: use the name repair from tidyr 0.8.
-#'   * a formula: a purrr-style anonymous function (see [rlang::as_function()])
-#'
-#'   See [vctrs::vec_as_names()] for more details on these terms and the
-#'   strategies used to enforce them.
 #' @seealso [complete()] for a common application of `expand`:
 #'   completing a data frame with missing combinations. [expand_grid()]
 #'   is low-level that doesn't deduplicate or sort values.
@@ -172,6 +160,9 @@ nesting <- function(..., .name_repair = "check_unique") {
 #'   * a function: apply custom name repair.
 #'   * [tidyr_legacy]: use the name repair from tidyr 0.8.
 #'   * a formula: a purrr-style anonymous function (see [rlang::as_function()])
+#'
+#'   See [vctrs::vec_as_names()] for more details on these terms and the
+#'   strategies used to enforce them.
 #' @return A tibble with one column for each input in `...`. The output
 #'   will have one row for each combination of the inputs, i.e. the size
 #'   be equal to the product of the sizes of the inputs. This implies

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -34,20 +34,20 @@ that don't appear in the data: to do so use expressions like
 
 Length-zero (empty) elements are automatically dropped.}
 
-\item{.name_repair}{Used to check that output data frame has valid
-names. Must be one of the following options:
+\item{.name_repair}{Treatment of problematic column names:
 \itemize{
-\item "minimal": no name repair or checks, beyond basic existence,
-\item "unique": make sure names are unique and not empty,
-\item "check_unique": (the default), no name repair, but check they are unique,
-\item "universal": make the names unique and syntactic
-\item a function: apply custom name repair.
-\item \link{tidyr_legacy}: use the name repair from tidyr 0.8.
-\item a formula: a purrr-style anonymous function (see \code{\link[rlang:as_function]{rlang::as_function()}})
+\item \code{"minimal"}: No name repair or checks, beyond basic existence,
+\item \code{"unique"}: Make sure names are unique and not empty,
+\item \code{"check_unique"}: (default value), no name repair, but check they are
+\code{unique},
+\item \code{"universal"}: Make the names \code{unique} and syntactic
+\item a function: apply custom name repair (e.g., \code{.name_repair = make.names}
+for names in the style of base R).
+\item A purrr-style anonymous function, see \code{\link[rlang:as_function]{rlang::as_function()}}
 }
 
-See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on these terms and the
-strategies used to enforce them.}
+See \link[tibble]{name-repair} for more details on these terms and the strategies used
+to enforce them.}
 }
 \description{
 \code{expand()} is often useful in conjunction with \code{left_join()} if

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -6,11 +6,11 @@
 \alias{nesting}
 \title{Expand data frame to include all combinations of values}
 \usage{
-expand(data, ...)
+expand(data, ..., .name_repair = "check_unique")
 
-crossing(...)
+crossing(..., .name_repair = "check_unique")
 
-nesting(...)
+nesting(..., .name_repair = "check_unique")
 }
 \arguments{
 \item{data}{A data frame.}
@@ -33,6 +33,21 @@ that don't appear in the data: to do so use expressions like
 \code{year = 2010:2020} or \verb{year = \link{full_seq}(year,1)}.
 
 Length-zero (empty) elements are automatically dropped.}
+
+\item{.name_repair}{Used to check that output data frame has valid
+names. Must be one of the following options:
+\itemize{
+\item "minimal": no name repair or checks, beyond basic existence,
+\item "unique": make sure names are unique and not empty,
+\item "check_unique": (the default), no name repair, but check they are unique,
+\item "universal": make the names unique and syntactic
+\item a function: apply custom name repair.
+\item \link{tidyr_legacy}: use the name repair from tidyr 0.8.
+\item a formula: a purrr-style anonymous function (see \code{\link[rlang:as_function]{rlang::as_function()}})
+}
+
+See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on these terms and the
+strategies used to enforce them.}
 }
 \description{
 \code{expand()} is often useful in conjunction with \code{left_join()} if

--- a/man/expand_grid.Rd
+++ b/man/expand_grid.Rd
@@ -4,11 +4,23 @@
 \alias{expand_grid}
 \title{Create a tibble from all combinations of inputs}
 \usage{
-expand_grid(...)
+expand_grid(..., .name_repair = "check_unique")
 }
 \arguments{
 \item{...}{Name-value pairs. The name will become the column name in the
 output.}
+
+\item{.name_repair}{Used to check that output data frame has valid
+names. Must be one of the following options:
+\itemize{
+\item "minimal": no name repair or checks, beyond basic existence,
+\item "unique": make sure names are unique and not empty,
+\item "check_unique": (the default), no name repair, but check they are unique,
+\item "universal": make the names unique and syntactic
+\item a function: apply custom name repair.
+\item \link{tidyr_legacy}: use the name repair from tidyr 0.8.
+\item a formula: a purrr-style anonymous function (see \code{\link[rlang:as_function]{rlang::as_function()}})
+}}
 }
 \value{
 A tibble with one column for each input in \code{...}. The output

--- a/man/expand_grid.Rd
+++ b/man/expand_grid.Rd
@@ -20,7 +20,10 @@ names. Must be one of the following options:
 \item a function: apply custom name repair.
 \item \link{tidyr_legacy}: use the name repair from tidyr 0.8.
 \item a formula: a purrr-style anonymous function (see \code{\link[rlang:as_function]{rlang::as_function()}})
-}}
+}
+
+See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on these terms and the
+strategies used to enforce them.}
 }
 \value{
 A tibble with one column for each input in \code{...}. The output

--- a/man/expand_grid.Rd
+++ b/man/expand_grid.Rd
@@ -10,20 +10,20 @@ expand_grid(..., .name_repair = "check_unique")
 \item{...}{Name-value pairs. The name will become the column name in the
 output.}
 
-\item{.name_repair}{Used to check that output data frame has valid
-names. Must be one of the following options:
+\item{.name_repair}{Treatment of problematic column names:
 \itemize{
-\item "minimal": no name repair or checks, beyond basic existence,
-\item "unique": make sure names are unique and not empty,
-\item "check_unique": (the default), no name repair, but check they are unique,
-\item "universal": make the names unique and syntactic
-\item a function: apply custom name repair.
-\item \link{tidyr_legacy}: use the name repair from tidyr 0.8.
-\item a formula: a purrr-style anonymous function (see \code{\link[rlang:as_function]{rlang::as_function()}})
+\item \code{"minimal"}: No name repair or checks, beyond basic existence,
+\item \code{"unique"}: Make sure names are unique and not empty,
+\item \code{"check_unique"}: (default value), no name repair, but check they are
+\code{unique},
+\item \code{"universal"}: Make the names \code{unique} and syntactic
+\item a function: apply custom name repair (e.g., \code{.name_repair = make.names}
+for names in the style of base R).
+\item A purrr-style anonymous function, see \code{\link[rlang:as_function]{rlang::as_function()}}
 }
 
-See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on these terms and the
-strategies used to enforce them.}
+See \link[tibble]{name-repair} for more details on these terms and the strategies used
+to enforce them.}
 }
 \value{
 A tibble with one column for each input in \code{...}. The output

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -136,10 +136,7 @@ test_that("expand_grid can control name_repair", {
     expect_error(expand_grid(x, x), "must not be duplicated")
   }
 
-  expect_message(
-    out <- expand_grid(x, x, .name_repair = "unique"),
-    "New names:"
-  )
+  expect_message(out <- expand_grid(x, x, .name_repair = "unique"), "New names:")
   expect_named(out, c("x...1", "x...2"))
 
   out <- expand_grid(x, x, .name_repair = "minimal")
@@ -149,21 +146,12 @@ test_that("expand_grid can control name_repair", {
 test_that("crossing/nesting/expand respect .name_repair", {
 
   x <- 1:2
-  expect_named(
-    crossing(x, x, .name_repair = "unique"),
-    c("x...1", "x...2")
-  )
+  expect_named(crossing(x, x, .name_repair = "unique"), c("x...1", "x...2"))
 
-  expect_named(
-    nesting(x, x, .name_repair = "unique"),
-    c("x...1", "x...2")
-  )
+  expect_named(nesting(x, x, .name_repair = "unique"), c("x...1", "x...2"))
 
   df <- tibble(x)
-  expect_named(
-    df %>% expand(x, x, .name_repair = "unique"),
-    c("x...1", "x...2")
-  )
+  expect_named(df %>% expand(x, x, .name_repair = "unique"), c("x...1", "x...2"))
 })
 
 

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -126,3 +126,44 @@ test_that("crossing handles list columns", {
   expect_equal(out$x, rep(x, each = 2))
   expect_equal(out$y, rep(y, 2))
 })
+
+test_that("expand_grid can control name_repair", {
+  x <- 1:2
+
+  if (packageVersion("tibble") > "2.99") {
+    expect_error(expand_grid(x, x), class = "vctrs_error_names_must_be_unique")
+  } else {
+    expect_error(expand_grid(x, x), "must not be duplicated")
+  }
+
+  expect_message(
+    out <- expand_grid(x, x, .name_repair = "unique"),
+    "New names:"
+  )
+  expect_named(out, c("x...1", "x...2"))
+
+  out <- expand_grid(x, x, .name_repair = "minimal")
+  expect_named(out, c("x", "x"))
+})
+
+test_that("crossing/nesting/expand respect .name_repair", {
+
+  x <- 1:2
+  expect_named(
+    crossing(x, x, .name_repair = "unique"),
+    c("x...1", "x...2")
+  )
+
+  expect_named(
+    nesting(x, x, .name_repair = "unique"),
+    c("x...1", "x...2")
+  )
+
+  df <- tibble(x)
+  expect_named(
+    df %>% expand(x, x, .name_repair = "unique"),
+    c("x...1", "x...2")
+  )
+})
+
+


### PR DESCRIPTION
Fixes #798 (Marked as help wanted) 

Notes: 
* Added .name_repair to `nesting` as well as the functions you mentioned in your comment on #798. 
* I wasn't sure how best to include the info about .name_repair in the roxygen so I ended up just copy and pasting it in. 

Very happy to receive any feedback!

Best, 
Jeffrey