### PR TITLE
Small revision to `pack()` for clarity

### DIFF
--- a/R/pack.R
+++ b/R/pack.R
@@ -66,15 +66,19 @@ pack <- function(.data, ..., .names_sep = NULL) {
   }
 
   cols <- map(cols, ~ tidyselect::eval_select(.x, .data))
+
+  unpacked <- setdiff(names(.data), unlist(map(cols, names)))
+  unpacked <- .data[unpacked]
+
   packed <- map(cols, ~ .data[.x])
 
   if (!is.null(.names_sep)) {
-    packed <- imap(packed, strip_names, .names_sep)
+    packed <- imap(packed, strip_names, names_sep = .names_sep)
   }
 
-  # TODO: find a different approach that preserves order
-  asis <- setdiff(names(.data), unlist(map(cols, names)))
-  out <- vec_cbind(.data[asis], new_data_frame(packed, n = nrow(.data)))
+  packed <- new_data_frame(packed, n = vec_size(.data))
+
+  out <- vec_cbind(unpacked, packed)
 
   reconstruct_tibble(.data, out)
 }


### PR DESCRIPTION
Also removes the TODO about preserving order, which I think is impossible. Consider a data frame with column names `c("x", "y", "z")`. How could `pack(df, c(x, z))` preserve order in any meaningful way?