### PR TITLE
Update README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -93,9 +93,9 @@ If you'd like to read more about data reshaping from a CS perspective, I'd recom
 
 To guide your reading, here's a translation between the terminology used in different places:
 
-| tidyr             | pivot_longer | pivot_wider |
+| tidyr 1.0.0       | pivot longer | pivot wider |
 |-------------------|--------------|-------------|
-| retired tidyr     | gather       | spread      |
+| tidyr < 1.0.0     | gather       | spread      |
 | reshape(2)        | melt         | cast        |
 | spreadsheets      | unpivot      | pivot       | 
 | databases         | fold         | unfold      |

--- a/README.Rmd
+++ b/README.Rmd
@@ -93,11 +93,12 @@ If you'd like to read more about data reshaping from a CS perspective, I'd recom
 
 To guide your reading, here's a translation between the terminology used in different places:
 
-| tidyr        | gather  | spread |
-|--------------|---------|--------|
-| reshape(2)   | melt    | cast   |
-| spreadsheets | unpivot | pivot  | 
-| databases    | fold    | unfold |
+| tidyr             | pivot_longer | pivot_wider |
+|-------------------|--------------|-------------|
+| retired tidyr     | gather       | spread      |
+| reshape(2)        | melt         | cast        |
+| spreadsheets      | unpivot      | pivot       | 
+| databases         | fold         | unfold      |
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# tidyr <a href='https:/tidyr.tidyverse.org'><img src='man/figures/logo.png' align="right" height="139" /></a>
+# tidyr <a href='https://tidyr.tidyverse.org'><img src='man/figures/logo.png' align="right" height="139" /></a>
 
 <!-- badges: start -->
 
@@ -104,11 +104,12 @@ I’d recommend the following three papers:
 To guide your reading, here’s a translation between the terminology used
 in different places:
 
-| tidyr        | gather  | spread |
-| ------------ | ------- | ------ |
-| reshape(2)   | melt    | cast   |
-| spreadsheets | unpivot | pivot  |
-| databases    | fold    | unfold |
+| tidyr 1.0.0    | pivot longer | pivot wider |
+| -------------- | ------------ | ----------- |
+| tidyr \< 1.0.0 | gather       | spread      |
+| reshape(2)     | melt         | cast        |
+| spreadsheets   | unpivot      | pivot       |
+| databases      | fold         | unfold      |
 
 ## Getting help
 


### PR DESCRIPTION
While the readme is mostly up-to-date, the translation of pivoting terminology in different places has the retired gather/spread at the forefront instead of the recommended pivot_longer and pivot_wider. This is also out of date on https://tidyr.tidyverse.org/index.html, though I believe that site builds off of this readme.