### PR TITLE
Avoid computing on `.data` in the `nest()` generic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* The `nest()` generic now avoids computing on `.data`, making it more
+  compatible with lazy tibbles (#1134).
+  
 * `chop()` now works correctly with data frames with 0 rows (#1206).
 
 * The `cols` argument of `chop()` is no longer optional. This matches the

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -315,6 +315,18 @@ test_that("warn about old style interface", {
   expect_named(out, c("x", "data"))
 })
 
+test_that("only warn about unnamed inputs (#1175)", {
+  df <- tibble(x = 1:3, y = 1:3, z = 1:3)
+  expect_warning(out <- nest(df, x, y, foo = z), "data = c(x, y)", fixed = TRUE)
+  expect_named(out, c("foo", "data"))
+})
+
+test_that("unnamed expressions are kept in the warning", {
+  df <- tibble(x = 1:3, z = 1:3)
+  expect_warning(out <- nest(df, x, starts_with("z")), 'data = c(x, starts_with("z"))', fixed = TRUE)
+  expect_named(out, "data")
+})
+
 test_that("can control output column name", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
   expect_warning(out <- nest(df, y, .key = "y"), "y = c(y)", fixed = TRUE)


### PR DESCRIPTION
Closes #1134 
Closes #1175 

We don't really need to do the full `eval_select()` call here, we just need to create a nice-ish label for the warning and rework the unnamed dots into a `c(...)` format to pass on to another call to `nest()`.

This should avoid any issues with dbplyr / dtplyr methods.

Also fixed #1175, where a mix of named/unnamed dots could cause some issues.