### PR TITLE
use str_split_n() to fix #1014

### DIFF
--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -31,7 +31,7 @@ separate_rows.data.frame <- function(data,
                                      convert = FALSE) {
   vars <- tidyselect::eval_select(expr(c(...)), data)
 
-  out <- purrr::modify_at(data, vars, strsplit, split = sep, perl = TRUE)
+  out <- purrr::modify_at(data, vars, str_split_n, pattern = sep)
   out <- unchop(as_tibble(out), any_of(vars))
   if (convert) {
     out[vars] <- map(out[vars], type.convert, as.is = TRUE)

--- a/tests/testthat/test-separate-rows.R
+++ b/tests/testthat/test-separate-rows.R
@@ -59,3 +59,11 @@ test_that("leaves list columns intact (#300)", {
   expect_equal(out$x, as.character(1:3))
   expect_equal(out$y, rep(list(1), 3))
 })
+
+test_that("does not silently drop blank values (#1014)", {
+  df <- tibble(x = 1:3, y = c("a", "d,e,f", ""))
+
+  out <- separate_rows(df, y)
+  expect_equal(out, tibble(x = c(1, 2, 2, 2, 3),
+                           y = c("a", "d", "e", "f", "")))
+})


### PR DESCRIPTION
Fixes #1014. Using strsplit caused it to silently drop rows when used against a blank value.

Current version;
``` r
library(tidyr)

df <- tibble(x = 1:3, y = c("a", "d,e,f", ""))
separate_rows(df, y, sep = ",")
#> # A tibble: 4 x 2
#>       x y    
#>   <int> <chr>
#> 1     1 a    
#> 2     2 d    
#> 3     2 e    
#> 4     2 f
```
Which silently drops the last y value.

Updated in this PR and how it was in tidyr 1.1.0
```r
df <- tibble(x = 1:3, y = c("a", "d,e,f", ""))
separate_rows(df, y, sep = ",")
#> # A tibble: 4 x 2
#>       x y    
#>   <int> <chr>
#> 1     1 "a"    
#> 2     2 "d"    
#> 3     2 "e"    
#> 4     2 "f"
#> 5     3 ""
```
