### PR TITLE
Fix typo in `names_repair` documentation (argument to `pivot_wider()`…

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -46,7 +46,7 @@
 #'   If these arguments do not give you enough control, use
 #'   `pivot_longer_spec()` to create a spec object and process manually as
 #'   needed.
-#' @param names_repair What happen if the output has invalid column names?
+#' @param names_repair What happens if the output has invalid column names?
 #'   The default, `"check_unique"` is to error if the columns are duplicated.
 #'   Use `"minimal"` to allow duplicates in the output, or `"unique"` to
 #'   de-duplicated by adding numeric suffixes. See [vctrs::vec_as_names()]

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -64,7 +64,7 @@ If not specified, the type of the columns generated from \code{names_to} will
 be character, and the type of the variables generated from \code{values_to}
 will be the common type of the input columns used to generate them.}
 
-\item{names_repair}{What happen if the output has invalid column names?
+\item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.
 Use \code{"minimal"} to allow duplicates in the output, or \code{"unique"} to
 de-duplicated by adding numeric suffixes. See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -35,7 +35,7 @@ Must be a data frame containing character \code{.name} and \code{.value} columns
 The special \code{.seq} variable is used to disambiguate rows internally;
 it is automatically removed after pivotting.}
 
-\item{names_repair}{What happen if the output has invalid column names?
+\item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.
 Use \code{"minimal"} to allow duplicates in the output, or \code{"unique"} to
 de-duplicated by adding numeric suffixes. See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -43,7 +43,7 @@ create syntactic variable names.}
 variables, this will be used to join their values together into a single
 string to use as a column name.}
 
-\item{names_repair}{What happen if the output has invalid column names?
+\item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.
 Use \code{"minimal"} to allow duplicates in the output, or \code{"unique"} to
 de-duplicated by adding numeric suffixes. See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -25,7 +25,7 @@ build_wider_spec(
 \arguments{
 \item{data}{A data frame to pivot.}
 
-\item{names_repair}{What happen if the output has invalid column names?
+\item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.
 Use \code{"minimal"} to allow duplicates in the output, or \code{"unique"} to
 de-duplicated by adding numeric suffixes. See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}


### PR DESCRIPTION
Fixes #865 