### PR TITLE
Rectangling function rewrite

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # tidyr (development version)
 
+* The rectangling tools, `hoist()`, `unnest_wider()`, and `unnest_longer()`,
+  have undergone a complete rewrite. This has fixed many edge case bugs, and
+  has added the following new features:
+  
+  * `unnest_wider()` and `unnest_longer()` can now unnest multiple columns at
+    once (#740).
+    
+  * The `indices_to` and `values_to` arguments to `unnest_longer()` now accept
+    a glue specification, which is useful when unnesting multiple columns.
+    
+  * If a `ptype` is supplied, but that column can't be simplified, the result
+    will be a list-of column where each element has type `ptype` (#998).
+    
+  * `unnest_wider()` has a new `strict` argument which controls whether or not
+    strict vctrs typing rules should be applied. It defaults to `FALSE` for
+    backwards compatibility, and because it is often more useful to be lax
+    when unnesting JSON, which doesn't always map one-to-one with R's types
+    (#1125).
+
 * `any_of()` and `all_of()` from tidyselect are now re-exported (#1217).
 
 * `unchop()` now respects `ptype` when unnesting a non-list column (#1211).

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -397,7 +397,7 @@ col_to_long <- function(col,
   if (!vec_is_list(col)) {
     ptype <- vec_ptype(col)
     col <- tidyr_chop(col)
-    col <- new_list_of(col, ptype = ptype)
+    col <- tidyr_temporary_new_list_of(col, ptype = ptype)
   }
 
   info <- collect_indices_info(col, indices_include)
@@ -435,7 +435,7 @@ col_to_long <- function(col,
   ptype <- vec_ptype_common(elt_ptype, !!!col)
   col <- vec_cast_common(!!!col, .to = ptype)
 
-  col <- new_list_of(col, ptype = ptype)
+  col <- tidyr_temporary_new_list_of(col, ptype = ptype)
 
   col
 }
@@ -597,7 +597,7 @@ col_to_wide <- function(col, name, strict, names_sep) {
   if (!vec_is_list(col)) {
     ptype <- vec_ptype(col)
     col <- tidyr_chop(col)
-    col <- new_list_of(col, ptype = ptype)
+    col <- tidyr_temporary_new_list_of(col, ptype = ptype)
   }
 
   # If we don't have a list_of, then a `NULL` `col_ptype` will get converted to
@@ -625,7 +625,7 @@ col_to_wide <- function(col, name, strict, names_sep) {
     out <- vec_cast_common(!!!out, .to = ptype)
   }
 
-  out <- new_list_of(out, ptype = ptype)
+  out <- tidyr_temporary_new_list_of(out, ptype = ptype)
 
   out
 }
@@ -803,7 +803,7 @@ col_simplify <- function(x,
   if (!is.null(ptype)) {
     x <- tidyr_new_list(x)
     x <- vec_cast_common(!!!x, .to = ptype)
-    x <- new_list_of(x, ptype = ptype)
+    x <- tidyr_temporary_new_list_of(x, ptype = ptype)
   }
 
   if (!simplify) {
@@ -851,4 +851,23 @@ col_simplify <- function(x,
     vec_unchop(x_scalars, ptype = x_ptype),
     vctrs_error_incompatible_type = function(e) x
   )
+}
+
+tidyr_temporary_new_list_of <- function(x, ptype) {
+  # TODO: Remove me and replace with `new_list_of()` when
+  # https://github.com/r-lib/vctrs/pull/784 is merged / fixed.
+
+  # This is an unfortunate hack required because vctr types currently
+  # can't have `""` names, and that can easily come up when unnesting a
+  # mix of named and unnamed elements.
+
+  # Most of the time, in the places we use this helper the names
+  # weren't needed at all, so it is safe to remove them. Any place
+  # where this isn't the case has a test and a linked open issue.
+  names <- names(x)
+  if (!is.null(names) && any(names == "")) {
+    x <- unname(x)
+  }
+
+  new_list_of(x, ptype = ptype)
 }

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -742,9 +742,23 @@ df_simplify <- function(x,
   if (!vec_is_list(ptype)) {
     abort("`ptype` must be a list.")
   }
-  if (!vec_is_list(ptype)) {
+  if (length(ptype) > 0L && !is_named(ptype)) {
+    abort("All elements of `ptype` must be named.")
+  }
+  if (vec_duplicate_any(names(ptype))) {
+    abort("The names of `ptype` must be unique.")
+  }
+
+  if (!vec_is_list(transform)) {
     abort("`transform` must be a list.")
   }
+  if (length(transform) > 0L && !is_named(transform)) {
+    abort("All elements of `transform` must be named.")
+  }
+  if (vec_duplicate_any(names(transform))) {
+    abort("The names of `transform` must be unique.")
+  }
+
   if (!is_bool(simplify)) {
     abort("`simplify` must be a single `TRUE` or `FALSE`.")
   }

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -43,7 +43,9 @@
 #'   For `hoist()` and `unnest_auto()`, this must identify a single column.
 #'
 #'   For `unnest_wider()` and `unnest_longer()`, you can use tidyselect to
-#'   select multiple columns to unnest simultaneously.
+#'   select multiple columns to unnest simultaneously. When using
+#'   `unnest_longer()` with multiple columns, values across columns that
+#'   originated from the same row are recycled to a common size.
 #' @param ... Components of `.col` to turn into columns in the form
 #'   `col_name = "pluck_specification"`. You can pluck by name with a character
 #'   vector, by position with an integer vector, or with a combination of the

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -60,8 +60,8 @@
 #'   check that each element has the type you expect when simplifying.
 #'
 #'   If a `ptype` has been specified, but `simplify = FALSE` or simplification
-#'   isn't possible, then a list-of column will be returned and each element
-#'   will have type `ptype`.
+#'   isn't possible, then a [list-of][vctrs::list_of()] column will be returned
+#'   and each element will have type `ptype`.
 #' @param .transform,transform Optionally, a named list of transformation
 #'   functions applied to each component. Use this function if you want
 #'   to transform or parse individual elements as they are extracted.

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -12,6 +12,10 @@
 #'
 #' Learn more in `vignette("rectangle")`.
 #'
+#' @details
+#' When both `ptype` and `transform` are supplied, the `transform` is applied
+#' before the `ptype`.
+#'
 #' @section Unnest variants:
 #'
 #' The three `unnest()` functions differ in how they change the shape of the
@@ -19,25 +23,31 @@
 #'
 #' * `unnest_wider()` preserves the rows, but changes the columns.
 #' * `unnest_longer()` preserves the columns, but changes the rows
-#' * `unnest()` can change both rows and columns.
+#' * [unnest()] can change both rows and columns.
 #'
 #' These principles guide their behaviour when they are called with a
 #' non-primary data type. For example, if you `unnest_wider()` a list of data
 #' frames, the number of rows must be preserved, so each column is turned into
 #' a list column of length one. Or if you `unnest_longer()` a list of data
-#' frame, the number of columns must be preserved so it creates a packed
+#' frames, the number of columns must be preserved so it creates a packed
 #' column. I'm not sure how if these behaviours are useful in practice, but
 #' they are theoretically pleasing.
 #'
 #' @section `unnest_auto()` heuristics:
 #' `unnest_auto()` inspects the inner names of the list-col:
-#' * If all elements are unnamed, it uses `unnest_longer()`
+#' * If all elements are unnamed, it uses
+#'   `unnest_longer(indices_include = FALSE)`.
 #' * If all elements are named, and there's at least one name in
-#'   common acros all components, it uses `unnest_wider()`
+#'   common across all components, it uses `unnest_wider()`.
 #' * Otherwise, it falls back to `unnest_longer(indices_include = TRUE)`.
 #'
 #' @param .data,data A data frame.
 #' @param .col,col List-column to extract components from.
+#'
+#'   For `hoist()` and `unnest_auto()`, this must identify a single column.
+#'
+#'   For `unnest_wider()` and `unnest_longer()`, you can use tidyselect to
+#'   select multiple columns to unnest simultaneously.
 #' @param ... Components of `.col` to turn into columns in the form
 #'   `col_name = "pluck_specification"`. You can pluck by name with a character
 #'   vector, by position with an integer vector, or with a combination of the
@@ -48,15 +58,21 @@
 #'   single string you can choose to omit the name, i.e. `hoist(df, col, "x")`
 #'   is short-hand for `hoist(df, col, x = "x")`.
 #' @param .simplify,simplify If `TRUE`, will attempt to simplify lists of
-#'   length-1 vectors to an atomic vector
-#' @param .ptype,ptype Optionally, a named list of prototypes declaring the desired
-#'   output type of each component. Use this argument if you want to check each
-#'   element has the types you expect when simplifying.
-#' @param .transform,transform Optionally, a named list of transformation functions
-#'   applied to each component. Use this function if you want transform or
-#'   parse individual elements as they are hoisted.
+#'   length-1 vectors to an atomic vector.
+#' @param .ptype,ptype Optionally, a named list of prototypes declaring the
+#'   desired output type of each component. Use this argument if you want to
+#'   check that each element has the type you expect when simplifying.
+#'
+#'   If a `ptype` has been specified, but `simplify = FALSE` or simplification
+#'   isn't possible, then a list-of column will be returned and each element
+#'   will have type `ptype`.
+#' @param .transform,transform Optionally, a named list of transformation
+#'   functions applied to each component. Use this function if you want
+#'   to transform or parse individual elements as they are extracted.
 #' @param .remove If `TRUE`, the default, will remove extracted components
-#'   from `.col`. This ensures that each value lives only in one place.
+#'   from `.col`. This ensures that each value lives only in one place. If all
+#'   components are removed from `.col`, then `.col` will be removed from the
+#'   result entirely.
 #' @examples
 #' df <- tibble(
 #'   character = c("Toothless", "Dory"),
@@ -113,13 +129,52 @@
 #' df %>% unnest_wider(y)
 #' df %>% unnest_longer(y)
 #'
+#' # Both unnest_wider() and unnest_longer() allow you to unnest multiple
+#' # columns at once. This is particularly useful with unnest_longer(), where
+#' # unnesting sequentially would generate a cartesian product of the rows.
+#' df <- tibble(
+#'   x = 1:2,
+#'   y = list(1:2, 3:4),
+#'   z = list(5:6, 7:8)
+#' )
+#' unnest_longer(df, c(y, z))
+#' unnest_longer(unnest_longer(df, y), z)
+#'
+#' # With JSON, it is common for empty elements to be represented by `list()`
+#' # rather then their typed equivalent, like `integer()`
+#' json <- list(
+#'   list(x = 1:2, y = 1:2),
+#'   list(x = list(), y = 3:4),
+#'   list(x = 3L, y = list())
+#' )
+#' df <- tibble(json = json)
+#'
+#' # The defaults of `unnest_wider()` treat empty types (like `list()`) as `NULL`.
+#' # This chains nicely into `unnest_longer()`.
+#' wide <- unnest_wider(df, json)
+#' wide
+#'
+#' unnest_longer(wide, c(x, y))
+#'
+#' # To instead enforce strict vctrs typing rules, use `strict`
+#' wide_strict <- unnest_wider(df, json, strict = TRUE)
+#' wide_strict
+#'
+#' try(unnest_longer(wide_strict, c(x, y)))
 #' @export hoist
-hoist <- function(.data, .col, ..., .remove = TRUE, .simplify = TRUE, .ptype = list(), .transform = list()) {
+hoist <- function(.data,
+                  .col,
+                  ...,
+                  .remove = TRUE,
+                  .simplify = TRUE,
+                  .ptype = list(),
+                  .transform = list()) {
   check_present(.col)
-  .col <- tidyselect::vars_pull(names(.data), !!enquo(.col))
+  .col <- tidyselect::vars_pull(names(.data), {{.col}})
+
   x <- .data[[.col]]
-  if (!is.list(x)) {
-    abort("`col` must be a list-column")
+  if (!vec_is_list(x)) {
+    abort("`.col` must identify a list-column.")
   }
 
   pluckers <- check_pluckers(...)
@@ -128,20 +183,20 @@ hoist <- function(.data, .col, ..., .remove = TRUE, .simplify = TRUE, .ptype = l
   # the lookup has a large performance impact:
   # https://github.com/tidyverse/tidyr/issues/1001
   pluck <- purrr::pluck
-  new_cols <- map(pluckers, function(idx) {
+  cols <- map(pluckers, function(idx) {
     map(x, ~ pluck(.x, !!!idx))
   })
-  new_cols <- map2(
-    new_cols,
-    names(new_cols),
-    simplify_col,
-    simplify = .simplify,
+  cols <- new_data_frame(cols, n = vec_size(.data))
+
+  cols <- df_simplify(
+    cols,
     ptype = .ptype,
-    transform = .transform
+    transform = .transform,
+    simplify = .simplify
   )
 
   # Place new columns before old column
-  out <- append_df(.data, new_cols, after = match(.col, names(.data)) - 1L)
+  out <- append_df(.data, cols, after = match(.col, names(.data)) - 1L)
 
   if (!.remove) {
     return(out)
@@ -167,104 +222,461 @@ hoist <- function(.data, .col, ..., .remove = TRUE, .simplify = TRUE, .ptype = l
 check_pluckers <- function(...) {
   pluckers <- list2(...)
 
-  is_string <- vapply(pluckers, function(x) is.character(x) && length(x) == 1, logical(1))
+  is_string <- map_lgl(pluckers, ~is.character(.x) && length(.x) == 1)
   auto_name <- names2(pluckers) == "" & is_string
 
   if (any(auto_name)) {
     names(pluckers)[auto_name] <- unlist(pluckers[auto_name])
   }
 
-  if (!is_named(pluckers)) {
-    stop("All elements of `...` must be named", call. = FALSE)
+  if (length(pluckers) > 0 && !is_named(pluckers)) {
+    abort("All elements of `...` must be named.")
   }
 
   if (vec_duplicate_any(names(pluckers))) {
-    abort("The names of `...` must be unique")
+    abort("The names of `...` must be unique.")
   }
+
+  # Standardize all pluckers to lists for splicing into `pluck()`
+  # and for easier handling in `strike()`
+  is_not_list <- !map_lgl(pluckers, vec_is_list)
+  pluckers[is_not_list] <- map(pluckers[is_not_list], vec_chop)
 
   pluckers
 }
 
+strike <- function(x, indices) {
+  if (!vec_is_list(indices)) {
+    abort("Internal error: `indices` must be a list.")
+  }
+
+  n_indices <- vec_size(indices)
+
+  if (n_indices == 0L) {
+    # Edge case corresponding to an empty plucker
+    return(x)
+  }
+
+  index <- indices[[1L]]
+  indices <- indices[-1L]
+
+  is_valid_index <-
+    (is.numeric(index) && (index <= vec_size(x))) ||
+    (is.character(index) && has_name(x, index))
+
+  if (!is_valid_index) {
+    # Nothing to do if the `pluck()` missed entirely
+    return(x)
+  }
+
+  if (n_indices == 1L) {
+    # At base index, remove it
+    if (is.numeric(index)) {
+      x <- x[-index]
+    } else if (is.character(index)) {
+      x <- x[setdiff(names(x), index)]
+    } else {
+      abort("Internal error: Only character and numeric values are valid indices.")
+    }
+  } else {
+    # Not at base index yet, continue recursion
+    x[[index]] <- strike(x[[index]], indices)
+  }
+
+  x
+}
+
 #' @export
 #' @rdname hoist
-#' @param values_to Name of column to store vector values. Defaults to `col`.
-#' @param indices_to A string giving the name of column which will contain the
-#'   inner names or position (if not named) of the values. Defaults to `col`
-#'   with `_id` suffix
-#' @param indices_include Add an index column? Defaults to `TRUE` when `col`
-#'   has inner names.
+#' @param values_to A single string representing the column name to store the
+#'   unnested values in. If multiple columns are specified in `col`, this can
+#'   also be a glue string containing `"{col}"` to provide a template for the
+#'   column names. If `NULL`, defaults to `"{col}"`.
+#' @param indices_to A string giving the name of the column which will contain
+#'   the inner names or positions (if not named) of the values. If multiple
+#'   columns are specified in `col`, this can also be a glue string containing
+#'   `"{col}"` to provide a template for the column names. If `NULL`, defaults
+#'   to `values_to` suffixed with `"_id"`.
+#' @param indices_include A single logical value specifying whether or not to
+#'   add an index column. If any value has inner names, the index column will be
+#'   a character vector of those names, otherwise it will be an integer vector
+#'   of positions. If `NULL`, defaults to `TRUE` if any value has inner names
+#'   or if `indices_to` is provided.
+#'
+#'   If `indices_to` is provided, then `indices_include` can't be `FALSE`.
 #' @inheritParams unnest
-unnest_longer <- function(data, col,
+unnest_longer <- function(data,
+                          col,
                           values_to = NULL,
                           indices_to = NULL,
                           indices_include = NULL,
                           names_repair = "check_unique",
                           simplify = TRUE,
                           ptype = list(),
-                          transform = list()
-                          ) {
-
+                          transform = list()) {
   check_present(col)
-  col <- tidyselect::vars_pull(names(data), !!enquo(col))
+  # TODO: Use `allow_rename = FALSE`.
+  # Requires https://github.com/r-lib/tidyselect/issues/225.
+  cols <- tidyselect::eval_select(enquo(col), data)
+  col_names <- names(cols)
+  n_col_names <- length(col_names)
 
-  values_to <- values_to %||% col
-  if (!is.null(indices_to)) {
-    indices_include <- indices_include %||% TRUE
-  } else {
-    indices_to <- paste0(col, "_id")
+  if (!is.null(indices_include) && !is_bool(indices_include)) {
+    abort("`indices_include` must be `NULL` or a single `TRUE` or `FALSE`.")
   }
 
-  data[[col]] <- map(
-    data[[col]], vec_to_long,
-    col = col,
+  if (is.null(values_to)) {
+    values_to <- "{col}"
+  }
+  if (!is_string(values_to)) {
+    abort("`values_to` must be a single string or `NULL`.")
+  }
+
+  if (is.null(indices_to)) {
+    indices_to <- paste0(values_to, "_id")
+  } else {
+    if (is_false(indices_include)) {
+      abort("Can't set `indices_include` to `FALSE` when `indices_to` is supplied.")
+    }
+    indices_include <- TRUE
+  }
+  if (!is_string(indices_to)) {
+    abort("`indices_to` must be a single string or `NULL`.")
+  }
+
+  values_to <- glue_col_names(values_to, col_names)
+  values_to <- vec_recycle(values_to, size = n_col_names)
+
+  indices_to <- glue_col_names(indices_to, col_names)
+  indices_to <- vec_recycle(indices_to, size = n_col_names)
+
+  for (i in seq_along(cols)) {
+    col <- cols[[i]]
+    col_name <- col_names[[i]]
+    col_values_to <- values_to[[i]]
+    col_indices_to <- indices_to[[i]]
+
+    data[[col]] <- col_to_long(
+      col = data[[col]],
+      name = col_name,
+      values_to = col_values_to,
+      indices_to = col_indices_to,
+      indices_include = indices_include
+    )
+  }
+
+  data <- unchop(data, all_of(cols))
+
+  for (i in seq_along(cols)) {
+    col <- cols[[i]]
+
+    data[[col]] <- df_simplify(
+      x = data[[col]],
+      ptype = ptype,
+      transform = transform,
+      simplify = simplify
+    )
+  }
+
+  unpack(data, all_of(cols), names_repair = names_repair)
+}
+
+# Converts a column of any type to a `list_of<tbl>`
+col_to_long <- function(col,
+                        name,
+                        values_to,
+                        indices_to,
+                        indices_include) {
+  if (is.null(col)) {
+    abort(glue("Invalid `NULL` column detected for column `{name}`."))
+  }
+
+  if (!vec_is_list(col)) {
+    ptype <- vec_ptype(col)
+    col <- tidyr_chop(col)
+    col <- new_list_of(col, ptype = ptype)
+  }
+
+  info <- collect_indices_info(col, indices_include)
+  indices_include <- info$indices_include
+  indices <- info$indices
+  index_ptype <- info$index_ptype
+
+  # If we don't have a list_of, then a `NULL` `col_ptype` will get converted to
+  # a 1 row, 1 col tibble for `elt_ptype`
+  col_ptype <- list_of_ptype(col)
+  elt_ptype <- elt_to_long(
+    x = col_ptype,
+    index = index_ptype,
+    name = name,
     values_to = values_to,
     indices_to = indices_to,
     indices_include = indices_include
   )
+  elt_ptype <- vec_ptype(elt_ptype)
 
-  data <- unchop(data, any_of(col), keep_empty = TRUE)
-  inner_cols <- names(data[[col]])
+  # Avoid expensive dispatch from `[[.list_of`, and allow for `[[<-`
+  col <- tidyr_new_list(col)
 
-  data[[col]][] <- map2(
-    data[[col]],
-    names(data[[col]]),
-    simplify_col,
-    simplify = simplify,
-    ptype = ptype,
-    transform = transform
+  for (i in seq_along(col)) {
+    col[[i]] <- elt_to_long(
+      x = col[[i]],
+      index = indices[[i]],
+      name = name,
+      values_to = values_to,
+      indices_to = indices_to,
+      indices_include = indices_include
+    )
+  }
+
+  ptype <- vec_ptype_common(elt_ptype, !!!col)
+  col <- vec_cast_common(!!!col, .to = ptype)
+
+  col <- new_list_of(col, ptype = ptype)
+
+  col
+}
+
+# Convert a list element to a long tibble with:
+# - 1 col (2 if `indices_include` is `TRUE`)
+# - N rows, where `N = vec_size(x)`
+elt_to_long <- function(x,
+                        index,
+                        name,
+                        values_to,
+                        indices_to,
+                        indices_include) {
+  if (is.null(x)) {
+    x <- unspecified(1L)
+
+    if (indices_include) {
+      if (is.integer(index)) {
+        index <- 1L
+      } else {
+        index <- NA_character_
+      }
+    }
+  }
+
+  if (!vec_is(x)) {
+    abort(glue("Column `{name}` must contain a list of vectors."))
+  }
+
+  if (indices_include) {
+    out <- list(x, index)
+    names(out) <- c(values_to, indices_to)
+  } else {
+    out <- list(x)
+    names(out) <- values_to
+  }
+
+  new_data_frame(out, n = vec_size(x))
+}
+
+collect_indices_info <- function(col, indices_include) {
+  out <- list(
+    indices_include = FALSE,
+    indices = NULL,
+    index_ptype = NULL
   )
 
-  unpack(data, any_of(col), names_repair = names_repair)
+  if (is_false(indices_include)) {
+    return(out)
+  }
+
+  indices <- map(col, vec_names)
+  unnamed <- vec_equal_na(indices)
+  all_unnamed <- all(unnamed)
+
+  if (is.null(indices_include) && all_unnamed) {
+    # Same as `indices_include = FALSE`
+    return(out)
+  }
+
+  sizes <- list_sizes(col)
+
+  if (all_unnamed) {
+    # Indices are requested, but none of the elements are named.
+    # Generate integer column of sequential indices.
+    indices <- map(sizes, seq_len)
+    index_ptype <- integer()
+  } else {
+    # Indices are requested, and some elements are named.
+    # For any unnamed elements, generate `NA` indices.
+    indices[unnamed] <- map(sizes[unnamed], vec_rep, x = NA_character_)
+    index_ptype <- character()
+  }
+
+  out$indices_include <- TRUE
+  out$indices <- indices
+  out$index_ptype <- index_ptype
+
+  out
+}
+
+glue_col_names <- function(string, col_names) {
+  data <- list(col = col_names)
+  out <- glue::glue_data(data, string, .envir = NULL)
+  out <- as.character(out)
+  out
 }
 
 #' @export
 #' @rdname hoist
 #' @param names_sep If `NULL`, the default, the names will be left
-#'   as is. If a string, the inner and outer names will be paste together using
+#'   as is. If a string, the outer and inner names will be pasted together using
 #'   `names_sep` as a separator.
-unnest_wider <- function(data, col,
+#'
+#'   If the values being unnested are unnamed and `names_sep` is supplied, the
+#'   inner names will be automatically generated as an increasing sequence of
+#'   integers.
+#' @param strict A single logical specifying whether or not to apply strict
+#'   vctrs typing rules. If `FALSE`, typed empty values (like `list()` or
+#'   `integer()`) nested within list-columns will be treated like `NULL` and
+#'   will not contribute to the type of the unnested column. This is useful
+#'   when working with JSON, where empty values tend to lose their type
+#'   information and show up as `list()`.
+unnest_wider <- function(data,
+                         col,
                          names_sep = NULL,
                          simplify = TRUE,
+                         strict = FALSE,
                          names_repair = "check_unique",
                          ptype = list(),
-                         transform = list()
-                         ) {
+                         transform = list()) {
   check_present(col)
-  col <- tidyselect::vars_pull(tbl_vars(data), !!enquo(col))
+  # TODO: Use `allow_rename = FALSE`.
+  # Requires https://github.com/r-lib/tidyselect/issues/225.
+  cols <- tidyselect::eval_select(enquo(col), data)
+  col_names <- names(cols)
 
-  data[[col]] <- map(data[[col]], vec_to_wide, col = col, names_sep = names_sep)
-  data <- unchop(data, any_of(col), keep_empty = TRUE)
+  if (!is.null(names_sep) && !is_string(names_sep)) {
+    abort("`names_sep` must be a single string or `NULL`.")
+  }
+  if (!is_bool(strict)) {
+    abort("`strict` must be a single `TRUE` or `FALSE`.")
+  }
 
-  data[[col]][] <- map2(
-    data[[col]],
-    names(data[[col]]),
-    simplify_col,
-    simplify = simplify,
-    ptype = ptype,
-    transform = transform
-  )
+  for (i in seq_along(cols)) {
+    col <- cols[[i]]
+    col_name <- col_names[[i]]
 
-  unpack(data, any_of(col), names_repair = names_repair)
+    data[[col]] <- col_to_wide(
+      col = data[[col]],
+      name = col_name,
+      strict = strict,
+      names_sep = names_sep
+    )
+  }
+
+  data <- unchop(data, all_of(cols))
+
+  for (i in seq_along(cols)) {
+    col <- cols[[i]]
+
+    data[[col]] <- df_simplify(
+      x = data[[col]],
+      ptype = ptype,
+      transform = transform,
+      simplify = simplify
+    )
+  }
+
+  unpack(data, all_of(cols), names_repair = names_repair)
+}
+
+# Converts a column of any type to a `list_of<tbl>`
+col_to_wide <- function(col, name, strict, names_sep) {
+  if (is.null(col)) {
+    abort(glue("Invalid `NULL` column detected for column `{name}`."))
+  }
+
+  if (!vec_is_list(col)) {
+    ptype <- vec_ptype(col)
+    col <- tidyr_chop(col)
+    col <- new_list_of(col, ptype = ptype)
+  }
+
+  # If we don't have a list_of, then a `NULL` `col_ptype` will get converted to
+  # a 1 row, 0 col tibble for `elt_ptype`
+  col_ptype <- list_of_ptype(col)
+  elt_ptype <- elt_to_wide(col_ptype, name = name, strict = strict, names_sep = names_sep)
+  elt_ptype <- vec_ptype(elt_ptype)
+
+  # Avoid expensive dispatch from `[[.list_of`
+  out <- tidyr_new_list(col)
+  out <- map(out, elt_to_wide, name = name, strict = strict, names_sep = names_sep)
+
+  # In the sole case of a list_of<data_frame>, we can be sure that the
+  # elements of `out` will all be of the same type. Otherwise,
+  # - If `col` isn't a list-of, we don't know the element type.
+  # - If `col` is a list-of but not one with a data frame ptype, then we
+  #   don't actually know if all elements have the same ptype, because the
+  #   number of resulting columns per element depends on that element's size.
+  has_identical_elements <- is_list_of(col) && is.data.frame(col_ptype)
+
+  if (has_identical_elements) {
+    ptype <- elt_ptype
+  } else {
+    ptype <- vec_ptype_common(elt_ptype, !!!out)
+    out <- vec_cast_common(!!!out, .to = ptype)
+  }
+
+  out <- new_list_of(out, ptype = ptype)
+
+  out
+}
+
+# Convert a list element to a wide tibble with:
+# - 1 row
+# - N cols, where `N = vec_size(x)`
+# - Column names come from `vec_names(x)`
+# - Data frames are treated specially. They are treated like heterogeneous lists
+#   where we know the type of each list element.
+# - When !strict, lists are treated specially as well. Any typed empty elements
+#   are replaced with `NULL` so their type doesn't interfere with the final
+#   common type. This is extremely useful for JSON data,
+#   where round tripping a typed empty cell results in an empty `list()` that
+#   won't be able to combine with other typed non-empty cells. However, it
+#   can create inconsistencies with vctrs typing rules.
+elt_to_wide <- function(x, name, strict, names_sep) {
+  if (is.null(x)) {
+    x <- list()
+  }
+
+  if (!vec_is(x)) {
+    abort(glue("Column `{name}` must contain a list of vectors."))
+  }
+
+  if (is.data.frame(x)) {
+    # Extremely special case for data.frames,
+    # which we want to treat like lists where we know the type of each element
+    x <- tidyr_new_list(x)
+    ptypes <- map(x, vec_ptype)
+    x <- tidyr_chop(x)
+    x <- map2(x, ptypes, new_list_of)
+  } else if (!strict && vec_is_list(x)) {
+    empty <- list_sizes(x) == 0L
+    if (any(empty)) {
+      # Can't use vec_assign(), see https://github.com/r-lib/vctrs/issues/1424
+      x[empty] <- list(NULL)
+    }
+    x <- tidyr_chop(x)
+  } else {
+    x <- tidyr_chop(x)
+  }
+
+  if (!is.null(names_sep)) {
+    outer <- name
+    inner <- vec_names(x) %||% vec_seq_along(x)
+    names(x) <- apply_names_sep(outer, inner, names_sep)
+  }
+
+  names(x) <- vec_as_names(names2(x), repair = "unique")
+
+  x <- new_data_frame(x, n = 1L)
+
+  x
 }
 
 #' @export
@@ -289,7 +701,7 @@ guess_dir <- function(x, col) {
 
   if (identical(is_null, TRUE)) {
     # all unnamed
-    code <- glue::glue("unnest_longer({col})")
+    code <- glue::glue("unnest_longer({col}, indices_include = FALSE)")
     reason <- "no element has names"
     out <- "longer"
   } else if (identical(is_null, FALSE)) {
@@ -306,7 +718,7 @@ guess_dir <- function(x, col) {
       out <- "wider"
     }
   } else {
-    code <- glue::glue("unnest_longer({col})")
+    code <- glue::glue("unnest_longer({col}, indices_include = FALSE)")
     reason <- "mix of named and unnamed elements"
     out <- "longer"
   }
@@ -317,152 +729,123 @@ guess_dir <- function(x, col) {
 
 # Helpers -----------------------------------------------------------------
 
-strike <- function(x, idx) {
-  if (length(idx) == 0) (
-    x
-  ) else if (length(idx) == 1) {
-    if (is.list(idx)) {
-      idx <- idx[[1]]
-    }
+df_simplify <- function(x,
+                        ...,
+                        ptype = list(),
+                        transform = list(),
+                        simplify = TRUE) {
+  ellipsis::check_dots_empty()
 
-    if (is.numeric(idx)) {
-      x[-idx]
-    } else if (is.character(idx)) {
-      if (has_name(x, idx)) {
-        x[setdiff(names(x), idx)]
-      } else {
-        x
-      }
-    } else {
-      x
-    }
-  } else {
-    cur_idx <- idx[[1]]
-    idx <- idx[-1]
-
-    if (is.numeric(cur_idx)) {
-      if (cur_idx > length(x)) {
-        x
-      } else {
-        x[[cur_idx]] <- strike(x[[cur_idx]], idx)
-        x
-      }
-    } else if (is.character(cur_idx)) {
-      if (!has_name(x, cur_idx)) {
-        x
-      } else {
-        x[[cur_idx]] <- strike(x[[cur_idx]], idx)
-        x
-      }
-    } else {
-      x
-    }
+  if (!vec_is_list(ptype)) {
+    abort("`ptype` must be a list.")
   }
+  if (!vec_is_list(ptype)) {
+    abort("`transform` must be a list.")
+  }
+  if (!is_bool(simplify)) {
+    abort("`simplify` must be a single `TRUE` or `FALSE`.")
+  }
+
+  x_n <- length(x)
+  x_size <- vec_size(x)
+  x_names <- names(x)
+
+  out <- vector("list", length = x_n)
+  names(out) <- x_names
+
+  for (i in seq_len(x_n)) {
+    col <- x[[i]]
+    col_name <- x_names[[i]]
+
+    col_ptype <- ptype[[col_name]]
+    col_transform <- transform[[col_name]]
+
+    out[[i]] <- col_simplify(
+      x = col,
+      ptype = col_ptype,
+      transform = col_transform,
+      simplify = simplify
+    )
+  }
+
+  new_data_frame(out, n = x_size)
 }
 
-simplify_col <- function(x, nm, ptype = list(), transform = list(), simplify = FALSE) {
-  transform <- transform[[nm]]
-  ptype <- ptype[[nm]]
+col_simplify <- function(x,
+                         ...,
+                         ptype = NULL,
+                         transform = NULL,
+                         simplify = TRUE) {
+  ellipsis::check_dots_empty()
 
   if (!is.null(transform)) {
-    x <- map(x, as_function(transform))
+    transform <- as_function(transform)
   }
 
-  if (!simplify || !is.list(x)) {
+  if (!vec_is_list(x)) {
+    if (!is.null(transform)) {
+      x <- transform(x)
+    }
+    if (!is.null(ptype)) {
+      x <- vec_cast(x, ptype)
+    }
+    return(x)
+  }
+
+  if (!is.null(transform)) {
+    x <- tidyr_new_list(x)
+    x <- map(x, transform)
+    # Can't convert result to list_of, as we can't be certain of element types
+  }
+  if (!is.null(ptype)) {
+    x <- tidyr_new_list(x)
+    x <- vec_cast_common(!!!x, .to = ptype)
+    x <- new_list_of(x, ptype = ptype)
+  }
+
+  if (!simplify) {
     return(x)
   }
 
   # Don't simplify lists of lists, because that typically indicates that
   # there might be multiple values.
-  is_list <- map_lgl(x, is.list)
-  if (any(is_list)) {
-    if (is.null(ptype)) {
-      return(x)
-    } else {
-      abort(glue("Can't simplfy '{nm}'; contains a nested list"))
-    }
-  }
-
-  # Don't try and simplify non-vectors
-  is_vec <- map_lgl(x, ~ vec_is(.x) || is.null(.x))
-  if (any(!is_vec)) {
-    if (is.null(ptype)) {
-      return(x)
-    } else {
-      abort(glue("Can't simplfy '{nm}'; contains a non-vector"))
-    }
-  }
-
-  n <- map_int(x, vec_size)
-  if (!all(n %in% c(0, 1))) {
-    if (is.null(ptype)) {
-      return(x)
-    } else {
-      abort(glue("Can't simplfy '{nm}'; elements have length > 1"))
-    }
-  }
-
-  # Ensure empty elements filled in with a single unspecified value
-  x[n == 0] <- list(NA)
-
-  if (is.null(ptype)) {
-    tryCatch(
-      vec_c(!!!x),
-      vctrs_error_incompatible_type = function(e) x
-    )
+  if (is_list_of(x)) {
+    has_list_of_list <- vec_is_list(list_of_ptype(x))
   } else {
-    vec_c(!!!x, .ptype = ptype)
+    has_list_of_list <- any(map_lgl(x, vec_is_list))
   }
-}
-
-# 1 row; n cols
-vec_to_wide <- function(x, col, names_sep = NULL) {
-  if (is.null(x)) {
-    return(NULL)
+  if (has_list_of_list) {
+    return(x)
   }
 
-  if (!is.null(names_sep)) {
-    names(x) <- paste0(col, names_sep, index(x))
-  }
+  # Don't try and simplify non-vectors. list-of types always contain vectors.
+  if (!is_list_of(x)) {
+    has_non_vector <- any(!map_lgl(x, ~ vec_is(.x) || is.null(.x)))
 
-  if (is.data.frame(x)) {
-    as_tibble(map(x, list))
-  } else if (vec_is(x)) {
-    if (is.list(x)) {
-      x <- purrr::compact(x)
-      x <- map(x, list)
-    } else {
-      x <- as.list(x)
+    if (has_non_vector) {
+      return(x)
     }
-    as_tibble(x, .name_repair = "unique", .rows = 1L)
-  } else {
-    stop("Input must be list of vectors", call. = FALSE)
   }
-}
 
-# 1 col; n rows
-vec_to_long <- function(x, col, values_to, indices_to, indices_include = NULL) {
-  if (is.null(x)) {
-    NULL
-  } else if (is.data.frame(x)) {
-    tibble(!!col := x)
-  } else if (vec_is(x)) {
+  # Ensure empty elements are filled in with their correct size 1 equivalent
+  info <- list_init_empty(x, null = TRUE, typed = TRUE)
 
-    indices_include <- indices_include %||% !is.null(names(x))
+  sizes <- info$sizes
 
-    if (isTRUE(indices_include)) {
-      tibble(
-        !!values_to := x,
-        !!indices_to := index(x)
-      )
-    } else {
-      tibble(!!values_to := x)
-    }
-  } else {
-    stop("Input must be list of vectors", call. = FALSE)
+  # Don't try to simplify if there are any size >1 left at this point
+  has_non_scalar <- any(sizes != 1L)
+  if (has_non_scalar) {
+    return(x)
   }
-}
 
-index <- function(x) {
-  names(x) %||% seq_along(x)
+  x_scalars <- info$x
+  x_ptype <- list_of_ptype(x)
+
+  # Assume that if combining fails, then we want to return the object
+  # after the `ptype` and `transform` have been applied, but before the
+  # empty element filling was applied
+  tryCatch(
+    vec_unchop(x_scalars, ptype = x_ptype),
+    vctrs_error_incompatible_type = function(e) x
+  )
 }

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -677,13 +677,20 @@ elt_to_wide <- function(x, name, strict, names_sep) {
     }
   }
 
-  if (!is.null(names_sep)) {
+  if (is.null(names_sep)) {
+    names(x) <- vec_as_names(names2(x), repair = "unique")
+  } else {
     outer <- name
-    inner <- vec_names(x) %||% vec_seq_along(x)
+
+    inner <- names(x)
+    if (is.null(inner)) {
+      inner <- as.character(seq_along(x))
+    } else {
+      inner <- vec_as_names(inner, repair = "unique")
+    }
+
     names(x) <- apply_names_sep(outer, inner, names_sep)
   }
-
-  names(x) <- vec_as_names(names2(x), repair = "unique")
 
   x <- new_data_frame(x, n = 1L)
 

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -12,10 +12,6 @@
 #'
 #' Learn more in `vignette("rectangle")`.
 #'
-#' @details
-#' When both `ptype` and `transform` are supplied, the `transform` is applied
-#' before the `ptype`.
-#'
 #' @section Unnest variants:
 #'
 #' The three `unnest()` functions differ in how they change the shape of the
@@ -69,6 +65,9 @@
 #' @param .transform,transform Optionally, a named list of transformation
 #'   functions applied to each component. Use this function if you want
 #'   to transform or parse individual elements as they are extracted.
+#'
+#'   When both `ptype` and `transform` are supplied, the `transform` is applied
+#'   before the `ptype`.
 #' @param .remove If `TRUE`, the default, will remove extracted components
 #'   from `.col`. This ensures that each value lives only in one place. If all
 #'   components are removed from `.col`, then `.col` will be removed from the

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -289,15 +289,17 @@ strike <- function(x, indices) {
 
 #' @export
 #' @rdname hoist
-#' @param values_to A single string representing the column name to store the
+#' @param values_to A string giving the column name (or names) to store the
 #'   unnested values in. If multiple columns are specified in `col`, this can
 #'   also be a glue string containing `"{col}"` to provide a template for the
-#'   column names. If `NULL`, defaults to `"{col}"`.
-#' @param indices_to A string giving the name of the column which will contain
+#'   column names. The default, `NULL`, gives the output columns the same names
+#'   as the input columns.
+#' @param indices_to A string giving the column name (or names) to store the
 #'   the inner names or positions (if not named) of the values. If multiple
 #'   columns are specified in `col`, this can also be a glue string containing
-#'   `"{col}"` to provide a template for the column names. If `NULL`, defaults
-#'   to `values_to` suffixed with `"_id"`.
+#'   `"{col}"` to provide a template for the column names. The default, `NULL`,
+#'   gives the output columns the same names as `values_to`, but suffixed with
+#'   `"_id"`.
 #' @param indices_include A single logical value specifying whether or not to
 #'   add an index column. If any value has inner names, the index column will be
 #'   a character vector of those names, otherwise it will be an integer vector

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -306,7 +306,7 @@ strike <- function(x, indices) {
 #'   of positions. If `NULL`, defaults to `TRUE` if any value has inner names
 #'   or if `indices_to` is provided.
 #'
-#'   If `indices_to` is provided, then `indices_include` can't be `FALSE`.
+#'   If `indices_to` is provided, then `indices_include` must not be `FALSE`.
 #' @inheritParams unnest
 unnest_longer <- function(data,
                           col,

--- a/R/utils.R
+++ b/R/utils.R
@@ -130,9 +130,11 @@ tidyr_new_list <- function(x) {
   x
 }
 
-# What `vec_chop2()` would be.
-# Equivalent to `vec_chop(x)`, but moves names of `x` to the result.
-tidyr_chop2 <- function(x) {
+# Version of `vec_chop()` that is always called without `indices`.
+# We move the names of `x` onto the result.
+# Not that same as a hypothetical `vec_chop2()`, because that would index into
+# lists with `vec_slice2()` rather than `vec_slice()`.
+tidyr_chop <- function(x) {
   names <- vec_names(x)
 
   if (!is.null(names)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -130,26 +130,6 @@ tidyr_new_list <- function(x) {
   x
 }
 
-# Version of `vec_chop()` that is always called without `indices`.
-# We move the names of `x` onto the result.
-# Not that same as a hypothetical `vec_chop2()`, because that would index into
-# lists with `vec_slice2()` rather than `vec_slice()`.
-tidyr_chop <- function(x) {
-  names <- vec_names(x)
-
-  if (!is.null(names)) {
-    x <- vec_set_names(x, NULL)
-  }
-
-  out <- vec_chop(x)
-
-  if (!is.null(names)) {
-    out <- vec_set_names(out, names)
-  }
-
-  out
-}
-
 # "Initializes" empty values to their size 1 equivalent
 # - Can initialize `NULL` to either `unspecified(1)` or a list-of ptype
 # - Can initialize typed empty elements to `vec_init(x, 1L)` or a list-of ptype

--- a/R/utils.R
+++ b/R/utils.R
@@ -148,6 +148,16 @@ tidyr_chop2 <- function(x) {
   out
 }
 
+list_of_ptype <- function(x) {
+  ptype <- attr(x, "ptype", exact = TRUE)
+
+  # ptypes should always be unnamed, but this isn't guaranteed right now.
+  # See https://github.com/r-lib/vctrs/pull/1020#discussion_r411327472
+  ptype <- vec_set_names(ptype, NULL)
+
+  ptype
+}
+
 apply_names_sep <- function(outer, inner, names_sep) {
   as.character(glue("{outer}{names_sep}{inner}"))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -148,6 +148,62 @@ tidyr_chop2 <- function(x) {
   out
 }
 
+# "Initializes" empty values to their size 1 equivalent
+# - Can initialize `NULL` to either `unspecified(1)` or a list-of ptype
+# - Can initialize typed empty elements to `vec_init(x, 1L)` or a list-of ptype
+# Returns a list containing:
+# - Updated `x`
+# - `sizes`, an integer vector containing updated sizes for the elements of `x`
+# - `null`, a logical vector indicating the original `NULL` values
+# - `typed`, a logical vector indicating the original empty typed values
+list_init_empty <- function(x,
+                            ...,
+                            null = TRUE,
+                            typed = TRUE) {
+  ellipsis::check_dots_empty()
+
+  if (!vec_is_list(x)) {
+    abort("Internal error: `x` must be a list.")
+  }
+
+  sizes <- list_sizes(x)
+  empty_null <- vec_equal_na(x)
+  empty_typed <- (sizes == 0L) & !empty_null
+
+  if (null && any(empty_null)) {
+    # Replace `NULL` elements with their size 1 equivalent
+
+    if (is_list_of(x)) {
+      ptype <- list_of_ptype(x)
+      replacement <- list(vec_init(ptype, n = 1L))
+      replacement <- new_list_of(replacement, ptype = ptype)
+    } else {
+      replacement <- list(unspecified(1L))
+    }
+
+    x <- vec_assign(x, empty_null, replacement)
+    sizes[empty_null] <- 1L
+  }
+
+  if (typed && any(empty_typed)) {
+    # Replace empty typed elements with their size 1 equivalent
+
+    if (is_list_of(x)) {
+      ptype <- list_of_ptype(x)
+      replacement <- list(vec_init(ptype, n = 1L))
+      replacement <- new_list_of(replacement, ptype = ptype)
+    } else {
+      # `vec_init()` is slow, see r-lib/vctrs#1423, so use `vec_slice()` equivalent
+      replacement <- map(vec_slice(x, empty_typed), vec_slice, i = NA_integer_)
+    }
+
+    x <- vec_assign(x, empty_typed, replacement)
+    sizes[empty_typed] <- 1L
+  }
+
+  list(x = x, sizes = sizes, null = empty_null, typed = empty_typed)
+}
+
 list_of_ptype <- function(x) {
   ptype <- attr(x, "ptype", exact = TRUE)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -130,6 +130,24 @@ tidyr_new_list <- function(x) {
   x
 }
 
+# What `vec_chop2()` would be.
+# Equivalent to `vec_chop(x)`, but moves names of `x` to the result.
+tidyr_chop2 <- function(x) {
+  names <- vec_names(x)
+
+  if (!is.null(names)) {
+    x <- vec_set_names(x, NULL)
+  }
+
+  out <- vec_chop(x)
+
+  if (!is.null(names)) {
+    out <- vec_set_names(out, names)
+  }
+
+  out
+}
+
 apply_names_sep <- function(outer, inner, names_sep) {
   as.character(glue("{outer}{names_sep}{inner}"))
 }

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -106,7 +106,7 @@ a character vector of those names, otherwise it will be an integer vector
 of positions. If \code{NULL}, defaults to \code{TRUE} if any value has inner names
 or if \code{indices_to} is provided.
 
-If \code{indices_to} is provided, then \code{indices_include} can't be \code{FALSE}.}
+If \code{indices_to} is provided, then \code{indices_include} must not be \code{FALSE}.}
 
 \item{names_repair}{Used to check that output data frame has valid
 names. Must be one of the following options:

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -34,6 +34,7 @@ unnest_wider(
   col,
   names_sep = NULL,
   simplify = TRUE,
+  strict = FALSE,
   names_repair = "check_unique",
   ptype = list(),
   transform = list()
@@ -44,7 +45,12 @@ unnest_auto(data, col)
 \arguments{
 \item{.data, data}{A data frame.}
 
-\item{.col, col}{List-column to extract components from.}
+\item{.col, col}{List-column to extract components from.
+
+For \code{hoist()} and \code{unnest_auto()}, this must identify a single column.
+
+For \code{unnest_wider()} and \code{unnest_longer()}, you can use tidyselect to
+select multiple columns to unnest simultaneously.}
 
 \item{...}{Components of \code{.col} to turn into columns in the form
 \code{col_name = "pluck_specification"}. You can pluck by name with a character
@@ -57,27 +63,43 @@ single string you can choose to omit the name, i.e. \code{hoist(df, col, "x")}
 is short-hand for \code{hoist(df, col, x = "x")}.}
 
 \item{.remove}{If \code{TRUE}, the default, will remove extracted components
-from \code{.col}. This ensures that each value lives only in one place.}
+from \code{.col}. This ensures that each value lives only in one place. If all
+components are removed from \code{.col}, then \code{.col} will be removed from the
+result entirely.}
 
 \item{.simplify, simplify}{If \code{TRUE}, will attempt to simplify lists of
-length-1 vectors to an atomic vector}
+length-1 vectors to an atomic vector.}
 
-\item{.ptype, ptype}{Optionally, a named list of prototypes declaring the desired
-output type of each component. Use this argument if you want to check each
-element has the types you expect when simplifying.}
+\item{.ptype, ptype}{Optionally, a named list of prototypes declaring the
+desired output type of each component. Use this argument if you want to
+check that each element has the type you expect when simplifying.
 
-\item{.transform, transform}{Optionally, a named list of transformation functions
-applied to each component. Use this function if you want transform or
-parse individual elements as they are hoisted.}
+If a \code{ptype} has been specified, but \code{simplify = FALSE} or simplification
+isn't possible, then a list-of column will be returned and each element
+will have type \code{ptype}.}
 
-\item{values_to}{Name of column to store vector values. Defaults to \code{col}.}
+\item{.transform, transform}{Optionally, a named list of transformation
+functions applied to each component. Use this function if you want
+to transform or parse individual elements as they are extracted.}
 
-\item{indices_to}{A string giving the name of column which will contain the
-inner names or position (if not named) of the values. Defaults to \code{col}
-with \verb{_id} suffix}
+\item{values_to}{A single string representing the column name to store the
+unnested values in. If multiple columns are specified in \code{col}, this can
+also be a glue string containing \code{"{col}"} to provide a template for the
+column names. If \code{NULL}, defaults to \code{"{col}"}.}
 
-\item{indices_include}{Add an index column? Defaults to \code{TRUE} when \code{col}
-has inner names.}
+\item{indices_to}{A string giving the name of the column which will contain
+the inner names or positions (if not named) of the values. If multiple
+columns are specified in \code{col}, this can also be a glue string containing
+\code{"{col}"} to provide a template for the column names. If \code{NULL}, defaults
+to \code{values_to} suffixed with \code{"_id"}.}
+
+\item{indices_include}{A single logical value specifying whether or not to
+add an index column. If any value has inner names, the index column will be
+a character vector of those names, otherwise it will be an integer vector
+of positions. If \code{NULL}, defaults to \code{TRUE} if any value has inner names
+or if \code{indices_to} is provided.
+
+If \code{indices_to} is provided, then \code{indices_include} can't be \code{FALSE}.}
 
 \item{names_repair}{Used to check that output data frame has valid
 names. Must be one of the following options:
@@ -95,8 +117,19 @@ See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on 
 strategies used to enforce them.}
 
 \item{names_sep}{If \code{NULL}, the default, the names will be left
-as is. If a string, the inner and outer names will be paste together using
-\code{names_sep} as a separator.}
+as is. If a string, the outer and inner names will be pasted together using
+\code{names_sep} as a separator.
+
+If the values being unnested are unnamed and \code{names_sep} is supplied, the
+inner names will be automatically generated as an increasing sequence of
+integers.}
+
+\item{strict}{A single logical specifying whether or not to apply strict
+vctrs typing rules. If \code{FALSE}, typed empty values (like \code{list()} or
+\code{integer()}) nested within list-columns will be treated like \code{NULL} and
+will not contribute to the type of the unnested column. This is useful
+when working with JSON, where empty values tend to lose their type
+information and show up as \code{list()}.}
 }
 \description{
 \code{hoist()}, \code{unnest_longer()}, and \code{unnest_wider()} provide tools for
@@ -110,6 +143,10 @@ based on heuristics described below.
 
 Learn more in \code{vignette("rectangle")}.
 }
+\details{
+When both \code{ptype} and \code{transform} are supplied, the \code{transform} is applied
+before the \code{ptype}.
+}
 \section{Unnest variants}{
 
 
@@ -118,14 +155,14 @@ output data frame:
 \itemize{
 \item \code{unnest_wider()} preserves the rows, but changes the columns.
 \item \code{unnest_longer()} preserves the columns, but changes the rows
-\item \code{unnest()} can change both rows and columns.
+\item \code{\link[=unnest]{unnest()}} can change both rows and columns.
 }
 
 These principles guide their behaviour when they are called with a
 non-primary data type. For example, if you \code{unnest_wider()} a list of data
 frames, the number of rows must be preserved, so each column is turned into
 a list column of length one. Or if you \code{unnest_longer()} a list of data
-frame, the number of columns must be preserved so it creates a packed
+frames, the number of columns must be preserved so it creates a packed
 column. I'm not sure how if these behaviours are useful in practice, but
 they are theoretically pleasing.
 }
@@ -134,9 +171,10 @@ they are theoretically pleasing.
 
 \code{unnest_auto()} inspects the inner names of the list-col:
 \itemize{
-\item If all elements are unnamed, it uses \code{unnest_longer()}
+\item If all elements are unnamed, it uses
+\code{unnest_longer(indices_include = FALSE)}.
 \item If all elements are named, and there's at least one name in
-common acros all components, it uses \code{unnest_wider()}
+common across all components, it uses \code{unnest_wider()}.
 \item Otherwise, it falls back to \code{unnest_longer(indices_include = TRUE)}.
 }
 }
@@ -197,4 +235,36 @@ df <- tibble(
 df \%>\% unnest_wider(y)
 df \%>\% unnest_longer(y)
 
+# Both unnest_wider() and unnest_longer() allow you to unnest multiple
+# columns at once. This is particularly useful with unnest_longer(), where
+# unnesting sequentially would generate a cartesian product of the rows.
+df <- tibble(
+  x = 1:2,
+  y = list(1:2, 3:4),
+  z = list(5:6, 7:8)
+)
+unnest_longer(df, c(y, z))
+unnest_longer(unnest_longer(df, y), z)
+
+# With JSON, it is common for empty elements to be represented by `list()`
+# rather then their typed equivalent, like `integer()`
+json <- list(
+  list(x = 1:2, y = 1:2),
+  list(x = list(), y = 3:4),
+  list(x = 3L, y = list())
+)
+df <- tibble(json = json)
+
+# The defaults of `unnest_wider()` treat empty types (like `list()`) as `NULL`.
+# This chains nicely into `unnest_longer()`.
+wide <- unnest_wider(df, json)
+wide
+
+unnest_longer(wide, c(x, y))
+
+# To instead enforce strict vctrs typing rules, use `strict`
+wide_strict <- unnest_wider(df, json, strict = TRUE)
+wide_strict
+
+try(unnest_longer(wide_strict, c(x, y)))
 }

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -87,16 +87,18 @@ to transform or parse individual elements as they are extracted.
 When both \code{ptype} and \code{transform} are supplied, the \code{transform} is applied
 before the \code{ptype}.}
 
-\item{values_to}{A single string representing the column name to store the
+\item{values_to}{A string giving the column name (or names) to store the
 unnested values in. If multiple columns are specified in \code{col}, this can
 also be a glue string containing \code{"{col}"} to provide a template for the
-column names. If \code{NULL}, defaults to \code{"{col}"}.}
+column names. The default, \code{NULL}, gives the output columns the same names
+as the input columns.}
 
-\item{indices_to}{A string giving the name of the column which will contain
+\item{indices_to}{A string giving the column name (or names) to store the
 the inner names or positions (if not named) of the values. If multiple
 columns are specified in \code{col}, this can also be a glue string containing
-\code{"{col}"} to provide a template for the column names. If \code{NULL}, defaults
-to \code{values_to} suffixed with \code{"_id"}.}
+\code{"{col}"} to provide a template for the column names. The default, \code{NULL},
+gives the output columns the same names as \code{values_to}, but suffixed with
+\code{"_id"}.}
 
 \item{indices_include}{A single logical value specifying whether or not to
 add an index column. If any value has inner names, the index column will be

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -80,7 +80,10 @@ will have type \code{ptype}.}
 
 \item{.transform, transform}{Optionally, a named list of transformation
 functions applied to each component. Use this function if you want
-to transform or parse individual elements as they are extracted.}
+to transform or parse individual elements as they are extracted.
+
+When both \code{ptype} and \code{transform} are supplied, the \code{transform} is applied
+before the \code{ptype}.}
 
 \item{values_to}{A single string representing the column name to store the
 unnested values in. If multiple columns are specified in \code{col}, this can
@@ -142,10 +145,6 @@ in to their own top-level columns, using the same syntax as \code{\link[purrr:pl
 based on heuristics described below.
 
 Learn more in \code{vignette("rectangle")}.
-}
-\details{
-When both \code{ptype} and \code{transform} are supplied, the \code{transform} is applied
-before the \code{ptype}.
 }
 \section{Unnest variants}{
 

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -50,7 +50,9 @@ unnest_auto(data, col)
 For \code{hoist()} and \code{unnest_auto()}, this must identify a single column.
 
 For \code{unnest_wider()} and \code{unnest_longer()}, you can use tidyselect to
-select multiple columns to unnest simultaneously.}
+select multiple columns to unnest simultaneously. When using
+\code{unnest_longer()} with multiple columns, values across columns that
+originated from the same row are recycled to a common size.}
 
 \item{...}{Components of \code{.col} to turn into columns in the form
 \code{col_name = "pluck_specification"}. You can pluck by name with a character

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -75,8 +75,8 @@ desired output type of each component. Use this argument if you want to
 check that each element has the type you expect when simplifying.
 
 If a \code{ptype} has been specified, but \code{simplify = FALSE} or simplification
-isn't possible, then a list-of column will be returned and each element
-will have type \code{ptype}.}
+isn't possible, then a \link[vctrs:list_of]{list-of} column will be returned
+and each element will have type \code{ptype}.}
 
 \item{.transform, transform}{Optionally, a named list of transformation
 functions applied to each component. Use this function if you want

--- a/tests/testthat/_snaps/rectangle.md
+++ b/tests/testthat/_snaps/rectangle.md
@@ -44,6 +44,51 @@
     Error <rlang_error>
       Column `y` must contain a list of vectors.
 
+# can unnest a vector with a mix of named/unnamed elements (#1200 comment)
+
+    Code
+      out <- unnest_wider(df, x, names_sep = "_")
+    Message <simpleMessage>
+      New names:
+      * `` -> ...1
+
+# unique name repair is done on the elements before applying `names_sep` (#1200 comment)
+
+    Code
+      out <- unnest_wider(df, col, names_sep = "_")
+    Message <simpleMessage>
+      New names:
+      * `` -> ...1
+
+---
+
+    Code
+      out <- unnest_wider(df, col, names_sep = "_")
+    Message <simpleMessage>
+      New names:
+      * `` -> ...1
+      * `` -> ...2
+
+# output structure is the same whether or not `names_sep` is applied (#1200 comment)
+
+    Code
+      out1 <- unnest_wider(df, col)
+    Message <simpleMessage>
+      New names:
+      * `` -> ...1
+      New names:
+      * `` -> ...1
+
+---
+
+    Code
+      out2 <- unnest_wider(df, col, names_sep = "_")
+    Message <simpleMessage>
+      New names:
+      * NA -> ...1
+      New names:
+      * `` -> ...1
+
 # can't currently combine compatible `<list> + <list_of<ptype>>`
 
     Code

--- a/tests/testthat/_snaps/rectangle.md
+++ b/tests/testthat/_snaps/rectangle.md
@@ -121,6 +121,60 @@
     Error <rlang_error>
       `indices_include` must be `NULL` or a single `TRUE` or `FALSE`.
 
+# `simplify` is validated
+
+    Code
+      (expect_error(df_simplify(data.frame(), simplify = 1)))
+    Output
+      <error/rlang_error>
+      `simplify` must be a single `TRUE` or `FALSE`.
+    Code
+      (expect_error(df_simplify(data.frame(), simplify = NA)))
+    Output
+      <error/rlang_error>
+      `simplify` must be a single `TRUE` or `FALSE`.
+    Code
+      (expect_error(df_simplify(data.frame(), simplify = c(TRUE, FALSE))))
+    Output
+      <error/rlang_error>
+      `simplify` must be a single `TRUE` or `FALSE`.
+
+# `ptype` is validated
+
+    Code
+      (expect_error(df_simplify(data.frame(), ptype = 1)))
+    Output
+      <error/rlang_error>
+      `ptype` must be a list.
+    Code
+      (expect_error(df_simplify(data.frame(), ptype = list(1))))
+    Output
+      <error/rlang_error>
+      All elements of `ptype` must be named.
+    Code
+      (expect_error(df_simplify(data.frame(), ptype = list(x = 1, x = 1))))
+    Output
+      <error/rlang_error>
+      The names of `ptype` must be unique.
+
+# `transform` is validated
+
+    Code
+      (expect_error(df_simplify(data.frame(), transform = 1)))
+    Output
+      <error/rlang_error>
+      `transform` must be a list.
+    Code
+      (expect_error(df_simplify(data.frame(), transform = list(1))))
+    Output
+      <error/rlang_error>
+      All elements of `transform` must be named.
+    Code
+      (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))
+    Output
+      <error/rlang_error>
+      The names of `transform` must be unique.
+
 # ptype is applied after transform
 
     Code

--- a/tests/testthat/_snaps/rectangle.md
+++ b/tests/testthat/_snaps/rectangle.md
@@ -1,0 +1,131 @@
+# nested lists generate a cast error if they can't be cast to the ptype
+
+    Code
+      hoist(df, x, "b", .ptype = list(b = double()))
+    Error <vctrs_error_incompatible_type>
+      Can't convert <list> to <double>.
+
+# non-vectors generate a cast error if a ptype is supplied
+
+    Code
+      hoist(df, x, "b", .ptype = list(b = integer()))
+    Error <vctrs_error_scalar_type>
+      Input must be a vector, not a symbol.
+
+# input validation catches problems
+
+    Code
+      (expect_error(df %>% hoist(y)))
+    Output
+      <error/rlang_error>
+      `.col` must identify a list-column.
+    Code
+      (expect_error(df %>% hoist(x, 1)))
+    Output
+      <error/rlang_error>
+      All elements of `...` must be named.
+    Code
+      (expect_error(df %>% hoist(x, a = "a", a = "b")))
+    Output
+      <error/rlang_error>
+      The names of `...` must be unique.
+
+# can't hoist() from a data frame column
+
+    Code
+      hoist(df, a, xx = 1)
+    Error <rlang_error>
+      `.col` must identify a list-column.
+
+# unnest_wider - bad inputs generate errors
+
+    Code
+      unnest_wider(df, y)
+    Error <rlang_error>
+      Column `y` must contain a list of vectors.
+
+# can't currently combine compatible `<list> + <list_of<ptype>>`
+
+    Code
+      unnest_wider(df, col)
+    Error <vctrs_error_incompatible_type>
+      Can't combine `..1$a` <list> and `..3$a` <list_of<integer>>.
+
+# unnest_longer - bad inputs generate errors
+
+    Code
+      unnest_longer(df, y)
+    Error <rlang_error>
+      Column `y` must contain a list of vectors.
+
+# can't mix `indices_to` with `indices_include = FALSE`
+
+    Code
+      unnest_longer(mtcars, mpg, indices_to = "x", indices_include = FALSE)
+    Error <rlang_error>
+      Can't set `indices_include` to `FALSE` when `indices_to` is supplied.
+
+# `values_to` and `indices_to` glue can't reach into surrounding env
+
+    Code
+      unnest_longer(mtcars, mpg, indices_to = "{x}")
+    Error <simpleError>
+      object 'x' not found
+
+---
+
+    Code
+      unnest_longer(mtcars, mpg, values_to = "{x}")
+    Error <simpleError>
+      object 'x' not found
+
+# `values_to` is validated
+
+    Code
+      unnest_longer(mtcars, mpg, values_to = 1)
+    Error <rlang_error>
+      `values_to` must be a single string or `NULL`.
+
+---
+
+    Code
+      unnest_longer(mtcars, mpg, values_to = c("x", "y"))
+    Error <rlang_error>
+      `values_to` must be a single string or `NULL`.
+
+# `indices_to` is validated
+
+    Code
+      unnest_longer(mtcars, mpg, indices_to = 1)
+    Error <rlang_error>
+      `indices_to` must be a single string or `NULL`.
+
+---
+
+    Code
+      unnest_longer(mtcars, mpg, indices_to = c("x", "y"))
+    Error <rlang_error>
+      `indices_to` must be a single string or `NULL`.
+
+# `indices_include` is validated
+
+    Code
+      unnest_longer(mtcars, mpg, indices_include = 1)
+    Error <rlang_error>
+      `indices_include` must be `NULL` or a single `TRUE` or `FALSE`.
+
+---
+
+    Code
+      unnest_longer(mtcars, mpg, indices_include = c(TRUE, FALSE))
+    Error <rlang_error>
+      `indices_include` must be `NULL` or a single `TRUE` or `FALSE`.
+
+# ptype is applied after transform
+
+    Code
+      col_simplify(list(1, 2, 3), ptype = integer(), transform = ~.x + 1.5)
+    Error <vctrs_error_cast_lossy>
+      Can't convert from <double> to <integer> due to loss of precision.
+      * Locations: 1
+

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -314,6 +314,12 @@ test_that("df-cols can be unnested (#1188)", {
   expect_identical(out, unpack(df, b))
 })
 
+test_that("df-cols result in list-ofs when `simplify = FALSE`", {
+  df <- tibble(a = 1:3, b = tibble(x = 1:3, y = 1:3))
+  out <- unnest_wider(df, b, simplify = FALSE)
+  expect_identical(out, tibble(a = 1:3, x = list_of(1L, 2L, 3L), y = list_of(1L, 2L, 3L)))
+})
+
 test_that("unnesting mixed empty types retains the column (#1125)", {
   df <- tibble(col = list(list(a = list()), list(a = integer())))
   expect_identical(unnest_wider(df, col), tibble(a = c(NA, NA)))

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -10,34 +10,43 @@ test_that("hoist extracts named elements", {
   expect_identical(out, tibble(a = list(1), b = list("b")))
 })
 
+test_that("can hoist named non-list elements at the deepest level", {
+  df <- tibble(x = list(list(a = c(aa = 1, bb = 2))))
+  out <- hoist(df, x, bb = list("a", "bb"))
+  expect_identical(out$bb, 2)
+})
+
 test_that("can check check/transform values", {
   df <- tibble(x = list(
     list(a = 1),
     list(a = "a")
   ))
 
-  if (packageVersion("vctrs") > "0.2.4") {
-    expect_error(
-      df %>% hoist(x, a = "a", .ptype = list(a = character())),
-      class = "vctrs_error_incompatible_type"
-    )
-  }
+  expect_error(
+    df %>% hoist(x, a = "a", .ptype = list(a = character())),
+    class = "vctrs_error_incompatible_type"
+  )
 
   out <- df %>% hoist(x, a = "a", .transform = list(a = as.character))
   expect_equal(out, tibble(a = c("1", "a")))
 })
 
-test_that("supplying ptype increases stringency of simplify", {
-  df <- tibble(x = list(
-    list(a = 1:2, b = list(list()), c = quote(a)),
-    list(a = 1, b = list(list()), c = quote(b)),
-    list(a = 1, b = list(list()), c = NULL)
-  ))
+test_that("nested lists generate a cast error if they can't be cast to the ptype", {
+  df <- tibble(x = list(list(b = list(1))))
+  expect_snapshot(error = TRUE, hoist(df, x, "b", .ptype = list(b = double())))
+})
 
-  ptype <- list(a = integer(), b = integer(), c = integer())
-  expect_error(df %>% hoist(x, "a", .ptype = ptype), "length > 1")
-  expect_error(df %>% hoist(x, "b", .ptype = ptype), "nested list")
-  expect_error(df %>% hoist(x, "c", .ptype = ptype), "non-vector")
+test_that("non-vectors generate a cast error if a ptype is supplied", {
+  df <- tibble(x = list(list(b = quote(a))))
+  expect_snapshot(error = TRUE, hoist(df, x, "b", .ptype = list(b = integer())))
+})
+
+test_that("a ptype generates a list-of<ptype> if the col can't be simplified (#998)", {
+  df <- tibble(x = list(list(a = 1:2), list(a = 1), list(a = 1)))
+  ptype = list(a = integer())
+
+  out <- hoist(df, x, "a", .ptype = ptype)
+  expect_identical(out$a, list_of(1:2, 1L, 1L, .ptype = integer()))
 })
 
 test_that("doesn't simplify uneven lengths", {
@@ -47,7 +56,7 @@ test_that("doesn't simplify uneven lengths", {
   ))
 
   out <- df %>% hoist(x, a = "a")
-  expect_equal(out$a, list(1, 2:3))
+  expect_identical(out$a, list(1, 2:3))
 })
 
 test_that("doesn't simplify lists of lists", {
@@ -57,7 +66,7 @@ test_that("doesn't simplify lists of lists", {
   ))
 
   out <- df %>% hoist(x, a = "a")
-  expect_equal(out$a, list(list(1), list(2)))
+  expect_identical(out$a, list(list(1), list(2)))
 })
 
 test_that("doesn't simplify non-vectors", {
@@ -67,7 +76,7 @@ test_that("doesn't simplify non-vectors", {
   ))
 
   out <- df %>% hoist(x, a = "a")
-  expect_equal(out$a, list(quote(a), quote(b)))
+  expect_identical(out$a, list(quote(a), quote(b)))
 })
 
 test_that("can hoist out scalars", {
@@ -79,15 +88,17 @@ test_that("can hoist out scalars", {
     )
   )
   out <- hoist(df, y, "mod")
-  expect_equal(out$mod, list(df$y[[1]]$mod, df$y[[2]]$mod))
+  expect_identical(out$mod, list(df$y[[1]]$mod, df$y[[2]]$mod))
 })
 
 test_that("input validation catches problems", {
   df <- tibble(x = list(list(1, b = "b")), y = 1)
 
-  expect_error(df %>% hoist(y), "list-column")
-  expect_error(df %>% hoist(x, 1), "named")
-  expect_error(df %>% hoist(x, a = "a", a = "b"), "unique")
+  expect_snapshot({
+    (expect_error(df %>% hoist(y)))
+    (expect_error(df %>% hoist(x, 1)))
+    (expect_error(df %>% hoist(x, a = "a", a = "b")))
+  })
 })
 
 test_that("string pluckers are automatically named", {
@@ -95,27 +106,56 @@ test_that("string pluckers are automatically named", {
   expect_named(out, c("x", "y", "z"))
 })
 
+test_that("can't hoist() from a data frame column", {
+  df <- tibble(a = tibble(x = 1))
+  expect_snapshot(error = TRUE, hoist(df, a, xx = 1))
+})
+
+test_that("can hoist() without any pluckers", {
+  df <- tibble(a = list(1))
+  expect_identical(hoist(df, a), df)
+})
+
+test_that("can use a character vector for deep hoisting", {
+  df <- tibble(x = list(list(b = list(a = 1))))
+  out <- hoist(df, x, ba = c("b", "a"))
+  expect_identical(out$ba, 1)
+})
+
+test_that("can use a numeric vector for deep hoisting", {
+  df <- tibble(x = list(list(b = list(a = 1, b = 2))))
+  out <- hoist(df, x, bb = c(1, 2))
+  expect_identical(out$bb, 2)
+})
+
+test_that("can't maintain type stability with empty elements due to `purrr::pluck()` (#1203)", {
+  # We want to be notified if this changes in purrr, but not error on CRAN
+  skip_on_cran()
+
+  df <- tibble(
+    col = list(
+      list(a = integer()),
+      list(a = integer())
+    )
+  )
+
+  out <- hoist(df, col, "a")
+
+  # Ideally:
+  # expect_identical(out$a, c(NA_integer_, NA_integer_))
+  expect_identical(out$a, c(NA, NA))
+})
+
+test_that("can hoist out a rcrd style column (#999)", {
+  x <- new_rcrd(list(x = 1, y = 2))
+  df <- tibble(a = list(list(x = x), list(x = x)))
+
+  out <- hoist(df, a, "x")
+
+  expect_identical(out$x, vec_c(x, x))
+})
+
 # strike ------------------------------------------------------------------
-
-test_that("strike can remove using a character vector", {
-  x <- list(a = list(), b = list(a = 1, b = 2), c = "c")
-
-  expect_equal(strike(x, "a"), x[c("b", "c")])
-  expect_equal(strike(x, "c"), x[c("a", "b")])
-
-  deep <- strike(x, c("b", "b"))
-  expect_equal(deep, list(a = list(), b = list(a = 1), c = "c"))
-})
-
-test_that("strike can remove using an integer vector", {
-  x <- list(a = list(), b = list(a = 1, b = 2), c = "c")
-
-  expect_equal(strike(x, 1), x[c(2, 3)])
-  expect_equal(strike(x, "c"), x[c("a", "b")])
-
-  deep <- strike(x, c(2, 2))
-  expect_equal(deep, list(a = list(), b = list(a = 1), c = "c"))
-})
 
 test_that("strike can remove using a list", {
   x <- list(a = list(), b = list(a = 1, b = 2), c = "c")
@@ -130,8 +170,8 @@ test_that("strike can remove using a list", {
 test_that("strike returns input if idx not present", {
   x <- list(a = list(), b = list(a = 1, b = 2), c = "c")
 
-  expect_equal(strike(x, 4), x)
-  expect_equal(strike(x, "d"), x)
+  expect_equal(strike(x, list(4)), x)
+  expect_equal(strike(x, list("d")), x)
   expect_equal(strike(x, list("b", 3)), x)
   expect_equal(strike(x, list("d", 3)), x)
   expect_equal(strike(x, list("b", "c")), x)
@@ -142,9 +182,7 @@ test_that("strike returns input if idx not present", {
 test_that("ignores weird inputs", {
   x <- list(a = list(), b = list(a = 1, b = 2), c = "c")
 
-  expect_equal(strike(x, NULL), x)
   expect_equal(strike(x, list()), x)
-  expect_equal(strike(x, mean), x)
   expect_equal(strike(x, list(mean, mean)), x)
 })
 
@@ -175,24 +213,36 @@ test_that("simplifies length-1 lists", {
 
   # Works when casting too
   out <- df %>% unnest_wider(y,
-    ptype = list(a = double(), b = double())
+    ptype = list(a = integer(), b = integer())
   )
-  expect_equal(out$a, c(1, 3))
-  expect_equal(out$b, c(2, NA))
+  expect_equal(out$a, c(1L, 3L))
+  expect_equal(out$b, c(2L, NA))
   expect_equal(out$c, list(c(1, 2), NULL))
 })
 
-test_that("can handle data frames consistently with vectors" , {
-  df <- tibble(x = 1:2, y = list(tibble(a = 1:2, b = 2:3)))
+test_that("treats data frames like lists where we have type info about each element" , {
+  df <- tibble(x = 1:2, y = list(tibble(a = 1:2)))
   out <- df %>% unnest_wider(y)
 
-  expect_named(out, c("x", "a", "b"))
+  expect_named(out, c("x", "a"))
   expect_equal(nrow(out), 2)
+
+  # We know the types of this, even though we can't simplify it
+  expect_identical(attr(out$a, "ptype"), integer())
+
+  df <- tibble(x = 1:2, y = list(list(a = 1:2)))
+  out <- df %>% unnest_wider(y)
+
+  expect_named(out, c("x", "a"))
+  expect_equal(nrow(out), 2)
+
+  # We don't know the types of this
+  expect_identical(class(out$a), "list")
 })
 
-test_that("bad inputs generate errors", {
+test_that("unnest_wider - bad inputs generate errors", {
   df <- tibble(x = 1, y = list(mean))
-  expect_error(unnest_wider(df, y), "must be list of vectors")
+  expect_snapshot(error = TRUE, unnest_wider(df, y))
 })
 
 test_that("list of 0-length vectors yields no new columns", {
@@ -202,6 +252,20 @@ test_that("list of 0-length vectors yields no new columns", {
   # similarly when empty
   df <- tibble(x = integer(), y = list())
   expect_named(unnest_wider(df, y), "x")
+
+  # similarly when using list_of() with 0-length elements
+  df <- tibble(x = 1:2, y = list_of(integer(), integer()))
+  expect_named(unnest_wider(df, y), "x")
+})
+
+test_that("list-col with only `NULL` works (#1186)", {
+  df <- tibble(x = list(NULL))
+  expect_identical(unnest_wider(df, x), tibble::new_tibble(list(), nrow = 1L))
+})
+
+test_that("empty list yields no new columns", {
+  df <- tibble(x = list())
+  expect_identical(unnest_wider(df, x), tibble())
 })
 
 test_that("list_of columns can be unnested", {
@@ -225,6 +289,114 @@ test_that("names_sep creates unique names", {
   expect_equal(out$y_a, c(1, 1))
 })
 
+test_that("`names_sep` works with empty elements (#1185)", {
+  df <- tibble(x = list(c(a = 1L), c(a = integer())))
+  out <- unnest_wider(df, x, names_sep = "_")
+  expect_identical(out, tibble(x_a = c(1L, NA)))
+})
+
+test_that("df-cols can be unnested (#1188)", {
+  df <- tibble(a = 1:3, b = tibble(x = 1:3, y = 1:3))
+  out <- unnest_wider(df, b)
+  expect_identical(out, unpack(df, b))
+})
+
+test_that("unnesting mixed empty types retains the column (#1125)", {
+  df <- tibble(col = list(list(a = list()), list(a = integer())))
+  expect_identical(unnest_wider(df, col), tibble(a = c(NA, NA)))
+})
+
+test_that("can unnest mixed empty types with `strict = FALSE`", {
+  df <- tibble(col = list(
+    list(a = "x"),
+    list(a = list()),
+    list(a = integer())
+  ))
+
+  expect_identical(
+    unnest_wider(df, col)$a,
+    c("x", NA, NA)
+  )
+
+  # They are replaced with `NULL` before simplification
+  expect_identical(
+    unnest_wider(df, col, simplify = FALSE)$a,
+    list("x", NULL, NULL)
+  )
+})
+
+test_that("can't unnest mixed empty types when in strict mode", {
+  df <- tibble(col = list(list(a = list()), list(a = 1L)))
+
+  # Not strict, useful for JSON data but doesn't follow vctrs type rules
+  expect_identical(unnest_wider(df, col), tibble(a = c(NA, 1L)))
+
+  # Strict means they can't be combined
+  expect_identical(
+    unnest_wider(df, col, strict = TRUE),
+    tibble(a = list(list(), 1L))
+  )
+})
+
+test_that("can unnest multiple columns wider at once (#740)", {
+  df <- tibble(
+    x = list(list(a = 1), list(a = 2)),
+    y = list(list(b = 1, c = "x"), list(b = 2, c = "y"))
+  )
+
+  expect_identical(
+    unnest_wider(df, c(x, y)),
+    tibble(a = c(1, 2), b = c(1, 2), c = c("x", "y"))
+  )
+})
+
+test_that("can't currently combine compatible `<list> + <list_of<ptype>>`", {
+  # Turn this into a working test after this issue is resolved
+  # https://github.com/r-lib/vctrs/pull/1231
+  skip_on_cran()
+
+  df <- tibble(col = list(list(a = 1:2), list_of(a = 1L)))
+
+  expect_snapshot(error = TRUE, unnest_wider(df, col))
+})
+
+test_that("invariant - final number of columns depends on element sizes", {
+  df <- tibble(x = list_of(.ptype = integer()))
+  expect_identical(dim(unnest_wider(df, x)), c(0L, 0L))
+
+  df <- tibble(x = list_of(NULL, .ptype = integer()))
+  expect_identical(dim(unnest_wider(df, x)), c(1L, 0L))
+
+  df <- tibble(x = list_of(integer()))
+  expect_identical(dim(unnest_wider(df, x)), c(1L, 0L))
+
+  df <- tibble(x = list_of(c(a = 1L)))
+  expect_identical(dim(unnest_wider(df, x)), c(1L, 1L))
+
+  df <- tibble(x = list_of(c(a = 1L), c(a = 1L, b = 2L, c = 3L)))
+  expect_identical(dim(unnest_wider(df, x)), c(2L, 3L))
+
+  df <- tibble(x = list_of(c(a = 1L, c = 3L), c(a = 1L, b = 2L)))
+  expect_identical(dim(unnest_wider(df, x)), c(2L, 3L))
+})
+
+test_that("invariant - for list_of<dataframe> special case, final number of columns and types comes from ptype columns (#1187)", {
+  df <- tibble(x = list_of(.ptype = tibble(a = integer())))
+  expect_identical(unnest_wider(df, x), tibble(a = integer()))
+
+  df <- tibble(x = list_of(NULL, .ptype = tibble(a = integer())))
+  expect_identical(unnest_wider(df, x), tibble(a = NA_integer_))
+
+  df <- tibble(x = list_of(tibble(a = integer())))
+  expect_identical(unnest_wider(df, x), tibble(a = NA_integer_))
+
+  df <- tibble(x = list_of(tibble(a = 1L)))
+  expect_identical(unnest_wider(df, x), tibble(a = 1L))
+
+  df <- tibble(x = list_of(tibble(a = 1:2)))
+  expect_identical(unnest_wider(df, x), tibble(a = list_of(1:2)))
+})
+
 # unnest_longer -----------------------------------------------------------
 
 test_that("uses input for default column names", {
@@ -232,6 +404,13 @@ test_that("uses input for default column names", {
   out <- df %>% unnest_longer(y)
 
   expect_named(out, c("x", "y"))
+})
+
+test_that("can adjust the column name with `values_to`", {
+  df <- tibble(x = 1:2, y = list(1, 1:2))
+  out <- df %>% unnest_longer(y, values_to = "y2")
+
+  expect_named(out, c("x", "y2"))
 })
 
 test_that("automatically adds id col if named", {
@@ -274,9 +453,9 @@ test_that("can unested dates", {
   expect_equal(out$x, x)
 })
 
-test_that("bad inputs generate errors", {
+test_that("unnest_longer - bad inputs generate errors", {
   df <- tibble(x = 1, y = list(mean))
-  expect_error(unnest_longer(df, y), "must be list of vectors")
+  expect_snapshot(error = TRUE, unnest_longer(df, y))
 })
 
 test_that("list_of columns can be unnested", {
@@ -289,6 +468,181 @@ test_that("list_of columns can be unnested", {
   # With id column
   df <- tibble(x = 1:2, y = list_of(c(a = 1L), c(b = 1:2)))
   expect_named(unnest_longer(df, y), c("x", "y", "y_id"))
+})
+
+test_that("mix of unnamed and named can be unnested (#1029)", {
+  df <- tibble(x = 1:3, y = list(1, c(b = 2), NULL))
+
+  out <- unnest_longer(df, y, indices_include = NULL)
+  expect_identical(out$y_id, c(NA, "b", NA))
+
+  out <- unnest_longer(df, y, indices_include = TRUE)
+  expect_identical(out$y_id, c(NA, "b", NA))
+})
+
+test_that("unnesting empty typed column is a no-op and retains column (#1199) (#1196)", {
+  df <- tibble(x = integer())
+  expect_identical(unnest_longer(df, x), df)
+
+  df <- tibble(x = tibble())
+  expect_identical(unnest_longer(df, x), df)
+
+  df <- tibble(x = tibble(a = integer()))
+  expect_identical(unnest_longer(df, x), df)
+
+  # In particular, #1196
+  df <- tibble(a = tibble(x = 1:2, y = 3:4, z = 5:6))
+  expect_identical(unnest_longer(df, a), df)
+})
+
+test_that("unnesting empty list retains logical column (#1199)", {
+  # Really an unspecified column that `vec_cast_common()` finalizes to logical
+  df <- tibble(x = list())
+  expect_identical(unnest_longer(df, x), tibble(x = logical()))
+})
+
+test_that("unnesting empty list with indices uses integer indices", {
+  df <- tibble(x = list())
+  out <- unnest_longer(df, x, indices_include = TRUE)
+  expect_identical(out$x_id, integer())
+})
+
+test_that("unnesting empty list-of retains ptype (#1199)", {
+  df <- tibble(x = list_of(.ptype = integer()))
+  expect_identical(unnest_longer(df, x), tibble(x = integer()))
+})
+
+test_that("unnesting list of data frames utilizes `values_to` (#1195)", {
+  df <- tibble(x = list(tibble(a = 1:2), tibble(a = 3:4)))
+
+  expect_identical(
+    unnest_longer(df, x, values_to = "foo"),
+    tibble(foo = tibble(a = 1:4))
+  )
+})
+
+test_that("unnesting list of data frames utilizes `indices_include` (#1194)", {
+  df <- tibble(x = list(tibble(a = 1:2), tibble(a = 3:4)))
+
+  expect_identical(
+    unnest_longer(df, x, indices_include = TRUE),
+    tibble(x = tibble(a = 1:4), x_id = c(1L, 2L, 1L, 2L))
+  )
+})
+
+test_that("can unnest a column with just `list(NULL)` (#1193)", {
+  df <- tibble(x = list(NULL))
+  expect_identical(unnest_longer(df, x), tibble(x = NA))
+
+  df <- tibble(x = list_of(NULL, .ptype = integer()))
+  expect_identical(unnest_longer(df, x), tibble(x = NA_integer_))
+})
+
+test_that("unnesting `list(NULL)` with indices uses integer indices", {
+  df <- tibble(x = list(NULL))
+  out <- unnest_longer(df, x, indices_include = TRUE)
+  expect_identical(out$x_id, 1L)
+})
+
+test_that("can unnest one row data frames (#1034)", {
+  col <- list(tibble(x = 1, y = 2), tibble(x = 2, y = 3))
+  df <- tibble(col = col)
+
+  expect_identical(
+    unnest_longer(df, col),
+    tibble(col = tibble(x = c(1, 2), y = c(2, 3)))
+  )
+})
+
+test_that("unnesting named vector results in unnamed column", {
+  df <- tibble(x = c(a = 1, b = 2))
+
+  # `x` converted to list with `tidyr_chop()` and names are moved to outer list.
+  # No index column is added.
+  expect_identical(unnest_longer(df, x), tibble(x = c(1, 2)))
+
+  # Conversion to list makes `x = list(1, 2)`, so indices are returned as `c(1L, 1L)`.
+  out <- unnest_longer(df, x, indices_include = TRUE)
+  expect_identical(out$x_id, c(1L, 1L))
+})
+
+test_that("can unnest multiple columns (#740)", {
+  df <- tibble(a = list(1:2, 3:4), b = list(1:2, 3:4))
+  expect_identical(unnest_longer(df, c(a, b)), unchop(df, c(a, b)))
+})
+
+test_that("tidyverse recycling rules are applied when unnesting multiple cols", {
+  df <- tibble(a = list(1L, 3:4), b = list(1:2, 4L))
+  out <- unnest_longer(df, c(a, b))
+  expect_identical(out$a, c(1L, 1L, 3L, 4L))
+  expect_identical(out$b, c(1L, 2L, 4L, 4L))
+})
+
+test_that("unnesting multiple columns uses independent indices", {
+  df <- tibble(a = list(c(x = 1), NULL), b = list(1, 2:3))
+  out <- unnest_longer(df, c(a, b))
+
+  expect_identical(out$a_id, c("x", NA, NA))
+  expect_named(out, c("a", "a_id", "b"))
+})
+
+test_that("unnesting multiple columns works with `indices_include = TRUE`", {
+  df <- tibble(a = list(c(x = 1), NULL), b = list(1, 2:3))
+  out <- unnest_longer(df, c(a, b), indices_include = TRUE)
+
+  expect_identical(out$a_id, c("x", NA, NA))
+  expect_identical(out$b_id, c(1L, 1L, 2L))
+})
+
+test_that("can use glue to name multiple `values_to` cols", {
+  df <- tibble(a = list(1, 2:3), b = list(1, 2:3))
+  expect_named(
+    unnest_longer(df, c(a, b), values_to = "{col}_"),
+    c("a_", "b_")
+  )
+})
+
+test_that("can use glue to name multiple `indices_to` cols", {
+  df <- tibble(a = list(1, 2:3), b = list(1, 2:3))
+  expect_named(
+    unnest_longer(df, c(a, b), indices_to = "{col}_name"),
+    c("a", "a_name", "b", "b_name")
+  )
+})
+
+test_that("default `indices_to` is based on `values_to` (#1201)", {
+  df <- tibble(a = list(c(x = 1), 2))
+  expect_named(
+    unnest_longer(df, a, values_to = "aa"),
+    c("aa", "aa_id")
+  )
+})
+
+test_that("can't mix `indices_to` with `indices_include = FALSE`", {
+  expect_snapshot(error = TRUE,
+    unnest_longer(mtcars, mpg, indices_to = "x", indices_include = FALSE)
+  )
+})
+
+test_that("`values_to` and `indices_to` glue can't reach into surrounding env", {
+  x <- "foo"
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, indices_to = "{x}"))
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, values_to = "{x}"))
+})
+
+test_that("`values_to` is validated", {
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, values_to = 1))
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, values_to = c("x", "y")))
+})
+
+test_that("`indices_to` is validated", {
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, indices_to = 1))
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, indices_to = c("x", "y")))
+})
+
+test_that("`indices_include` is validated", {
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, indices_include = 1))
+  expect_snapshot(error = TRUE, unnest_longer(mtcars, mpg, indices_include = c(TRUE, FALSE)))
 })
 
 # unnest_auto -------------------------------------------------------------
@@ -325,4 +679,159 @@ test_that("works with an input that has column named `col`", {
   )
   expect_message(out <- df %>% unnest_auto(list_col), "unnest_wider")
   expect_named(out, c("col", "x", "y"))
+})
+
+# col_simplify -----------------------------------------------------------
+
+test_that("non-list isn't simplified", {
+  expect_identical(col_simplify(1:5), 1:5)
+})
+
+test_that("transform is applied to entire non-list", {
+  expect_identical(col_simplify(1:5, transform = function(x) x + 1L), 2:6)
+})
+
+test_that("transform is applied to list elements individually", {
+  expect_identical(
+    col_simplify(list(1, 2), transform = length),
+    c(1L, 1L)
+  )
+})
+
+test_that("transform is applied even if you can't simplify", {
+  expect_identical(
+    col_simplify(list(1:2, 2L), transform = ~.x + 1L),
+    list(2:3, 3L)
+  )
+})
+
+test_that("transform can result in simplification", {
+  expect_identical(
+    col_simplify(list(1:2, 2L), transform = sum),
+    c(3L, 2L)
+  )
+})
+
+test_that("lose list-of status after applying transform", {
+  x <- list_of(1L, 1:2)
+
+  expect_identical(
+    col_simplify(x, transform = ~.x + 1),
+    list(2, c(2, 3))
+  )
+
+  x <- list_of(NULL, .ptype = integer())
+
+  # Not `NA_integer_`
+  expect_identical(
+    col_simplify(x, transform = ~.x),
+    NA
+  )
+})
+
+test_that("ptype is applied to entire non-list", {
+  expect_identical(col_simplify(1:5, ptype = double()), as.double(1:5))
+})
+
+test_that("ptype is applied to list elements individually", {
+  expect_identical(
+    col_simplify(list(1, 2, 3), ptype = integer()),
+    c(1L, 2L, 3L)
+  )
+})
+
+test_that("ptype is applied even if you can't simplify - and results in a list-of!", {
+  expect_identical(
+    col_simplify(list(c(1, 2), 2, 3), ptype = integer()),
+    list_of(1:2, 2L, 3L)
+  )
+})
+
+test_that("ptype is applied after transform", {
+  expect_identical(
+    col_simplify(list(1, 2, 3), ptype = integer(), transform = ~.x + 1),
+    c(2L, 3L, 4L)
+  )
+
+  expect_snapshot(error = TRUE, {
+    col_simplify(list(1, 2, 3), ptype = integer(), transform = ~.x + 1.5)
+  })
+})
+
+test_that("lists of lists aren't simplified", {
+  x <- list(list(1), list(2))
+  expect_identical(col_simplify(x), x)
+
+  x <- list_of(list(1), list(2))
+  expect_identical(col_simplify(x), x)
+})
+
+test_that("lists of non-vectors aren't simplified", {
+  x <- list(sym("x"), sym("y"))
+  expect_identical(col_simplify(x), x)
+})
+
+test_that("lists with length >1 vectors aren't simplified", {
+  x <- list(1, 1:2, 3)
+  expect_identical(col_simplify(x), x)
+
+  x <- list_of(1L, 1:2, 3L)
+  expect_identical(col_simplify(x), x)
+})
+
+test_that("Empty elements are retained if we can't simplify", {
+  x <- list(1, NULL, 1:2, integer())
+  expect_identical(col_simplify(x), x)
+})
+
+test_that("`NULL` are initialized to size 1 equivalent", {
+  x <- list(1, NULL, 2)
+  expect_identical(col_simplify(x), c(1, NA, 2))
+  expect_identical(col_simplify(x, ptype = integer()), c(1L, NA, 2L))
+
+  x <- list_of(1, NULL, 2)
+  expect_identical(col_simplify(x), c(1, NA, 2))
+})
+
+test_that("`NULL` is handled correctly when it is the only element", {
+  x <- list(NULL)
+
+  expect_identical(col_simplify(x), NA)
+  expect_identical(col_simplify(x, ptype = integer()), NA_integer_)
+
+  x <- list_of(NULL, .ptype = integer())
+
+  expect_identical(col_simplify(x), NA_integer_)
+  expect_identical(col_simplify(x, ptype = double()), NA_real_)
+})
+
+test_that("empty typed elements are initialized to size 1 equivalent", {
+  x <- list(integer(), 1L, integer())
+  expect_identical(col_simplify(x), c(NA, 1L, NA))
+
+  x <- list_of(integer(), 1L)
+  expect_identical(col_simplify(x), c(NA, 1L))
+})
+
+test_that("empty typed element is handled correctly if it is the only element", {
+  x <- list(integer())
+
+  expect_identical(col_simplify(x), NA_integer_)
+  expect_identical(col_simplify(x, ptype = double()), NA_real_)
+
+  x <- list_of(integer())
+
+  expect_identical(col_simplify(x), NA_integer_)
+  expect_identical(col_simplify(x, ptype = double()), NA_real_)
+})
+
+test_that("can simplify record style objects (#999)", {
+  rcrd <- new_rcrd(list(x = 1, y = 2))
+  x <- list(rcrd, rcrd)
+  expect_identical(col_simplify(x), vec_c(rcrd, rcrd))
+})
+
+test_that("can simplify one row data frames (#1034)", {
+  x <- list(tibble(x = 1, y = 2), tibble(x = 2, y = 3))
+  expect_identical(col_simplify(x), vec_c(x[[1]], x[[2]]))
 })

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -736,6 +736,32 @@ test_that("works with an input that has column named `col`", {
   expect_named(out, c("col", "x", "y"))
 })
 
+# df_simplify ------------------------------------------------------------
+
+test_that("`simplify` is validated", {
+  expect_snapshot({
+    (expect_error(df_simplify(data.frame(), simplify = 1)))
+    (expect_error(df_simplify(data.frame(), simplify = NA)))
+    (expect_error(df_simplify(data.frame(), simplify = c(TRUE, FALSE))))
+  })
+})
+
+test_that("`ptype` is validated", {
+  expect_snapshot({
+    (expect_error(df_simplify(data.frame(), ptype = 1)))
+    (expect_error(df_simplify(data.frame(), ptype = list(1))))
+    (expect_error(df_simplify(data.frame(), ptype = list(x = 1, x = 1))))
+  })
+})
+
+test_that("`transform` is validated", {
+  expect_snapshot({
+    (expect_error(df_simplify(data.frame(), transform = 1)))
+    (expect_error(df_simplify(data.frame(), transform = list(1))))
+    (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))
+  })
+})
+
 # col_simplify -----------------------------------------------------------
 
 test_that("non-list isn't simplified", {

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -295,6 +295,18 @@ test_that("`names_sep` works with empty elements (#1185)", {
   expect_identical(out, tibble(x_a = c(1L, NA)))
 })
 
+test_that("`names_sep` works with data frame columns", {
+  df <- tibble(x = tibble(a = 1, b = 2))
+  out <- unnest_wider(df, x, names_sep = "_")
+  expect_named(out, c("x_a", "x_b"))
+})
+
+test_that("`names_sep` works with non-list atomic vectors", {
+  df <- tibble(x = c(a = 1, b = 2))
+  out <- unnest_wider(df, x, names_sep = "_")
+  expect_named(out, "x_1")
+})
+
 test_that("df-cols can be unnested (#1188)", {
   df <- tibble(a = 1:3, b = tibble(x = 1:3, y = 1:3))
   out <- unnest_wider(df, b)


### PR DESCRIPTION
`unnest_longer()`:
Closes #1201
Closes #1199 
Closes #1198 
Closes #1196 
Closes #1195 
Closes #1194 
Closes #1193 
Closes #1034 
Closes #1029 
Closes #740 

`unnest_wider()`:
Closes #1188 
Closes #1187 
Closes #1186
Closes #1125 
Closes #1133 
Closes #1060 

`hoist()`:
Added test of current behavior for #1203 
Closes #1044 
Closes #1000 
Closes #999 
Closes #998 
Closes #996 

Other:
Part of #1185 

---

Affected revdeps:

- ffscrapr
  - Pre-emptive PR already merged https://github.com/ffverse/ffscrapr/pull/344

- wehoop
  - Lots of off-label usage of `unnest_wider()`. PR https://github.com/saiemgilani/wehoop/pull/14
  - Two tests explicitly check for a set of column names after all the unnesting is applied. Fixing the first part of https://github.com/tidyverse/tidyr/issues/1125#issuecomment-959802379 means that columns with all empty elements are now (correctly) retained, which means this set of column names should be updated. Luckily this test isn't tested on CRAN, so it should be easy. PR https://github.com/saiemgilani/wehoop/pull/15

Update: Both revdeps have already merged the PRs and have updated their packages on CRAN. So there are now no affected revdeps.

---

This PR completely rewrites the rectangling functions. They are now much more consistent in a variety of edge cases, and are often much faster than they used to be. I anticipate very little breaking changes, except in some extreme off-label usage situations. I will leave in-line comments, but I think this generally should be reviewed as if these were completely new functions.

Here is the most interesting performance difference I found so far, which comes from https://stackoverflow.com/questions/68897169/any-speedier-alternatives-to-tidyrunnest-longer-when-dealing-with-nested-nam. Mainly this comes from getting rid of `tibble()` in favor of `new_data_frame()`. I think #1133 also identified this. (It is also worth noting that in this case a simple `unnest()` is even faster. Like, in the ~200ms range. But it is nice to see this improvement).

```r
library(tidyr)

elt <- 1:5
col <- rep(list(elt), 200000L)

df <- tibble(col = col)
df
#> # A tibble: 200,000 × 1
#>    col      
#>    <list>   
#>  1 <int [5]>
#>  2 <int [5]>
#>  3 <int [5]>
#>  4 <int [5]>
#>  5 <int [5]>
#>  6 <int [5]>
#>  7 <int [5]>
#>  8 <int [5]>
#>  9 <int [5]>
#> 10 <int [5]>
#> # … with 199,990 more rows

# CRAN
bench::mark(unnest_longer(df, col))
#> # A tibble: 1 × 6
#>   expression                  min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>             <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest_longer(df, col)    1.14m    1.14m    0.0146     292MB     2.09

# This PR
bench::mark(unnest_longer(df, col))
#> # A tibble: 1 × 6
#>   expression                  min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>             <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest_longer(df, col)    2.45s    2.45s     0.408    39.6MB     4.90
```