### PR TITLE
element in hoist example not named, throws error

### DIFF
--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -170,7 +170,7 @@ df \%>\% unnest_wider(metadata)
 
 # Extract only specified components
 df \%>\% hoist(metadata,
-  "species",
+  species = "species",
   first_film = list("films", 1L),
   third_film = list("films", 3L)
 )


### PR DESCRIPTION
The current example using hoist throws error `All elements of ... must be named`. Using `species = "species"` instead of just `"species"` fixes issue.