### PR TITLE
Ensure `ptype` is used on non-list columns in `unchop()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr (development version)
 
+* `unchop()` now respects `ptype` when unnesting a non-list column (#1211).
+
 * The `nest()` generic now avoids computing on `.data`, making it more
   compatible with lazy tibbles (#1134).
   

--- a/R/chop.R
+++ b/R/chop.R
@@ -209,15 +209,20 @@ df_unchop <- function(x, ..., ptype = list(), keep_empty = FALSE) {
 
   for (i in seq_len_width) {
     col <- x[[i]]
+    col_name <- names[[i]]
     col_is_list <- x_is_list[[i]]
 
+    col_ptype <- ptype[[col_name]]
+
     if (!col_is_list) {
+      if (!is_null(col_ptype)) {
+        col <- vec_cast(col, col_ptype, x_arg = col_name)
+      }
       out_cols[[i]] <- vec_slice(col, out_loc)
       next
     }
 
-    col_name <- names[[i]]
-    col_ptype <- ptype[[col_name]] %||% attr(col, "ptype", exact = TRUE)
+    col_ptype <- col_ptype %||% attr(col, "ptype", exact = TRUE)
 
     # Drop to a bare list to avoid dispatch
     col <- unclass(col)

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -189,6 +189,15 @@ test_that("ptype overrides list-of ptype", {
   )
 })
 
+test_that("ptype is utilized on non-list columns (#1211)", {
+  df <- tibble(x = 1)
+
+  expect_identical(
+    unchop(df, x, ptype = list(x = integer())),
+    tibble(x = 1L)
+  )
+})
+
 test_that("the ptype must be a list", {
   expect_snapshot(error = TRUE, unchop(mtcars, mpg, ptype = 1))
 })


### PR DESCRIPTION
Closes #1211 