### PR TITLE
fill also fills NaN

### DIFF
--- a/src/fill.cpp
+++ b/src/fill.cpp
@@ -40,7 +40,7 @@ SEXP fillDown(SEXP x) {
     double lastVal = xin[0];
 
     for (int i = 0; i < n; ++i) {
-      if (!ISNA(xin[i]))
+      if (!ISNAN(xin[i]))
         lastVal = xin[i];
       xout[i] = lastVal;
     }
@@ -118,7 +118,7 @@ SEXP fillUp(SEXP x) {
     double lastVal = xin[n - 1];
 
     for (int i = n - 1; i >= 0; --i) {
-      if (!ISNA(xin[i]))
+      if (!ISNAN(xin[i]))
         lastVal = xin[i];
       xout[i] = lastVal;
     }

--- a/tests/testthat/test-fill.R
+++ b/tests/testthat/test-fill.R
@@ -81,3 +81,9 @@ test_that("fill respects grouping", {
   out <- df %>% dplyr::group_by(x) %>% fill(y)
   expect_equal(out$y, c(1, 1, NA))
 })
+
+test_that("missings filled up for NaN", {
+  df <- tibble(x = c(1, 2), y = c(1, NaN))
+  out <- fill(df, y)
+  expect_equal(out$y, c(1, 1))
+})

--- a/tests/testthat/test-fill.R
+++ b/tests/testthat/test-fill.R
@@ -82,7 +82,7 @@ test_that("fill respects grouping", {
   expect_equal(out$y, c(1, 1, NA))
 })
 
-test_that("missings filled up for NaN", {
+test_that("missings filled up for NaN (#982)", {
   df <- tibble(x = c(1, 2), y = c(1, NaN))
   out <- fill(df, y)
   expect_equal(out$y, c(1, 1))


### PR DESCRIPTION
Fixes issue #982 

`fill` should also handle `NaN` values like `replace_na` already does.

Current version:
```
df <- tibble(x = c(1, 2), y = c(1, NaN))
fill(df, y)
# A tibble: 2 x 2
      x     y
  <dbl> <dbl>
1     1     1
2     2   NaN
```

Updated in this PR:
```
df <- tibble(x = c(1, 2), y = c(1, NaN))
fill(df, y)
# A tibble: 2 x 2
      x     y
  <dbl> <dbl>
1     1     1
2     2     1
```