### PR TITLE
Speed up `unnest_longer()` and `unnest_wider()`

### DIFF
--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -426,11 +426,11 @@ vec_to_wide <- function(x, col, names_sep = NULL) {
   }
 
   if (is.data.frame(x)) {
-    as_tibble(map(x, list))
+    as_tibble(lapply(x, list))
   } else if (vec_is(x)) {
     if (is.list(x)) {
-      x <- purrr::compact(x)
-      x <- map(x, list)
+      x <- vec_slice(x, list_sizes(x) != 0)
+      x <- lapply(x, list)
     } else {
       x <- as.list(x)
     }

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -402,7 +402,7 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
     n <- map_int(x, vec_size)
   }
 
-  if (!all(n %in% c(0, 1))) {
+  if (any(n > 1)) {
     if (is.null(ptype)) {
       return(x)
     } else {

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -377,7 +377,7 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
 
   # Don't simplify lists of lists, because that typically indicates that
   # there might be multiple values.
-  is_list <- map_lgl(x, is.list)
+  is_list <- vapply(x, is.list, logical(1L))
   if (any(is_list)) {
     if (is.null(ptype)) {
       return(x)
@@ -387,7 +387,7 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
   }
 
   # Don't try and simplify non-vectors
-  is_vec <- map_lgl(x, ~ vec_is(.x) || is.null(.x))
+  is_vec <- vapply(x, function(.x) vec_is(.x), logical(1L))
   if (any(!is_vec)) {
     if (is.null(ptype)) {
       return(x)

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -437,7 +437,7 @@ vec_to_wide <- function(x, col, names_sep = NULL) {
     new_data_frame(lapply(x, list))
   } else if (vec_is(x)) {
     if (is.list(x)) {
-      x <- vec_slice(x, list_sizes(x) != 0)
+      x <- tidyr_compact(x)
       x <- lapply(x, list)
     } else {
       x <- as.list(x)
@@ -474,4 +474,13 @@ vec_to_long <- function(x, col, values_to, indices_to, indices_include = NULL) {
 
 index <- function(x) {
   names(x) %||% seq_along(x)
+}
+
+# `purrr::compact()` is too slow in a tight loop because
+# * it always calls `as_mapper()`
+# * applies `is_empty()` to every element
+# might become a proper vctrs function
+# https://github.com/r-lib/vctrs/issues/1395
+tidyr_compact <- function(x) {
+  vec_slice(x, list_sizes(x) != 0)
 }

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -398,8 +398,10 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
 
   if (vec_is_list(x)) {
     n <- list_sizes(x)
+  } else if (is.data.frame(x)) {
+    n <- rep(vec_size(x), nrow(x))
   } else {
-    n <- map_int(x, vec_size)
+    n <- 1L
   }
 
   if (any(n > 1)) {

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -203,7 +203,6 @@ unnest_longer <- function(data, col,
                           ptype = list(),
                           transform = list()
                           ) {
-
   check_present(col)
   col <- tidyselect::vars_pull(names(data), !!enquo(col))
 
@@ -212,6 +211,10 @@ unnest_longer <- function(data, col,
     indices_include <- indices_include %||% TRUE
   } else {
     indices_to <- paste0(col, "_id")
+  }
+
+  if (!is.null(indices_include) || is_bool(indices_include)) {
+    abort("`indices_include` must be `NULL`, `TRUE`, or `FALSE`.")
   }
 
   data[[col]] <- map(
@@ -449,7 +452,7 @@ vec_to_long <- function(x, col, values_to, indices_to, indices_include = NULL) {
   } else if (vec_is(x)) {
     indices_include <- indices_include %||% !is.null(names(x))
 
-    if (isTRUE(indices_include)) {
+    if (indices_include) {
       new_data_frame(
         list2(
           !!values_to := x,

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -387,7 +387,7 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
   }
 
   # Don't try and simplify non-vectors
-  is_vec <- vapply(x, function(.x) vec_is(.x), logical(1L))
+  is_vec <- vapply(x, function(.x) vec_is(.x) || is.null(.x), logical(1L))
   if (any(!is_vec)) {
     if (is.null(ptype)) {
       return(x)

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -434,7 +434,7 @@ vec_to_wide <- function(x, col, names_sep = NULL) {
     } else {
       x <- as.list(x)
     }
-    as_tibble(x, .name_repair = "unique", .rows = 1L)
+    data_frame(!!!x, .name_repair = "unique", .size = 1L)
   } else {
     stop("Input must be list of vectors", call. = FALSE)
   }
@@ -445,18 +445,19 @@ vec_to_long <- function(x, col, values_to, indices_to, indices_include = NULL) {
   if (is.null(x)) {
     NULL
   } else if (is.data.frame(x)) {
-    tibble(!!col := x)
+    new_data_frame(list2(!!col := x))
   } else if (vec_is(x)) {
-
     indices_include <- indices_include %||% !is.null(names(x))
 
     if (isTRUE(indices_include)) {
-      tibble(
-        !!values_to := x,
-        !!indices_to := index(x)
+      new_data_frame(
+        list2(
+          !!values_to := x,
+          !!indices_to := index(x)
+        )
       )
     } else {
-      tibble(!!values_to := x)
+      new_data_frame(list2(!!values_to := x))
     }
   } else {
     stop("Input must be list of vectors", call. = FALSE)

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -401,7 +401,7 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
   } else if (is.data.frame(x)) {
     n <- rep(vec_size(x), nrow(x))
   } else {
-    n <- 1L
+    n <- vec_size(x)
   }
 
   if (any(n > 1)) {

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -396,7 +396,12 @@ simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = F
     }
   }
 
-  n <- map_int(x, vec_size)
+  if (vec_is_list(x)) {
+    n <- list_sizes(x)
+  } else {
+    n <- map_int(x, vec_size)
+  }
+
   if (!all(n %in% c(0, 1))) {
     if (is.null(ptype)) {
       return(x)

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -429,7 +429,7 @@ vec_to_wide <- function(x, col, names_sep = NULL) {
   }
 
   if (is.data.frame(x)) {
-    as_tibble(lapply(x, list))
+    new_data_frame(lapply(x, list))
   } else if (vec_is(x)) {
     if (is.list(x)) {
       x <- vec_slice(x, list_sizes(x) != 0)

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -213,7 +213,7 @@ unnest_longer <- function(data, col,
     indices_to <- paste0(col, "_id")
   }
 
-  if (!is.null(indices_include) || is_bool(indices_include)) {
+  if (!is.null(indices_include) && !is_bool(indices_include)) {
     abort("`indices_include` must be `NULL`, `TRUE`, or `FALSE`.")
   }
 


### PR DESCRIPTION
Changes
* replace `map()` and `compact()` with `lapply()` and `vec_slice() + list_sizes()`
* replace `tibble()` with `new_data_frame()`

They should also benefit nicely from #1126.

## Benchmarks

``` r
library(dplyr, warn.conflicts = FALSE)
library(purrr)
library(tidyr)

array_fields <- c("titles", "aliases", "allegiances", "books", 
                  "povBooks", "tvSeries", "playedBy")
got_chars2 <- map(repurrrsive::got_chars, 
                  ~map_at(.x, array_fields, ~as.list(.x)))

times <- tibble(
  method = character(),
  rows = integer(),
  time = numeric()
)

data <- tibble(data = rep(got_chars2, length.out = 5000))

bench::mark(
  unnest_longer = unnest_longer(data, data),
  unnest_wider = unnest_wider(data, data, simplify = TRUE),
  check = FALSE
)

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest_longer    192ms    199ms      4.98    5.55MB     16.6
#> 2 unnest_wider     911ms    911ms      1.10    14.6MB     24.1

# CRAN
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest_longer    2.33s    2.33s     0.430      12MB     15.5
#> 2 unnest_wider     2.33s    2.33s     0.430    17.4MB     23.2
```

<sup>Created on 2021-06-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>