### PR TITLE
Speed up `unchop()`

### DIFF
--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -100,6 +100,17 @@ test_that("correctly performs tidy recycling with size 1 inputs", {
   expect_identical(unchop(df, c(x, y)), expect)
 })
 
+test_that("correctly performs tidy recycling with NULL inputs", {
+  df <- tibble(x = list(NULL, 2:3), y = list(2:3, 1))
+  expect <- tibble(x = c(NA_integer_, NA_integer_, 2L, 3L), y = c(2, 3, 1, 1))
+  expect_identical(unchop(df, c(x, y)), expect)
+})
+
+test_that("correctly performs tidy recycling with size 0 inputs", {
+  df <- tibble(x = list(integer(), 2:3), y = list(2:3, 1))
+  expect_error(unchop(df, c(x, y)), "Can't recycle input of size 0 to size 2.")
+})
+
 test_that("can specify a ptype with extra columns", {
   df <- tibble(x = 1, y = list(1, 2))
   ptype <- tibble(y = numeric(), z = numeric())

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -193,10 +193,10 @@ test_that("vectors become columns", {
 
 test_that("multiple columns must be same length", {
   df <- tibble(x = list(1:2), y = list(1:3))
-  expect_error(unnest(df, c(x, y)), "Incompatible lengths: 2, 3")
+  expect_error(unnest(df, c(x, y)), "Can't recycle input of size 2 to size 3.")
 
   df <- tibble(x = list(1:2), y = list(tibble(y = 1:3)))
-  expect_error(unnest(df, c(x, y)), "Incompatible lengths: 2, 3")
+  expect_error(unnest(df, c(x, y)), "Can't recycle input of size 2 to size 3.")
 })
 
 test_that("can use non-syntactic names", {


### PR DESCRIPTION
``` r
library(tidyr)
set.seed(1)

n <- 100e3
df <- tibble(
  a = purrr::map(1:n, ~ rlang::seq2(1, sample(0:10, 1))),
  y = 1:n
)

bench::mark(
  drop_empty = unchop(df, a),
  keep_empty = unchop(df, a, keep_empty = TRUE),
  check = FALSE
)

# this PR
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 drop_empty   72.2ms   72.9ms      13.7    25.4MB     34.3
#> 2 keep_empty   81.4ms   81.4ms      12.3      29MB     86.0

# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 drop_empty 642.71ms 642.71ms     1.56     13.1MB     21.8
#> 2 keep_empty    1.02s    1.02s     0.979    13.9MB     22.5
```

<sup>Created on 2021-06-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
