### PR TITLE
Clarify names_ptypes vs. names_transform, 

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -56,18 +56,20 @@
 #'   to implicit missing values, and should generally be used only when missing
 #'   values in `data` were created by its structure.
 #' @param names_transform,values_transform A list of column name-function pairs.
-#'   Use these arguments if you need to change the type of specific columns.
+#'   Use these arguments if you need to change the types of specific columns.
 #'   For example, `names_transform = list(week = as.integer)` would convert
-#'   a character week variable to an integer.
-#' @param names_ptypes,values_ptypes A list of column name-prototype pairs.
-#'   A prototype (or ptype for short) is a zero-length vector (like `integer()`
-#'   or `numeric()`) that defines the type, class, and attributes of a vector.
-#'   Use these arguments to confirm that the created columns are the types that
-#'   you expect.
+#'   a character variable called `week` to an integer.
 #'
 #'   If not specified, the type of the columns generated from `names_to` will
 #'   be character, and the type of the variables generated from `values_to`
 #'   will be the common type of the input columns used to generate them.
+#' @param names_ptypes,values_ptypes A list of column name-prototype pairs.
+#'   A prototype (or ptype for short) is a zero-length vector (like `integer()`
+#'   or `numeric()`) that defines the type, class, and attributes of a vector.
+#'   Use these arguments if you want to confirm that the created columns are
+#'   the types that you expect. Note that if you want to change (instead of confirm)
+#'   the types of specific columns, you should use `names_transform` or
+#'   `values_transform` instead.
 #' @param ... Additional arguments passed on to methods.
 #' @export
 #' @examples

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -59,17 +59,19 @@ needed.}
 \item{names_ptypes, values_ptypes}{A list of column name-prototype pairs.
 A prototype (or ptype for short) is a zero-length vector (like \code{integer()}
 or \code{numeric()}) that defines the type, class, and attributes of a vector.
-Use these arguments to confirm that the created columns are the types that
-you expect.
+Use these arguments if you want to confirm that the created columns are
+the types that you expect. Note that if you want to change (instead of confirm)
+the types of specific columns, you should use \code{names_transform} or
+\code{values_transform} instead.}
+
+\item{names_transform, values_transform}{A list of column name-function pairs.
+Use these arguments if you need to change the types of specific columns.
+For example, \code{names_transform = list(week = as.integer)} would convert
+a character variable called \code{week} to an integer.
 
 If not specified, the type of the columns generated from \code{names_to} will
 be character, and the type of the variables generated from \code{values_to}
 will be the common type of the input columns used to generate them.}
-
-\item{names_transform, values_transform}{A list of column name-function pairs.
-Use these arguments if you need to change the type of specific columns.
-For example, \code{names_transform = list(week = as.integer)} would convert
-a character week variable to an integer.}
 
 \item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -54,17 +54,19 @@ values in \code{data} were created by its structure.}
 \item{values_ptypes}{A list of column name-prototype pairs.
 A prototype (or ptype for short) is a zero-length vector (like \code{integer()}
 or \code{numeric()}) that defines the type, class, and attributes of a vector.
-Use these arguments to confirm that the created columns are the types that
-you expect.
+Use these arguments if you want to confirm that the created columns are
+the types that you expect. Note that if you want to change (instead of confirm)
+the types of specific columns, you should use \code{names_transform} or
+\code{values_transform} instead.}
+
+\item{values_transform}{A list of column name-function pairs.
+Use these arguments if you need to change the types of specific columns.
+For example, \code{names_transform = list(week = as.integer)} would convert
+a character variable called \code{week} to an integer.
 
 If not specified, the type of the columns generated from \code{names_to} will
 be character, and the type of the variables generated from \code{values_to}
 will be the common type of the input columns used to generate them.}
-
-\item{values_transform}{A list of column name-function pairs.
-Use these arguments if you need to change the type of specific columns.
-For example, \code{names_transform = list(week = as.integer)} would convert
-a character week variable to an integer.}
 
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pivot into
 longer format.}
@@ -121,17 +123,19 @@ needed.}
 \item{names_ptypes}{A list of column name-prototype pairs.
 A prototype (or ptype for short) is a zero-length vector (like \code{integer()}
 or \code{numeric()}) that defines the type, class, and attributes of a vector.
-Use these arguments to confirm that the created columns are the types that
-you expect.
+Use these arguments if you want to confirm that the created columns are
+the types that you expect. Note that if you want to change (instead of confirm)
+the types of specific columns, you should use \code{names_transform} or
+\code{values_transform} instead.}
+
+\item{names_transform}{A list of column name-function pairs.
+Use these arguments if you need to change the types of specific columns.
+For example, \code{names_transform = list(week = as.integer)} would convert
+a character variable called \code{week} to an integer.
 
 If not specified, the type of the columns generated from \code{names_to} will
 be character, and the type of the variables generated from \code{values_to}
 will be the common type of the input columns used to generate them.}
-
-\item{names_transform}{A list of column name-function pairs.
-Use these arguments if you need to change the type of specific columns.
-For example, \code{names_transform = list(week = as.integer)} would convert
-a character week variable to an integer.}
 }
 \description{
 This is a low level interface to pivotting, inspired by the cdata package,


### PR DESCRIPTION
This PR addresses #980, though I'm not sure if it closes it.

It clarifies that `names_ptypes` is used to _confirm_ the type of a variable vs. `names_transform` is used to _change_ it. I think for most situations `names_transform` is what the user wants, not `names_ptypes`, so the paragraph about "if you don't do anything, these are the default types you'll get" is moved under `names_transform`.