### PR TITLE
Switch column order from pivot_longer() so indices are before values

### DIFF
--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -452,8 +452,8 @@ vec_to_long <- function(x, col, values_to, indices_to, indices_include = NULL) {
 
     if (isTRUE(indices_include)) {
       tibble(
-        !!values_to := x,
-        !!indices_to := index(x)
+        !!indices_to := index(x),
+        !!values_to := x
       )
     } else {
       tibble(!!values_to := x)

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -238,16 +238,16 @@ test_that("automatically adds id col if named", {
   df <- tibble(x = 1:2, y = list(c(a = 1), c(b = 2)))
   out <- df %>% unnest_longer(y)
 
-  expect_named(out, c("x", "y", "y_id"))
+  expect_named(out, c("x", "y_id", "y"))
 })
 
 test_that("can force integer indexes", {
   df <- tibble(x = 1:2, y = list(1, 2))
   out <- df %>% unnest_longer(y, indices_include = TRUE)
-  expect_named(out, c("x", "y", "y_id"))
+  expect_named(out, c("x", "y_id", "y"))
 
   out <- df %>% unnest_longer(y, indices_to = "y2")
-  expect_named(out, c("x", "y", "y2"))
+  expect_named(out, c("x", "y2", "y"))
 })
 
 test_that("preserves empty rows", {
@@ -288,7 +288,7 @@ test_that("list_of columns can be unnested", {
 
   # With id column
   df <- tibble(x = 1:2, y = list_of(c(a = 1L), c(b = 1:2)))
-  expect_named(unnest_longer(df, y), c("x", "y", "y_id"))
+  expect_named(unnest_longer(df, y), c("x", "y_id", "y"))
 })
 
 # unnest_auto -------------------------------------------------------------
@@ -308,7 +308,7 @@ test_that("common name becomes wider", {
 test_that("no common name falls back to longer with index", {
   df <- tibble(x = 1:2, y = list(c(a = 1), c(b = 2)))
   expect_message(out <- df %>% unnest_auto(y), "unnest_longer")
-  expect_named(out, c("x", "y", "y_id"))
+  expect_named(out, c("x", "y_id", "y"))
 })
 
 test_that("mix of named and unnamed becomes longer", {


### PR DESCRIPTION
This is a small thing, but I find it awkward that indices are after values in the output from pivot_longer().

If there is a good reason for this order, or you do not think this (potentially breaking) change is "worth it", just reject :)
I guess the main risk is that people may rely on column indices rather than names.