### PR TITLE
Documentation fix for name discard (pivot_longer)

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -23,7 +23,7 @@
 #'   or `names_pattern` is provided. In this case, there are two special
 #'   values you can take advantage of:
 #'
-#'   * `NA` will discard that component of the name.
+#'   * `NULL` will discard that component of the name.
 #'   * `.value` indicates that component of the name defines the name of the
 #'     column containing the cell values, overriding `values_to`.
 #' @param names_prefix A regular expression used to remove matching text


### PR DESCRIPTION
Documentation explains to use NA for the argument names_to when using pivot_longer. This throws an error and the correct argument is NULL, which provides the intended functionality.
``` r
library(tidyverse)

lollies <- tibble::tribble(
   ~flavour, ~number_of_licks, ~price,
   "orange", 115, 2.5,
   "strawberry", 87, 1.7
)
lollies
#> # A tibble: 2 x 3
#>   flavour    number_of_licks price
#>   <chr>                <dbl> <dbl>
#> 1 orange                 115   2.5
#> 2 strawberry              87   1.7
lollies %>% tidyr::pivot_longer(number_of_licks:price, names_to = NA, values_to = "x")
#> Error: The LHS of `:=` must be a string or a symbol
lollies %>% tidyr::pivot_longer(number_of_licks:price, names_to = NULL, values_to = "x")
#> # A tibble: 4 x 2
#>   flavour        x
#>   <chr>      <dbl>
#> 1 orange     115  
#> 2 orange       2.5
#> 3 strawberry  87  
#> 4 strawberry   1.7
```

<sup>Created on 2021-11-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>