### PR TITLE
Add argument to `pivot_wider()` to aggregate unused columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # tidyr (development version)
 
 * `separate_rows()` works for factor columns (@mgirlich, #1058).
+* `pivot_wider()` gets a `others_fn` argument to aggregate columns not used
+  in `id_cols`, `names_from`, and `values_from`.
 
 # tidyr 1.1.2
 

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -50,13 +50,12 @@
 #'
 #'   This can be a named list if you want to apply different aggregations
 #'   to different value columns.
-#' @param others_fn Optionally, a function applied to the columns not used in
-#'   `id_cols`, `names_from`, and `values_from`. You will typically use this
-#'   when the combination of `id_cols` and `value` column does not uniquely
-#'   identify an observation.
+#' @param others_fn By default columns not used in `id_cols`, `names_from`, and
+#'   `values_from` are dropped. Optionally, you can specify a function to
+#'   aggregate these columns.
 #'
 #'   This can be a named list if you want to apply different aggregations
-#'   to different value columns.
+#'   to different columns.
 #' @param ... Additional arguments passed on to methods.
 #' @export
 #' @examples

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -71,13 +71,12 @@ in the output. You will typically use this when the combination of
 This can be a named list if you want to apply different aggregations
 to different value columns.}
 
-\item{others_fn}{Optionally, a function applied to the columns not used in
-\code{id_cols}, \code{names_from}, and \code{values_from}. You will typically use this
-when the combination of \code{id_cols} and \code{value} column does not uniquely
-identify an observation.
+\item{others_fn}{By default columns not used in \code{id_cols}, \code{names_from}, and
+\code{values_from} are dropped. Optionally, you can specify a function to
+aggregate these columns.
 
 This can be a named list if you want to apply different aggregations
-to different value columns.}
+to different columns.}
 
 \item{...}{Additional arguments passed on to methods.}
 }

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -16,6 +16,7 @@ pivot_wider(
   values_from = value,
   values_fill = NULL,
   values_fn = NULL,
+  others_fn = NULL,
   ...
 )
 }
@@ -66,6 +67,14 @@ to different value columns.}
 \item{values_fn}{Optionally, a function applied to the \code{value} in each cell
 in the output. You will typically use this when the combination of
 \code{id_cols} and \code{value} column does not uniquely identify an observation.
+
+This can be a named list if you want to apply different aggregations
+to different value columns.}
+
+\item{others_fn}{Optionally, a function applied to the columns not used in
+\code{id_cols}, \code{names_from}, and \code{values_from}. You will typically use this
+when the combination of \code{id_cols} and \code{value} column does not uniquely
+identify an observation.
 
 This can be a named list if you want to apply different aggregations
 to different value columns.}
@@ -123,6 +132,17 @@ warpbreaks \%>\%
     names_from = wool,
     values_from = breaks,
     values_fn = mean
+  )
+
+# Can aggregate other columns with `others_fn`
+warpbreaks$n <- 1:54
+warpbreaks \%>\%
+  pivot_wider(
+    id_cols = tension,
+    names_from = wool,
+    values_from = breaks,
+    values_fn = mean,
+    others_fn = list(n = sum)
   )
 }
 \seealso{

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -64,13 +64,12 @@ in the output. You will typically use this when the combination of
 This can be a named list if you want to apply different aggregations
 to different value columns.}
 
-\item{others_fn}{Optionally, a function applied to the columns not used in
-\code{id_cols}, \code{names_from}, and \code{values_from}. You will typically use this
-when the combination of \code{id_cols} and \code{value} column does not uniquely
-identify an observation.
+\item{others_fn}{By default columns not used in \code{id_cols}, \code{names_from}, and
+\code{values_from} are dropped. Optionally, you can specify a function to
+aggregate these columns.
 
 This can be a named list if you want to apply different aggregations
-to different value columns.}
+to different columns.}
 
 \item{names_from}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A pair of
 arguments describing which column (or columns) to get the name of the

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -11,7 +11,8 @@ pivot_wider_spec(
   names_repair = "check_unique",
   id_cols = NULL,
   values_fill = NULL,
-  values_fn = NULL
+  values_fn = NULL,
+  others_fn = NULL
 )
 
 build_wider_spec(
@@ -59,6 +60,14 @@ to different value columns.}
 \item{values_fn}{Optionally, a function applied to the \code{value} in each cell
 in the output. You will typically use this when the combination of
 \code{id_cols} and \code{value} column does not uniquely identify an observation.
+
+This can be a named list if you want to apply different aggregations
+to different value columns.}
+
+\item{others_fn}{Optionally, a function applied to the columns not used in
+\code{id_cols}, \code{names_from}, and \code{values_from}. You will typically use this
+when the combination of \code{id_cols} and \code{value} column does not uniquely
+identify an observation.
 
 This can be a named list if you want to apply different aggregations
 to different value columns.}

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -215,3 +215,34 @@ test_that("column order in output matches spec", {
   pv <- pivot_wider_spec(df, sp)
   expect_named(pv, c("name", sp$.name))
 })
+
+# aggregate other columns -------------------------------------------------
+
+test_that("can aggregate other columns with `others_fn`", {
+  df <- tibble(
+    a = c(1, 1, 2),
+    key = c("x", "x", "x"),
+    val = 1:3,
+    b = 2
+  )
+
+  pv <- pivot_wider(df,
+    id_cols = a,
+    names_from = key,
+    values_from = val,
+    values_fn = list(val = max),
+    others_fn = list(b = length)
+  )
+
+  expect_equal(pv$b, c(2, 1))
+
+  pv <- pivot_wider(df,
+    id_cols = a,
+    names_from = key,
+    values_from = val,
+    values_fn = list(val = max),
+    others_fn = length
+  )
+
+  expect_equal(pv$b, c(2, 1))
+})


### PR DESCRIPTION
Closes #990.

This PR adds an argument `others_fn` that works similarly to `values_fn` and allows to aggregate "unused" columns, i.e. columns not used in `id_cols`, `names_from`, and `values_from`.

I am not sure about the naming but I think the functionality is nice.

``` r
library(dplyr, warn.conflicts = FALSE)
library(tidyr)

d <- data.frame(
  id = rep(1:5, each = 3),
  update = c(as.Date("2020-07-01") + 1:15),
  key = rep(c("a", "b", "c"), 5),
  val = 1:15
)

d %>% 
  pivot_wider(id,
    names_from = key,
    values_from = val,
    others_fn = max
  ) 
#> # A tibble: 5 x 5
#>      id     a     b     c update    
#>   <int> <int> <int> <int> <date>    
#> 1     1     1     2     3 2020-07-04
#> 2     2     4     5     6 2020-07-07
#> 3     3     7     8     9 2020-07-10
#> 4     4    10    11    12 2020-07-13
#> 5     5    13    14    15 2020-07-16
```

<sup>Created on 2020-12-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>