### PR TITLE
expand_grid typo

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -130,8 +130,8 @@ nesting <- function(..., .name_repair = "check_unique") {
 
 #' Create a tibble from all combinations of inputs
 #'
-#' @section Compared to [expand.grid]:
-#' * Varies the first element fastest.
+#' @section Compared to [expand.grid] ,expand_grid :
+#' * Varies the first element slowest.
 #' * Never converts strings to factors.
 #' * Does not add any additional attributes.
 #' * Returns a tibble, not a data frame.


### PR DESCRIPTION
closes #1025 

Updated Value section in expand_grid docs-

- "Varies the first element slowest" (from "fastest")

- "Compared to expand.grid" to "Compared to expand.grid , expand_grid :"