### PR TITLE
Ensure snapshot tests are static

### DIFF
--- a/tests/testthat/_snaps/gather.md
+++ b/tests/testthat/_snaps/gather.md
@@ -15,6 +15,6 @@
       they will be dropped
     Output
             k          v
-      1 date1 1636502400
-      2 date2      18951
+      1 date1 1546300800
+      2 date2      17897
 

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -165,8 +165,8 @@ test_that("common attributes are preserved", {
 
 test_that("varying attributes are dropped with a warning", {
   df <- data.frame(
-    date1 = as.POSIXct(Sys.Date()),
-    date2 = Sys.Date() + 10
+    date1 = as.POSIXct("2019-01-01", tz = "UTC"),
+    date2 = as.Date("2019-01-01")
   )
   expect_snapshot(gather(df, k, v))
 })


### PR DESCRIPTION
Follow up to https://github.com/tidyverse/tidyr/pull/1210

Make sure the snapshot tests don't rely on the current date in any way 🤦 