### PR TITLE
Update warning related tests to use `expect_snapshot()`

### DIFF
--- a/tests/testthat/_snaps/gather.md
+++ b/tests/testthat/_snaps/gather.md
@@ -1,16 +1,20 @@
 # factors coerced to characters, not integers
 
     Code
-      (expect_warning(out <- gather(df, k, v)))
-    Output
-      <warning: attributes are not identical across measure variables;
-      they will be dropped>
+      out <- gather(df, k, v)
+    Warning <warning>
+      attributes are not identical across measure variables;
+      they will be dropped
 
 # varying attributes are dropped with a warning
 
     Code
-      (expect_warning(gather(df, k, v)))
+      gather(df, k, v)
+    Warning <warning>
+      attributes are not identical across measure variables;
+      they will be dropped
     Output
-      <warning: attributes are not identical across measure variables;
-      they will be dropped>
+            k          v
+      1 date1 1636502400
+      2 date2      18951
 

--- a/tests/testthat/_snaps/gather.md
+++ b/tests/testthat/_snaps/gather.md
@@ -1,0 +1,16 @@
+# factors coerced to characters, not integers
+
+    Code
+      (expect_warning(out <- gather(df, k, v)))
+    Output
+      <warning: attributes are not identical across measure variables;
+      they will be dropped>
+
+# varying attributes are dropped with a warning
+
+    Code
+      (expect_warning(gather(df, k, v)))
+    Output
+      <warning: attributes are not identical across measure variables;
+      they will be dropped>
+

--- a/tests/testthat/_snaps/nest.md
+++ b/tests/testthat/_snaps/nest.md
@@ -1,10 +1,10 @@
 # nesting no columns nests all inputs
 
     Code
-      (expect_warning(out <- nest(df)))
-    Output
-      <warning: `...` must not be empty for ungrouped data frames.
-      Did you want `data = everything()`?>
+      out <- nest(df)
+    Warning <warning>
+      `...` must not be empty for ungrouped data frames.
+      Did you want `data = everything()`?
 
 # bad inputs generate errors
 
@@ -37,118 +37,126 @@
 # warn about old style interface
 
     Code
-      (expect_warning(out <- nest(df, y)))
-    Output
-      <warning: All elements of `...` must be named.
-      Did you want `data = c(y)`?>
+      out <- nest(df, y)
+    Warning <warning>
+      All elements of `...` must be named.
+      Did you want `data = c(y)`?
 
 # only warn about unnamed inputs (#1175)
 
     Code
-      (expect_warning(out <- nest(df, x, y, foo = z)))
-    Output
-      <warning: All elements of `...` must be named.
-      Did you want `data = c(x, y)`?>
+      out <- nest(df, x, y, foo = z)
+    Warning <warning>
+      All elements of `...` must be named.
+      Did you want `data = c(x, y)`?
 
 # unnamed expressions are kept in the warning
 
     Code
-      (expect_warning(out <- nest(df, x, starts_with("z"))))
-    Output
-      <warning: All elements of `...` must be named.
-      Did you want `data = c(x, starts_with("z"))`?>
+      out <- nest(df, x, starts_with("z"))
+    Warning <warning>
+      All elements of `...` must be named.
+      Did you want `data = c(x, starts_with("z"))`?
 
 # can control output column name
 
     Code
-      (expect_warning(out <- nest(df, y, .key = "y")))
-    Output
-      <warning: All elements of `...` must be named.
-      Did you want `y = c(y)`?>
+      out <- nest(df, y, .key = "y")
+    Warning <warning>
+      All elements of `...` must be named.
+      Did you want `y = c(y)`?
 
 # can control output column name when nested
 
     Code
-      (expect_warning(out <- nest(df, .key = "y")))
-    Output
-      <warning: `.key` is deprecated>
+      out <- nest(df, .key = "y")
+    Warning <warning>
+      `.key` is deprecated
 
 # .key gets warning with new interface
 
     Code
-      (expect_warning(out <- nest(df, y = y, .key = "y")))
-    Output
-      <warning: `.key` is deprecated>
+      out <- nest(df, y = y, .key = "y")
+    Warning <warning>
+      `.key` is deprecated
 
 # cols must go in cols
 
     Code
-      (expect_warning(unnest(df, x, y)))
+      unnest(df, x, y)
+    Warning <warning>
+      unnest() has a new interface. See ?unnest for details.
+      Try `df %>% unnest(c(x, y))`, with `mutate()` if needed
     Output
-      <warning: unnest() has a new interface. See ?unnest for details.
-      Try `df %>% unnest(c(x, y))`, with `mutate()` if needed>
+      # A tibble: 2 x 2
+            x y    
+        <dbl> <chr>
+      1     3 a    
+      2     4 b    
 
 # need supply column names
 
     Code
-      (expect_warning(unnest(df)))
+      unnest(df)
+    Warning <warning>
+      `cols` is now required when using unnest().
+      Please use `cols = c(y)`
     Output
-      <warning: `cols` is now required when using unnest().
-      Please use `cols = c(y)`>
+      # A tibble: 2 x 2
+            x y    
+        <int> <chr>
+      1     1 a    
+      2     2 b    
 
 # sep combines column names
 
     Code
-      (expect_warning(out <- df %>% unnest(c(x, y), .sep = "_")))
-    Output
-      <deprecated>
-      message: The `.sep` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      out <- df %>% unnest(c(x, y), .sep = "_")
+    Warning <lifecycle_warning_deprecated>
+      The `.sep` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       Use `names_sep = '_'` instead.
-      Backtrace:
-       1. testthat::expect_warning(out <- df %>% unnest(c(x, y), .sep = "_"))
-       8. tidyr::unnest(., c(x, y), .sep = "_")
 
 # unnest has mutate semantics
 
     Code
-      (expect_warning(out <- df %>% unnest(z = map(y, `+`, 1))))
-    Output
-      <warning: unnest() has a new interface. See ?unnest for details.
-      Try `df %>% unnest(c(z))`, with `mutate()` if needed>
+      out <- df %>% unnest(z = map(y, `+`, 1))
+    Warning <warning>
+      unnest() has a new interface. See ?unnest for details.
+      Try `df %>% unnest(c(z))`, with `mutate()` if needed
 
 # .drop and .preserve are deprecated
 
     Code
-      (expect_warning(df %>% unnest(x, .preserve = y)))
-    Output
-      <deprecated>
-      message: The `.preserve` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      df %>% unnest(x, .preserve = y)
+    Warning <lifecycle_warning_deprecated>
+      The `.preserve` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       All list-columns are now preserved
-      Backtrace:
-       1. testthat::expect_warning(df %>% unnest(x, .preserve = y))
-       8. tidyr::unnest(., x, .preserve = y)
+    Output
+      # A tibble: 2 x 2
+            x y        
+        <dbl> <list>   
+      1     3 <chr [1]>
+      2     4 <chr [1]>
 
 ---
 
     Code
-      (expect_warning(df %>% unnest(x, .drop = FALSE)))
-    Output
-      <deprecated>
-      message: The `.drop` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      df %>% unnest(x, .drop = FALSE)
+    Warning <lifecycle_warning_deprecated>
+      The `.drop` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       All list-columns are now preserved.
-      Backtrace:
-       1. testthat::expect_warning(df %>% unnest(x, .drop = FALSE))
-       8. tidyr::unnest(., x, .drop = FALSE)
+    Output
+      # A tibble: 2 x 2
+            x y        
+        <dbl> <list>   
+      1     3 <chr [1]>
+      2     4 <chr [1]>
 
 # .id creates vector of names for vector unnest
 
     Code
-      (expect_warning(out <- unnest(df, y, .id = "name")))
-    Output
-      <deprecated>
-      message: The `.id` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      out <- unnest(df, y, .id = "name")
+    Warning <lifecycle_warning_deprecated>
+      The `.id` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       Manually create column of names instead.
-      Backtrace:
-       1. testthat::expect_warning(out <- unnest(df, y, .id = "name"))
-       7. tidyr::unnest(df, y, .id = "name")
 

--- a/tests/testthat/_snaps/nest.md
+++ b/tests/testthat/_snaps/nest.md
@@ -1,3 +1,11 @@
+# nesting no columns nests all inputs
+
+    Code
+      (expect_warning(out <- nest(df)))
+    Output
+      <warning: `...` must not be empty for ungrouped data frames.
+      Did you want `data = everything()`?>
+
 # bad inputs generate errors
 
     Code
@@ -25,4 +33,122 @@
       unnest(df, x)
     Error <vctrs_error_incompatible_type>
       Can't combine `..1` <double> and `..2` <tbl_df>.
+
+# warn about old style interface
+
+    Code
+      (expect_warning(out <- nest(df, y)))
+    Output
+      <warning: All elements of `...` must be named.
+      Did you want `data = c(y)`?>
+
+# only warn about unnamed inputs (#1175)
+
+    Code
+      (expect_warning(out <- nest(df, x, y, foo = z)))
+    Output
+      <warning: All elements of `...` must be named.
+      Did you want `data = c(x, y)`?>
+
+# unnamed expressions are kept in the warning
+
+    Code
+      (expect_warning(out <- nest(df, x, starts_with("z"))))
+    Output
+      <warning: All elements of `...` must be named.
+      Did you want `data = c(x, starts_with("z"))`?>
+
+# can control output column name
+
+    Code
+      (expect_warning(out <- nest(df, y, .key = "y")))
+    Output
+      <warning: All elements of `...` must be named.
+      Did you want `y = c(y)`?>
+
+# can control output column name when nested
+
+    Code
+      (expect_warning(out <- nest(df, .key = "y")))
+    Output
+      <warning: `.key` is deprecated>
+
+# .key gets warning with new interface
+
+    Code
+      (expect_warning(out <- nest(df, y = y, .key = "y")))
+    Output
+      <warning: `.key` is deprecated>
+
+# cols must go in cols
+
+    Code
+      (expect_warning(unnest(df, x, y)))
+    Output
+      <warning: unnest() has a new interface. See ?unnest for details.
+      Try `df %>% unnest(c(x, y))`, with `mutate()` if needed>
+
+# need supply column names
+
+    Code
+      (expect_warning(unnest(df)))
+    Output
+      <warning: `cols` is now required when using unnest().
+      Please use `cols = c(y)`>
+
+# sep combines column names
+
+    Code
+      (expect_warning(out <- df %>% unnest(c(x, y), .sep = "_")))
+    Output
+      <deprecated>
+      message: The `.sep` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      Use `names_sep = '_'` instead.
+      Backtrace:
+       1. testthat::expect_warning(out <- df %>% unnest(c(x, y), .sep = "_"))
+       8. tidyr::unnest(., c(x, y), .sep = "_")
+
+# unnest has mutate semantics
+
+    Code
+      (expect_warning(out <- df %>% unnest(z = map(y, `+`, 1))))
+    Output
+      <warning: unnest() has a new interface. See ?unnest for details.
+      Try `df %>% unnest(c(z))`, with `mutate()` if needed>
+
+# .drop and .preserve are deprecated
+
+    Code
+      (expect_warning(df %>% unnest(x, .preserve = y)))
+    Output
+      <deprecated>
+      message: The `.preserve` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      All list-columns are now preserved
+      Backtrace:
+       1. testthat::expect_warning(df %>% unnest(x, .preserve = y))
+       8. tidyr::unnest(., x, .preserve = y)
+
+---
+
+    Code
+      (expect_warning(df %>% unnest(x, .drop = FALSE)))
+    Output
+      <deprecated>
+      message: The `.drop` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      All list-columns are now preserved.
+      Backtrace:
+       1. testthat::expect_warning(df %>% unnest(x, .drop = FALSE))
+       8. tidyr::unnest(., x, .drop = FALSE)
+
+# .id creates vector of names for vector unnest
+
+    Code
+      (expect_warning(out <- unnest(df, y, .id = "name")))
+    Output
+      <deprecated>
+      message: The `.id` argument of `unnest()` is deprecated as of tidyr 1.0.0.
+      Manually create column of names instead.
+      Backtrace:
+       1. testthat::expect_warning(out <- unnest(df, y, .id = "name"))
+       7. tidyr::unnest(df, y, .id = "name")
 

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -1,10 +1,10 @@
 # duplicated keys produce list column with warning
 
     Code
-      (expect_warning(pv <- pivot_wider(df, names_from = key, values_from = val)))
-    Output
-      <warning: Values are not uniquely identified; output will contain list-cols.
+      pv <- pivot_wider(df, names_from = key, values_from = val)
+    Warning <warning>
+      Values are not uniquely identified; output will contain list-cols.
       * Use `values_fn = list` to suppress this warning.
       * Use `values_fn = length` to identify where the duplicates arise.
-      * Use `values_fn = {summary_fun}` to summarise duplicates.>
+      * Use `values_fn = {summary_fun}` to summarise duplicates.
 

--- a/tests/testthat/_snaps/separate.md
+++ b/tests/testthat/_snaps/separate.md
@@ -1,27 +1,40 @@
 # too many pieces dealt with as requested
 
     Code
-      (expect_warning(separate(df, x, c("x", "y"))))
+      separate(df, x, c("x", "y"))
+    Warning <warning>
+      Expected 2 pieces. Additional pieces discarded in 1 rows [2].
     Output
-      <warning: Expected 2 pieces. Additional pieces discarded in 1 rows [2].>
+      # A tibble: 2 x 2
+        x     y    
+        <chr> <chr>
+      1 a     b    
+      2 a     b    
 
 ---
 
     Code
-      warn2 <- expect_warning(warn1 <- expect_warning(separate(df, x, c("x", "y"),
-      extra = "error")))
-      warn1
+      separate(df, x, c("x", "y"), extra = "error")
+    Warning <warning>
+      `extra = "error"` is deprecated. Please use `extra = "warn"` instead
+      Expected 2 pieces. Additional pieces discarded in 1 rows [2].
     Output
-      <warning: `extra = "error"` is deprecated. Please use `extra = "warn"` instead>
-    Code
-      warn2
-    Output
-      <warning: Expected 2 pieces. Additional pieces discarded in 1 rows [2].>
+      # A tibble: 2 x 2
+        x     y    
+        <chr> <chr>
+      1 a     b    
+      2 a     b    
 
 # too few pieces dealt with as requested
 
     Code
-      (expect_warning(separate(df, x, c("x", "y", "z"))))
+      separate(df, x, c("x", "y", "z"))
+    Warning <warning>
+      Expected 3 pieces. Missing pieces filled with `NA` in 1 rows [1].
     Output
-      <warning: Expected 3 pieces. Missing pieces filled with `NA` in 1 rows [1].>
+      # A tibble: 2 x 3
+        x     y     z    
+        <chr> <chr> <chr>
+      1 a     b     <NA> 
+      2 a     b     c    
 

--- a/tests/testthat/_snaps/separate.md
+++ b/tests/testthat/_snaps/separate.md
@@ -1,0 +1,27 @@
+# too many pieces dealt with as requested
+
+    Code
+      (expect_warning(separate(df, x, c("x", "y"))))
+    Output
+      <warning: Expected 2 pieces. Additional pieces discarded in 1 rows [2].>
+
+---
+
+    Code
+      warn2 <- expect_warning(warn1 <- expect_warning(separate(df, x, c("x", "y"),
+      extra = "error")))
+      warn1
+    Output
+      <warning: `extra = "error"` is deprecated. Please use `extra = "warn"` instead>
+    Code
+      warn2
+    Output
+      <warning: Expected 2 pieces. Additional pieces discarded in 1 rows [2].>
+
+# too few pieces dealt with as requested
+
+    Code
+      (expect_warning(separate(df, x, c("x", "y", "z"))))
+    Output
+      <warning: Expected 3 pieces. Missing pieces filled with `NA` in 1 rows [1].>
+

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -143,10 +143,7 @@ test_that("factors coerced to characters, not integers", {
     v2 = factor(letters[1:3])
   )
 
-  expect_warning(
-    out <- gather(df, k, v),
-    "attributes are not identical across measure variables"
-  )
+  expect_snapshot((expect_warning(out <- gather(df, k, v))))
 
   expect_equal(out$v, c(1:3, letters[1:3]))
 })
@@ -171,10 +168,7 @@ test_that("varying attributes are dropped with a warning", {
     date1 = as.POSIXct(Sys.Date()),
     date2 = Sys.Date() + 10
   )
-  expect_warning(
-    gather(df, k, v),
-    "attributes are not identical across measure variables"
-  )
+  expect_snapshot((expect_warning(gather(df, k, v))))
 })
 
 test_that("gather preserves OBJECT bit on e.g. POSIXct", {

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -143,7 +143,7 @@ test_that("factors coerced to characters, not integers", {
     v2 = factor(letters[1:3])
   )
 
-  expect_snapshot((expect_warning(out <- gather(df, k, v))))
+  expect_snapshot(out <- gather(df, k, v))
 
   expect_equal(out$v, c(1:3, letters[1:3]))
 })
@@ -168,7 +168,7 @@ test_that("varying attributes are dropped with a warning", {
     date1 = as.POSIXct(Sys.Date()),
     date2 = Sys.Date() + 10
   )
-  expect_snapshot((expect_warning(gather(df, k, v))))
+  expect_snapshot(gather(df, k, v))
 })
 
 test_that("gather preserves OBJECT bit on e.g. POSIXct", {

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -94,7 +94,7 @@ test_that("can nest multiple columns", {
 test_that("nesting no columns nests all inputs", {
   # included only for backward compatibility
   df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
-  expect_warning(out <- nest(df), "must not be empty")
+  expect_snapshot((expect_warning(out <- nest(df))))
   expect_named(out, "data")
   expect_equal(out$data[[1]], df)
 })
@@ -311,73 +311,78 @@ test_that("unnest keeps list cols", {
 
 test_that("warn about old style interface", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
-  expect_warning(out <- nest(df, y), "data = c(y)", fixed = TRUE)
+  expect_snapshot((expect_warning(out <- nest(df, y))))
   expect_named(out, c("x", "data"))
 })
 
 test_that("only warn about unnamed inputs (#1175)", {
   df <- tibble(x = 1:3, y = 1:3, z = 1:3)
-  expect_warning(out <- nest(df, x, y, foo = z), "data = c(x, y)", fixed = TRUE)
+  expect_snapshot((expect_warning(out <- nest(df, x, y, foo = z))))
   expect_named(out, c("foo", "data"))
 })
 
 test_that("unnamed expressions are kept in the warning", {
   df <- tibble(x = 1:3, z = 1:3)
-  expect_warning(out <- nest(df, x, starts_with("z")), 'data = c(x, starts_with("z"))', fixed = TRUE)
+  expect_snapshot((expect_warning(out <- nest(df, x, starts_with("z")))))
   expect_named(out, "data")
 })
 
 test_that("can control output column name", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
-  expect_warning(out <- nest(df, y, .key = "y"), "y = c(y)", fixed = TRUE)
+  expect_snapshot((expect_warning(out <- nest(df, y, .key = "y"))))
   expect_named(out, c("x", "y"))
 })
 
 test_that("can control output column name when nested", {
   df <- dplyr::group_by(tibble(x = c(1, 1, 1), y = 1:3), x)
-  expect_warning(out <- nest(df, .key = "y"), "`.key`", fixed = TRUE)
+  expect_snapshot((expect_warning(out <- nest(df, .key = "y"))))
   expect_named(out, c("x", "y"))
 })
 
 test_that(".key gets warning with new interface", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
-  expect_warning(out <- nest(df, y = y, .key = "y"), ".key", fixed = TRUE)
+  expect_snapshot((expect_warning(out <- nest(df, y = y, .key = "y"))))
   expect_named(df, c("x", "y"))
 })
 
 test_that("cols must go in cols", {
   df <- tibble(x = list(3, 4), y = list("a", "b"))
-  expect_warning(unnest(df, x, y), "c(x, y)", fixed = TRUE)
+  expect_snapshot((expect_warning(unnest(df, x, y))))
 })
 
 test_that("need supply column names", {
   df <- tibble(x = 1:2, y = list("a", "b"))
-  expect_warning(unnest(df), "c(y)", fixed = TRUE)
+  expect_snapshot((expect_warning(unnest(df))))
 })
 
 test_that("sep combines column names", {
+  local_options(lifecycle_verbosity = "warning")
   df <- tibble(x = list(tibble(x = 1)), y = list(tibble(x = 1)))
-  expect_warning(out <- df %>% unnest(c(x, y), .sep = "_"), "names_sep")
+  expect_snapshot((expect_warning(out <- df %>% unnest(c(x, y), .sep = "_"))))
   expect_named(out, c("x_x", "y_x"))
 })
 
 test_that("unnest has mutate semantics", {
   df <- tibble(x = 1:3, y = list(1, 2:3, 4))
-  expect_warning(out <- df %>% unnest(z = map(y, `+`, 1)), "mutate")
+  expect_snapshot((expect_warning(out <- df %>% unnest(z = map(y, `+`, 1)))))
   expect_equal(out$z, 2:5)
 })
 
 test_that(".drop and .preserve are deprecated", {
-  df <- tibble(x = list(3, 4), y = list("a", "b"))
-  expect_warning(df %>% unnest(x, .preserve = y), ".preserve")
+  local_options(lifecycle_verbosity = "warning")
 
   df <- tibble(x = list(3, 4), y = list("a", "b"))
-  expect_warning(df %>% unnest(x, .drop = FALSE), ".drop")
+  expect_snapshot((expect_warning(df %>% unnest(x, .preserve = y))))
+
+  df <- tibble(x = list(3, 4), y = list("a", "b"))
+  expect_snapshot((expect_warning(df %>% unnest(x, .drop = FALSE))))
 })
 
 test_that(".id creates vector of names for vector unnest", {
+  local_options(lifecycle_verbosity = "warning")
+
   df <- tibble(x = 1:2, y = list(a = 1, b = 1:2))
-  expect_warning(out <- unnest(df, y, .id = "name"), "names")
+  expect_snapshot((expect_warning(out <- unnest(df, y, .id = "name"))))
 
   expect_equal(out$name, c("a", "b", "b"))
 })

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -94,7 +94,7 @@ test_that("can nest multiple columns", {
 test_that("nesting no columns nests all inputs", {
   # included only for backward compatibility
   df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
-  expect_snapshot((expect_warning(out <- nest(df))))
+  expect_snapshot(out <- nest(df))
   expect_named(out, "data")
   expect_equal(out$data[[1]], df)
 })
@@ -311,60 +311,60 @@ test_that("unnest keeps list cols", {
 
 test_that("warn about old style interface", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
-  expect_snapshot((expect_warning(out <- nest(df, y))))
+  expect_snapshot(out <- nest(df, y))
   expect_named(out, c("x", "data"))
 })
 
 test_that("only warn about unnamed inputs (#1175)", {
   df <- tibble(x = 1:3, y = 1:3, z = 1:3)
-  expect_snapshot((expect_warning(out <- nest(df, x, y, foo = z))))
+  expect_snapshot(out <- nest(df, x, y, foo = z))
   expect_named(out, c("foo", "data"))
 })
 
 test_that("unnamed expressions are kept in the warning", {
   df <- tibble(x = 1:3, z = 1:3)
-  expect_snapshot((expect_warning(out <- nest(df, x, starts_with("z")))))
+  expect_snapshot(out <- nest(df, x, starts_with("z")))
   expect_named(out, "data")
 })
 
 test_that("can control output column name", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
-  expect_snapshot((expect_warning(out <- nest(df, y, .key = "y"))))
+  expect_snapshot(out <- nest(df, y, .key = "y"))
   expect_named(out, c("x", "y"))
 })
 
 test_that("can control output column name when nested", {
   df <- dplyr::group_by(tibble(x = c(1, 1, 1), y = 1:3), x)
-  expect_snapshot((expect_warning(out <- nest(df, .key = "y"))))
+  expect_snapshot(out <- nest(df, .key = "y"))
   expect_named(out, c("x", "y"))
 })
 
 test_that(".key gets warning with new interface", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
-  expect_snapshot((expect_warning(out <- nest(df, y = y, .key = "y"))))
+  expect_snapshot(out <- nest(df, y = y, .key = "y"))
   expect_named(df, c("x", "y"))
 })
 
 test_that("cols must go in cols", {
   df <- tibble(x = list(3, 4), y = list("a", "b"))
-  expect_snapshot((expect_warning(unnest(df, x, y))))
+  expect_snapshot(unnest(df, x, y))
 })
 
 test_that("need supply column names", {
   df <- tibble(x = 1:2, y = list("a", "b"))
-  expect_snapshot((expect_warning(unnest(df))))
+  expect_snapshot(unnest(df))
 })
 
 test_that("sep combines column names", {
   local_options(lifecycle_verbosity = "warning")
   df <- tibble(x = list(tibble(x = 1)), y = list(tibble(x = 1)))
-  expect_snapshot((expect_warning(out <- df %>% unnest(c(x, y), .sep = "_"))))
+  expect_snapshot(out <- df %>% unnest(c(x, y), .sep = "_"))
   expect_named(out, c("x_x", "y_x"))
 })
 
 test_that("unnest has mutate semantics", {
   df <- tibble(x = 1:3, y = list(1, 2:3, 4))
-  expect_snapshot((expect_warning(out <- df %>% unnest(z = map(y, `+`, 1)))))
+  expect_snapshot(out <- df %>% unnest(z = map(y, `+`, 1)))
   expect_equal(out$z, 2:5)
 })
 
@@ -372,17 +372,17 @@ test_that(".drop and .preserve are deprecated", {
   local_options(lifecycle_verbosity = "warning")
 
   df <- tibble(x = list(3, 4), y = list("a", "b"))
-  expect_snapshot((expect_warning(df %>% unnest(x, .preserve = y))))
+  expect_snapshot(df %>% unnest(x, .preserve = y))
 
   df <- tibble(x = list(3, 4), y = list("a", "b"))
-  expect_snapshot((expect_warning(df %>% unnest(x, .drop = FALSE))))
+  expect_snapshot(df %>% unnest(x, .drop = FALSE))
 })
 
 test_that(".id creates vector of names for vector unnest", {
   local_options(lifecycle_verbosity = "warning")
 
   df <- tibble(x = 1:2, y = list(a = 1, b = 1:2))
-  expect_snapshot((expect_warning(out <- unnest(df, y, .id = "name"))))
+  expect_snapshot(out <- unnest(df, y, .id = "name"))
 
   expect_equal(out$name, c("a", "b", "b"))
 })

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -119,9 +119,7 @@ test_that("can override default keys", {
 test_that("duplicated keys produce list column with warning", {
   df <- tibble(a = c(1, 1, 2), key = c("x", "x", "x"), val = 1:3)
 
-  expect_snapshot((expect_warning(
-    pv <- pivot_wider(df, names_from = key, values_from = val)
-  )))
+  expect_snapshot(pv <- pivot_wider(df, names_from = key, values_from = val))
 
   expect_equal(pv$a, c(1, 2))
   expect_equal(as.list(pv$x), list(c(1L, 2L), 3L))

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -49,7 +49,7 @@ test_that("convert keeps characters as character", {
 test_that("too many pieces dealt with as requested", {
   df <- tibble(x = c("a b", "a b c"))
 
-  expect_snapshot((expect_warning(separate(df, x, c("x", "y")))))
+  expect_snapshot(separate(df, x, c("x", "y")))
 
   merge <- separate(df, x, c("x", "y"), extra = "merge")
   expect_equal(merge[[1]], c("a", "a"))
@@ -59,19 +59,13 @@ test_that("too many pieces dealt with as requested", {
   expect_equal(drop[[1]], c("a", "a"))
   expect_equal(drop[[2]], c("b", "b"))
 
-  expect_snapshot({
-    warn2 <- expect_warning(
-      warn1 <- expect_warning(separate(df, x, c("x", "y"), extra = "error"))
-    )
-    warn1
-    warn2
-  })
+  expect_snapshot(separate(df, x, c("x", "y"), extra = "error"))
 })
 
 test_that("too few pieces dealt with as requested", {
   df <- tibble(x = c("a b", "a b c"))
 
-  expect_snapshot((expect_warning(separate(df, x, c("x", "y", "z")))))
+  expect_snapshot(separate(df, x, c("x", "y", "z")))
 
   left <- separate(df, x, c("x", "y", "z"), fill = "left")
   expect_equal(left$x, c(NA, "a"))

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -49,7 +49,7 @@ test_that("convert keeps characters as character", {
 test_that("too many pieces dealt with as requested", {
   df <- tibble(x = c("a b", "a b c"))
 
-  expect_warning(separate(df, x, c("x", "y")), "Additional pieces discarded")
+  expect_snapshot((expect_warning(separate(df, x, c("x", "y")))))
 
   merge <- separate(df, x, c("x", "y"), extra = "merge")
   expect_equal(merge[[1]], c("a", "a"))
@@ -59,15 +59,19 @@ test_that("too many pieces dealt with as requested", {
   expect_equal(drop[[1]], c("a", "a"))
   expect_equal(drop[[2]], c("b", "b"))
 
-  suppressWarnings(
-    expect_warning(separate(df, x, c("x", "y"), extra = "error"), "deprecated")
-  )
+  expect_snapshot({
+    warn2 <- expect_warning(
+      warn1 <- expect_warning(separate(df, x, c("x", "y"), extra = "error"))
+    )
+    warn1
+    warn2
+  })
 })
 
 test_that("too few pieces dealt with as requested", {
   df <- tibble(x = c("a b", "a b c"))
 
-  expect_warning(separate(df, x, c("x", "y", "z")), "Missing pieces filled")
+  expect_snapshot((expect_warning(separate(df, x, c("x", "y", "z")))))
 
   left <- separate(df, x, c("x", "y", "z"), fill = "left")
   expect_equal(left$x, c(NA, "a"))


### PR DESCRIPTION
As mentioned in https://github.com/tidyverse/tidyr/pull/1204#discussion_r745873267