### PR TITLE
Create list-columns with `list_of()` in `chop()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tidyr (development version)
 
+* `chop()` now creates list-columns of class `vctrs::list_of()`. This
+  helps keep track of the type in case the chopped data frame is
+  emptied. This allows `unchop()` to reconstitute a data frame with
+  the correct column types even when there is no observation.
+
 * `chop()` now preserves the width of the input data frame even when
   it has no observation.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,8 @@
 
 * `chop()` now creates list-columns of class `vctrs::list_of()`. This
   helps keep track of the type in case the chopped data frame is
-  emptied. This allows `unchop()` to reconstitute a data frame with
-  the correct column types even when there is no observation.
+  empty. This allows `unchop()` to reconstitute a data frame with
+  the correct column types even when there are no observations.
 
 * `chop()` now preserves the width of the input data frame even when
   it has no observation.

--- a/R/chop.R
+++ b/R/chop.R
@@ -14,6 +14,13 @@
 #' that `chop()`ing` since it better preserves the connections between
 #' observations.
 #'
+#' `chop()` creates list-columns of class [vctrs::list_of()] to ensure
+#' consistent behaviour when the chopped data frame is emptied. For
+#' instance this helps getting back the original column types after
+#' the roundtrip chop and unchop. Because `<list_of>` keeps tracks of
+#' the type of its elements, `unchop()` is able to reconstitute the
+#' correct vector type even for empty list-columns.
+#'
 #' @param data A data frame.
 #' @param cols Column to chop or unchop (automatically quoted).
 #'
@@ -69,8 +76,9 @@ chop <- function(data, cols) {
   split <- vec_split(vals, keys)
 
   if (length(split$val)) {
-    chopped_vals <- map(split$val, ~ new_data_frame(map(.x, list), n = 1L))
-    vals <- vec_rbind(!!!chopped_vals)
+    split_vals <- transpose(split$val)
+    vals <- map2(split_vals, vec_ptype(vals), new_list_of)
+    vals <- new_data_frame(vals)
   }
 
   out <- vec_cbind(split$key, vals)

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -41,6 +41,13 @@ Generally, unchopping is more useful than chopping because it simplifies
 a complex data structure, and \code{\link[=nest]{nest()}}ing is usually more appropriate
 that \code{chop()}ing` since it better preserves the connections between
 observations.
+
+\code{chop()} creates list-columns of class \code{\link[vctrs:list_of]{vctrs::list_of()}} to ensure
+consistent behaviour when the chopped data frame is emptied. For
+instance this helps getting back the original column types after
+the roundtrip chop and unchop. Because \verb{<list_of>} keeps tracks of
+the type of its elements, \code{unchop()} is able to reconstitute the
+correct vector type even for empty list-columns.
 }
 \examples{
 # Chop ==============================================================

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -8,8 +8,8 @@ test_that("can chop multiple columns", {
   out <- df %>% chop(c(a, b))
 
   expect_named(out, c("x", "a", "b"))
-  expect_equal(out$a, list(1:2, 3L))
-  expect_equal(out$b, list(1:2, 3L))
+  expect_equal(out$a, list_of(1:2, 3L))
+  expect_equal(out$b, list_of(1:2, 3L))
 })
 
 test_that("chopping no columns returns input", {
@@ -86,4 +86,15 @@ test_that("grouping is preserved", {
   df <- tibble(g = 1, x = list(1, 2))
   out <- df %>% dplyr::group_by(g) %>% unchop(x)
   expect_equal(dplyr::group_vars(out), "g")
+})
+
+test_that("can unchop empty data frame", {
+  chopped <- tibble(x = integer(), y = list())
+  expect_identical(unchop(chopped, y), tibble(x = integer(), y = unspecified()))
+})
+
+test_that("unchop retrieves correct types with emptied chopped df", {
+  chopped <- chop(tibble(x = 1:3, y = 4:6), y)
+  empty <- vec_slice(chopped, 0L)
+  expect_identical(unchop(empty, y), tibble(x = integer(), y = integer()))
 })


### PR DESCRIPTION
Branched from #883 

Helps with roundtrips when the chopped df is emptied. Implementation avoids rbind and is a little faster:

```r
  library(vctrs)
  library(tidyr)

  big <- vec_rbind(!!!rep(list(mtcars), 1000))

  # Before
  bench::mark(chop(big, cyl))[1:8]
  #> # A tibble: 1 x 8
  #>   expression          min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
  #>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
  #> 1 chop(big, cyl)     16ms     17ms      58.3     893KB     6.72    26     3

  # After
  bench::mark(chop(big, cyl))[1:8]
  #> # A tibble: 1 x 8
  #>   expression          min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
  #>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
  #> 1 chop(big, cyl)   10.8ms   11.3ms      87.2     893KB     2.03    43     1
```