### PR TITLE
Fix broken `\link{}` in doc

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -35,8 +35,7 @@
 #'
 #'   When used with continuous variables, you may need to fill in values
 #'   that do not appear in the data: to do so use expressions like
-
-#'   `year = 2010:2020` or `year = \link{full_seq}(year,1)`.
+#'   `year = 2010:2020` or [`year = full_seq(year, 1)`][full_seq].
 #' @seealso [complete()] to expand list objects. [expand_grid()]
 #'   to input vectors rather than a data frame.
 #' @export

--- a/man/complete.Rd
+++ b/man/complete.Rd
@@ -29,7 +29,7 @@ the data, use \code{forcats::fct_drop()}.
 
 When used with continuous variables, you may need to fill in values
 that do not appear in the data: to do so use expressions like
-\code{year = 2010:2020} or \verb{year = \link{full_seq}(year,1)}.}
+\code{year = 2010:2020} or \code{\link[=full_seq]{year = full_seq(year, 1)}}.}
 
 \item{fill}{A named list that for each variable supplies a single value to
 use instead of \code{NA} for missing combinations.}

--- a/man/deprecated-se.Rd
+++ b/man/deprecated-se.Rd
@@ -106,7 +106,7 @@ the data, use \code{forcats::fct_drop()}.
 
 When used with continuous variables, you may need to fill in values
 that do not appear in the data: to do so use expressions like
-\code{year = 2010:2020} or \verb{year = \link{full_seq}(year,1)}.}
+\code{year = 2010:2020} or \code{\link[=full_seq]{year = full_seq(year, 1)}}.}
 
 \item{vars, cols, col}{Name of columns.}
 

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -35,7 +35,7 @@ the data, use \code{forcats::fct_drop()}.
 
 When used with continuous variables, you may need to fill in values
 that do not appear in the data: to do so use expressions like
-\code{year = 2010:2020} or \verb{year = \link{full_seq}(year,1)}.}
+\code{year = 2010:2020} or \code{\link[=full_seq]{year = full_seq(year, 1)}}.}
 
 \item{.name_repair}{Treatment of problematic column names:
 \itemize{


### PR DESCRIPTION
Before, the affected line in the documentation read

> like `year = 2010:2020` or `year = \link{full_seq}(year,1)`.

(`\link{}` inside a Markdown code span doesn't work for obvious reasons)