### PR TITLE
speed up `pivot_longer()`

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -233,30 +233,26 @@ pivot_longer_spec <- function(data,
     val_type <- vec_ptype_common(!!!set_names(val_cols[col_id], cols), .ptype = values_ptypes[[value]])
     out <- vec_c(!!!val_cols, .ptype = val_type)
     # Interleave into correct order
-    idx <- (matrix(seq_len(nrow(data) * length(val_cols)), ncol = nrow(data), byrow = TRUE))
+    n_vals <- nrow(data) * length(val_cols)
+    idx <- t(matrix(seq_len(n_vals), ncol = n_vals / nrow(data)))
     vals[[value]] <- vec_slice(out, as.integer(idx))
   }
   vals <- as_tibble(vals)
 
-  # Line up output rows by combining spec and existing data frame
-  rows <- expand_grid(
-    df_id = vec_seq_along(data),
-    key_id = vec_seq_along(keys),
-  )
-  rows$val_id <- vec_seq_along(rows)
-
-  if (values_drop_na) {
-    rows <- vec_slice(rows, !vec_equal_na(vals))
-  }
-
   # Join together df, spec, and val to produce final tibble
   df_out <- drop_cols(as_tibble(data, .name_repair = "minimal"), spec$.name)
+
   out <- wrap_error_names(vec_cbind(
-    vec_slice(df_out, rows$df_id),
-    vec_slice(keys, rows$key_id),
-    vec_slice(vals, rows$val_id),
+    vec_rep_each(df_out, vec_size(keys)),
+    vec_rep(keys, vec_size(data)),
+    vals,
     .name_repair = names_repair
   ))
+
+  if (values_drop_na) {
+    out <- vec_slice(out, !vec_equal_na(vals))
+  }
+
   out$.seq <- NULL
 
   reconstruct_tibble(data, out)

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -233,6 +233,8 @@ pivot_longer_spec <- function(data,
     val_type <- vec_ptype_common(!!!set_names(val_cols[col_id], cols), .ptype = values_ptypes[[value]])
     out <- vec_c(!!!val_cols, .ptype = val_type)
     # Interleave into correct order
+    # TODO somehow `t(matrix(x))` is _faster_ than `matrix(x, byrow = TRUE)`
+    # if this gets fixed in R this should use `byrow = TRUE` again
     n_vals <- nrow(data) * length(val_cols)
     idx <- t(matrix(seq_len(n_vals), ncol = n_vals / nrow(data)))
     vals[[value]] <- vec_slice(out, as.integer(idx))


### PR DESCRIPTION
Changes
* don't create `rows` data frame but slice the vectors directly
* don't use `matrix(byrow = TRUE)` as it is surprisingly slow

It looks like a bug to me that `matrix(x, byrow = TRUE)` is slower than `t(matrix(x))`. Probably, this should be fixed in base R.

## Benchmark: `pivot_longer()`

```r
library(data.table)
library(tidyr)

data.test <- matrix(
  data = sample(
    x = c(0L, 1L, 2L, NA_integer_),#the genotypes
    size = 2e+07,
    replace = TRUE,
    prob = c(0.8, 0.10, 0.05, 0.05)
  ),
  nrow = 20000,#number of SNPs/markers
  ncol = 1000,#number of samples
  dimnames = list(rownames = seq(1, 20000, 1), colnames = seq(1, 1000, 1))
) %>%
  tibble::as_tibble(x = ., rownames = "MARKERS")

bench::mark(
  pivot = tidyr::pivot_longer(data.test, cols = -MARKERS, names_to = "INDIVIDUALS", values_to = "GENOTYPES"),
  melt = data.table::as.data.table(data.test) %>%
    data.table::melt.data.table(
      data = .,
      id.vars = "MARKERS",
      variable.name = "INDIVIDUALS",
      value.name = "GENOTYPES",
      variable.factor = FALSE) %>%
    tibble::as_tibble(.),
  check = FALSE,
  iterations = 5
)

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 13
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
#> 1 pivot         452ms    465ms      1.96     918MB     5.89     5    15      2.54s <NULL>
#> 2 melt          247ms    362ms      2.65     459MB     2.65     5     5      1.88s <NULL>

# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 pivot         1.27s    1.27s     0.790    1.12GB     3.16
#> 2 melt       264.05ms 338.71ms     2.95   458.57MB     1.48
```

## Benchmark: `matrix()`

``` r
library(ggplot2)
library(purrr)

matrix_compare <- function(n, ncol) {
  bench::mark(
    by_row = matrix(seq_len(n), ncol = ncol, byrow = TRUE),
    transpose = t(matrix(seq_len(n), ncol = n / ncol))
  )
}

n_bench <- map_dfr(
  set_names(10e3 * c(1L, 2L, 5L, 10L, 20L, 50L, 100L)),
  matrix_compare,
  ncol = 200,
  .id = "n"
)

n_bench %>% 
  dplyr::transmute(
    n = as.integer(n),
    name = names(expression),
    median
  ) %>% 
  ggplot(aes(n, median, colour = name)) +
  geom_line() +
  geom_point() +
  labs(
    colour = "approach",
    x = "sequence size",
    y = "median time"
  )
```

![](https://i.imgur.com/arPxWsz.png)

``` r
ncol_bench <- map_dfr(
  set_names(200L * c(1L, 2L, 5L, 10L, 20L, 50L, 100L)),
  matrix_compare,
  n = 1e6,
  .id = "ncol"
)

ncol_bench %>% 
  dplyr::transmute(
    ncol = as.integer(ncol),
    name = names(expression),
    median
  ) %>% 
  ggplot(aes(ncol, median, colour = name)) +
  geom_line() +
  geom_point() +
  labs(
    colour = "approach",
    x = "Number of columns",
    y = "median time"
  )
```

![](https://i.imgur.com/P2FCN6V.png)

<sup>Created on 2021-06-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>