### PR TITLE
support unnest_wider on Date class columns

### DIFF
--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -401,7 +401,11 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
   }
 
   # Ensure empty elements filled in with a single unspecified value
-  x[n == 0] <- list(NA)
+  x[n == 0] <- if (is.list(x)) {
+    list(NA)
+  } else {
+    NA
+  }
 
   if (is.null(ptype)) {
     tryCatch(


### PR DESCRIPTION
`unnest_wider` on Date class columns fail unless `simplify = FALSE` is set.

``` r
df = tibble::tibble(x = list(c(a = as.Date("2020-01-01"), b = as.Date("2020-01-02"))))
tidyr::unnest_wider(df, x)
#> Error in as.Date.default(value): do not know how to convert 'value' to class "Date"
tidyr::unnest_wider(df, x, simplify = FALSE)
#> # A tibble: 1 x 2
#>   a          b         
#>   <date>     <date>    
#> 1 2020-01-01 2020-01-02
```

<sup>Created on 2020-08-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

As far as I investigated, the issue comes from this line:

https://github.com/tidyverse/tidyr/blob/61e92096bcfe1ef29d994c3ffa9853257b759f99/R/rectangle.R#L404

Following reprex shows that `list(NA)` cannot be converted to class "Date" whereas `NA` can be.

``` r
x = c(a = as.Date("2020-01-01"), b = as.Date("2020-01-02"))
x[1] <- list(NA)
#> Error in as.Date.default(value): do not know how to convert 'value' to class "Date"
x[1] <- NA
```

<sup>Created on 2020-08-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

In this PR, I suggest substitute elements by `list(NA)` if `x` is a list, and by `NA` otherwise.