### PR TITLE
Ensure `unpack()` is size stable in the zero col / one row case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # tidyr (development version)
+  
+* `unpack()` now works correctly with data frame columns containing 1 row but
+  0 columns (#1189).
 
 * The `ptype` argument of `unnest()` now works as expected (#1158). 
 

--- a/R/pack.R
+++ b/R/pack.R
@@ -98,8 +98,10 @@ unpack <- function(data, cols, names_sep = NULL, names_repair = "check_unique") 
   check_present(cols)
   cols <- tidyselect::eval_select(enquo(cols), data)
 
+  size <- vec_size(data)
+
   # Start from first principles to avoid issues in any subclass methods
-  out <- new_data_frame(data, n = vec_size(data))
+  out <- new_data_frame(data, n = size)
 
   cols <- map2(out[cols], names(cols), check_unpack, names_sep = names_sep)
 
@@ -108,7 +110,8 @@ unpack <- function(data, cols, names_sep = NULL, names_repair = "check_unique") 
 
   names(out) <- vec_as_names(names(out), repair = names_repair, repair_arg = "names_repair")
 
-  out <- as_tibble(out, .name_repair = "minimal")
+  out <- tibble::new_tibble(out, nrow = size)
+
   reconstruct_tibble(data, out)
 }
 

--- a/tests/testthat/test-pack.R
+++ b/tests/testthat/test-pack.R
@@ -69,3 +69,8 @@ test_that("can choose to add separtor", {
   out <- df %>% unpack(c(y, z), names_sep = "_")
   expect_named(out, c("x", "y_a", "z_a"))
 })
+
+test_that("can unpack 1-row but 0-col dataframe (#1189)", {
+  df <- tibble(x = tibble(.rows = 1))
+  expect_identical(unpack(df, x), tibble::new_tibble(list(), nrow = 1L))
+})


### PR DESCRIPTION
Part of #1189 