### PR TITLE
Update `replace_na()` to use vctrs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     tibble (>= 2.1.1),
     tidyselect (>= 1.1.0),
     utils,
-    vctrs (>= 0.3.6.9000)
+    vctrs (>= 0.3.6)
 Suggests: 
     covr,
     data.table,
@@ -53,5 +53,3 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
 Config/testthat/edition: 3
-Remotes:
-    r-lib/vctrs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     tibble (>= 2.1.1),
     tidyselect (>= 1.1.0),
     utils,
-    vctrs (>= 0.3.6)
+    vctrs (>= 0.3.6.9000)
 Suggests: 
     covr,
     data.table,
@@ -53,3 +53,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
 Config/testthat/edition: 3
+Remotes:
+    r-lib/vctrs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # tidyr (development version)
 
-* `replace_na()` has been updated to use vctrs. Note that `replace_na()` is
+* `replace_na()` has been updated to use vctrs. This is a breaking change, as
+  `data` can no longer be promoted to the type of `replace`. The returned value
+  now always has the same type as `data`. Note that `replace_na()` is generally
   considered to be superseded in favor of `dplyr::across()` +
   `dplyr::coalesce()`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidyr (development version)
 
+* `replace_na()` has been updated to use vctrs. Note that `replace_na()` is
+  considered to be superseded in favor of `dplyr::across()` +
+  `dplyr::coalesce()`.
+
 # tidyr 1.1.3
 
 * tidyr verbs no longer have "default" methods for lazyeval fallbacks. This

--- a/R/replace_na.R
+++ b/R/replace_na.R
@@ -36,7 +36,8 @@ replace_na <- function(data, replace, ...) {
 #' @export
 replace_na.default <- function(data, replace = NA, ...) {
   check_replacement(replace, "data")
-  data[!is_complete(data)] <- replace
+  missing <- vec_equal_na(data)
+  data <- vec_assign(data, missing, replace, x_arg = "data", value_arg = "replace")
   data
 }
 
@@ -46,16 +47,32 @@ replace_na.data.frame <- function(data, replace = list(), ...) {
 
   replace_vars <- intersect(names(replace), names(data))
 
-  for (var in replace_vars) {
-    check_replacement(replace[[var]], var)
-    data[[var]][!is_complete(data[[var]])] <- replace[[var]]
+  data_args <- paste0("data$", replace_vars)
+  replace_args <- paste0("value$", replace_vars)
+
+  for (i in seq_along(replace_vars)) {
+    var <- replace_vars[[i]]
+    data_arg <- data_args[[i]]
+    replace_arg <- replace_args[[i]]
+
+    check_replacement(replace[[var]], data_arg)
+
+    missing <- vec_equal_na(data[[var]])
+
+    data[[var]] <- vec_assign(
+      data[[var]],
+      missing,
+      replace[[var]],
+      x_arg = data_arg,
+      value_arg = replace_arg
+    )
   }
 
   data
 }
 
 check_replacement <- function(x, var) {
-  n <- length(x)
+  n <- vec_size(x)
   if (n == 1) {
     return()
   }

--- a/R/replace_na.R
+++ b/R/replace_na.R
@@ -9,8 +9,7 @@
 #' @param ... Additional arguments for methods. Currently unused.
 #' @return
 #' * If `data` is a data frame, `replace_na()` returns a data frame.
-#' * If `data` is a vector, `replace_na()` returns a vector, with class
-#'   given by the union of `data` and `replace`.
+#' * If `data` is a vector, `replace_na()` returns a vector of the same type.
 #' @seealso [dplyr::na_if()] to replace specified values with `NA`s;
 #'   [dplyr::coalesce()] to replaces `NA`s with values from other vectors.
 #' @export

--- a/man/replace_na.Rd
+++ b/man/replace_na.Rd
@@ -20,8 +20,7 @@ replaces all of the \code{NA} values in the vector.}
 \value{
 \itemize{
 \item If \code{data} is a data frame, \code{replace_na()} returns a data frame.
-\item If \code{data} is a vector, \code{replace_na()} returns a vector, with class
-given by the union of \code{data} and \code{replace}.
+\item If \code{data} is a vector, \code{replace_na()} returns a vector of the same type.
 }
 }
 \description{

--- a/tests/testthat/_snaps/replace_na.md
+++ b/tests/testthat/_snaps/replace_na.md
@@ -1,0 +1,10 @@
+# replacement must be castable to `data`
+
+    Can't convert from `replace` <double> to `data` <integer> due to loss of precision.
+    * Locations: 1
+
+# replacement must be castable to corresponding column
+
+    Can't convert from `value$a` <double> to `data$a` <integer> due to loss of precision.
+    * Locations: 1
+

--- a/tests/testthat/test-replace_na.R
+++ b/tests/testthat/test-replace_na.R
@@ -14,6 +14,19 @@ test_that("can only be length 0", {
   expect_error(replace_na(1, 1:10), "length 10, not length 1")
 })
 
+test_that("can replace missing rows in arrays", {
+  x <- matrix(c(NA, NA, NA, 6), nrow = 2)
+  replace <- matrix(c(-1, -2), nrow = 1)
+  expect <- matrix(c(-1, NA, -2, 6), nrow = 2)
+
+  expect_identical(replace_na(x, replace), expect)
+})
+
+test_that("replacement must be castable to `data`", {
+  x <- c(1L, NA)
+  expect_snapshot_error(replace_na(x, 1.5))
+})
+
 # data frame -------------------------------------------------------------
 
 test_that("empty call does nothing", {
@@ -39,4 +52,24 @@ test_that("can replace NULLs in list-column", {
   rs <- replace_na(df, list(x = list(1:5)))
 
   expect_identical(rs, tibble(x = list(1, 1:5)))
+})
+
+test_that("df-col rows must be completely missing to be replaceable", {
+  col <- tibble(x = c(1, NA, NA), y = c(1, 2, NA))
+  df <- tibble(a = col)
+
+  col <- tibble(x = c(1, NA, -1), y = c(1, 2, -2))
+  expect <- tibble(a = col)
+
+  replace <- tibble(x = -1, y = -2)
+
+  expect_identical(
+    replace_na(df, list(a = replace)),
+    expect
+  )
+})
+
+test_that("replacement must be castable to corresponding column", {
+  df <- tibble(a = c(1L, NA))
+  expect_snapshot_error(replace_na(df, list(a = 1.5)))
 })


### PR DESCRIPTION
This PR is an attempt to update `replace_na()` to use vctrs.

Pros:
- Better error messages
- Support for df-cols and matrices

Cons:
- Breaking change from previously using `[<-`, which allows the type of `data` to be altered (see below). This was documented behavior.

```r
library(tidyr)

x <- c(1L, 2L, NA)

# before
replace_na(x, 1.5)
#> [1] 1.0 2.0 1.5

# after
replace_na(x, 1.5)
#> Error: Can't convert from `replace` <double> to `data` <integer> due to loss of precision.
#> * Locations: 1
```

Since `replace_na()` is generally considered superseded by `across()` + `coalesce()`, it is perfectly fine to close this if the con outweighs the pros here.