### PR TITLE
Preserve width of empty chopped data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* `chop()` now preserves the width of the input data frame even when
+  it has no observation.
+
 * `pivot_longer()` no longer creates a `.copy` variable in the presence of
   duplicate column names. This makes it more consistent with the handling
   of non-unique specs.

--- a/R/chop.R
+++ b/R/chop.R
@@ -68,9 +68,12 @@ chop <- function(data, cols) {
   keys <- data[setdiff(names(data), cols)]
   split <- vec_split(vals, keys)
 
-  vals <- map(split$val, ~ new_data_frame(map(.x, list), n = 1L))
+  if (length(split$val)) {
+    chopped_vals <- map(split$val, ~ new_data_frame(map(.x, list), n = 1L))
+    vals <- vec_rbind(!!!chopped_vals)
+  }
 
-  out <- vec_cbind(split$key, vec_rbind(!!!vals))
+  out <- vec_cbind(split$key, vals)
   reconstruct_tibble(data, out)
 }
 

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -23,6 +23,12 @@ test_that("grouping is preserved", {
   expect_equal(dplyr::group_vars(out), "g")
 })
 
+test_that("can chop empty data frame", {
+  df <- tibble(x = integer(), y = integer())
+  expect_identical(chop(df, y), df)
+  expect_identical(chop(df, x), df[2:1])
+})
+
 
 # unchop ------------------------------------------------------------------
 


### PR DESCRIPTION
  ```r
  df <- tibble(x = integer(), y = integer())

  # Before
  chop(df, y)
  #> # A tibble: 0 x 1
  #> # … with 1 variable: x <int>

  # After
  chop(df, y)
  #> # A tibble: 0 x 2
  #> # … with 2 variables: x <int>, y <int>
  ```