### PR TITLE
Update `replace_na()` to utilize vctrs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # tidyr (development version)
 
+* `replace_na()` has been updated to utilize vctrs. This has resulted in the
+  following changes:
+  
+  * The type of `data` can no longer change when the replacement is applied.
+    `replace` will now always be cast to the type of `data` before the
+    replacement is made. For example, this means that using a replacement value
+    of `1.5` on an integer column is no longer allowed. Similarly, replacing
+    missing values in a list-column must now be done with `list("foo")` rather
+    than just `"foo"`.
+    
+  * For list-columns, empty atomic elements like `integer(0)` are no longer
+    replaced. The only value that is replaced in a list-column is `NULL`
+    (#1168).
+    
+  * Replacements can now be done on a much larger variety of types and columns,
+    including data frame columns and the rcrd type from vctrs.
+  
+  Note that in general `replace_na()` is considered to be superseded in favor
+  of a combination of `dplyr::across()` and `dplyr::coalesce()`, which also
+  allows you to utilize tidyselect.
+  
 * `fill()` is now backed by `vctrs::vec_fill_missing()`, which provides a more
   comprehensive method for filling different types of missing values. This
   results in the following improvements:

--- a/R/replace_na.R
+++ b/R/replace_na.R
@@ -8,8 +8,7 @@
 #'   replaces all of the `NA` values in the vector.
 #' @param ... Additional arguments for methods. Currently unused.
 #' @return
-#' * If `data` is a data frame, `replace_na()` returns a data frame.
-#' * If `data` is a vector, `replace_na()` returns a vector of the same type.
+#' `replace_na()` returns an object with the same type as `data`.
 #' @seealso [dplyr::na_if()] to replace specified values with `NA`s;
 #'   [dplyr::coalesce()] to replaces `NA`s with values from other vectors.
 #' @export

--- a/R/replace_na.R
+++ b/R/replace_na.R
@@ -9,8 +9,7 @@
 #' @param ... Additional arguments for methods. Currently unused.
 #' @return
 #' * If `data` is a data frame, `replace_na()` returns a data frame.
-#' * If `data` is a vector, `replace_na()` returns a vector, with class
-#'   given by the union of `data` and `replace`.
+#' * If `data` is a vector, `replace_na()` returns a vector of the same type.
 #' @seealso [dplyr::na_if()] to replace specified values with `NA`s;
 #'   [dplyr::coalesce()] to replaces `NA`s with values from other vectors.
 #' @export
@@ -36,29 +35,50 @@ replace_na <- function(data, replace, ...) {
 #' @export
 replace_na.default <- function(data, replace = NA, ...) {
   check_replacement(replace, "data")
-  data[!is_complete(data)] <- replace
-  data
+  missing <- vec_equal_na(data)
+  vec_assign(data, missing, replace, x_arg = "data", value_arg = "replace")
 }
 
 #' @export
 replace_na.data.frame <- function(data, replace = list(), ...) {
-  stopifnot(is_list(replace))
+  if (!vec_is_list(replace)) {
+    abort("`replace` must be a list.")
+  }
 
-  replace_vars <- intersect(names(replace), names(data))
+  names <- intersect(names(replace), names(data))
 
-  for (var in replace_vars) {
-    check_replacement(replace[[var]], var)
-    data[[var]][!is_complete(data[[var]])] <- replace[[var]]
+  col_args <- as.character(glue("data${names}"))
+  value_args <- as.character(glue("replace${names}"))
+
+  for (i in seq_along(names)) {
+    name <- names[[i]]
+
+    col <- data[[name]]
+    value <- replace[[name]]
+
+    col_arg <- col_args[[i]]
+    value_arg <- value_args[[i]]
+
+    check_replacement(value, col_arg)
+
+    missing <- vec_equal_na(col)
+
+    data[[name]] <- vec_assign(
+      x = col,
+      i = missing,
+      value = value,
+      x_arg = col_arg,
+      value_arg = value_arg
+    )
   }
 
   data
 }
 
 check_replacement <- function(x, var) {
-  n <- length(x)
-  if (n == 1) {
-    return()
-  }
+  n <- vec_size(x)
 
-  abort(glue("Replacement for `{var}` is length {n}, not length 1"))
+  if (n != 1) {
+    abort(glue("Replacement for `{var}` is length {n}, not length 1."))
+  }
 }

--- a/man/replace_na.Rd
+++ b/man/replace_na.Rd
@@ -20,8 +20,7 @@ replaces all of the \code{NA} values in the vector.}
 \value{
 \itemize{
 \item If \code{data} is a data frame, \code{replace_na()} returns a data frame.
-\item If \code{data} is a vector, \code{replace_na()} returns a vector, with class
-given by the union of \code{data} and \code{replace}.
+\item If \code{data} is a vector, \code{replace_na()} returns a vector of the same type.
 }
 }
 \description{

--- a/man/replace_na.Rd
+++ b/man/replace_na.Rd
@@ -18,10 +18,7 @@ replaces all of the \code{NA} values in the vector.}
 \item{...}{Additional arguments for methods. Currently unused.}
 }
 \value{
-\itemize{
-\item If \code{data} is a data frame, \code{replace_na()} returns a data frame.
-\item If \code{data} is a vector, \code{replace_na()} returns a vector of the same type.
-}
+\code{replace_na()} returns an object with the same type as \code{data}.
 }
 \description{
 Replace NAs with specified values

--- a/tests/testthat/_snaps/replace_na.md
+++ b/tests/testthat/_snaps/replace_na.md
@@ -1,0 +1,18 @@
+# replacement must be castable to `data`
+
+    Code
+      (expect_error(replace_na(x, 1.5)))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Can't convert from `replace` <double> to `data` <integer> due to loss of precision.
+      * Locations: 1
+
+# replacement must be castable to corresponding column
+
+    Code
+      (expect_error(replace_na(df, list(a = 1.5))))
+    Output
+      <error/vctrs_error_cast_lossy>
+      Can't convert from `replace$a` <double> to `data$a` <integer> due to loss of precision.
+      * Locations: 1
+

--- a/tests/testthat/test-replace_na.R
+++ b/tests/testthat/test-replace_na.R
@@ -14,6 +14,38 @@ test_that("can only be length 0", {
   expect_error(replace_na(1, 1:10), "length 10, not length 1")
 })
 
+test_that("can replace missing rows in arrays", {
+  x <- matrix(c(NA, NA, NA, 6), nrow = 2)
+  replace <- matrix(c(-1, -2), nrow = 1)
+  expect <- matrix(c(-1, NA, -2, 6), nrow = 2)
+
+  expect_identical(replace_na(x, replace), expect)
+})
+
+test_that("can replace missing values in rcrds", {
+  x <- new_rcrd(list(x = c(1, NA, NA), y = c(1, NA, 2)))
+  expect <- new_rcrd(list(x = c(1, 0, NA), y = c(1, 0, 2)))
+
+  expect_identical(
+    replace_na(x, new_rcrd(list(x = 0, y = 0))),
+    expect
+  )
+})
+
+test_that("replacement must be castable to `data`", {
+  x <- c(1L, NA)
+  expect_snapshot((expect_error(replace_na(x, 1.5))))
+})
+
+test_that("empty atomic elements are not replaced in lists (#1168)", {
+  x <- list(character(), NULL)
+
+  expect_identical(
+    replace_na(x, replace = list("foo")),
+    list(character(), "foo")
+  )
+})
+
 # data frame -------------------------------------------------------------
 
 test_that("empty call does nothing", {
@@ -39,4 +71,24 @@ test_that("can replace NULLs in list-column", {
   rs <- replace_na(df, list(x = list(1:5)))
 
   expect_identical(rs, tibble(x = list(1, 1:5)))
+})
+
+test_that("df-col rows must be completely missing to be replaceable", {
+  col <- tibble(x = c(1, NA, NA), y = c(1, 2, NA))
+  df <- tibble(a = col)
+
+  col <- tibble(x = c(1, NA, -1), y = c(1, 2, -2))
+  expect <- tibble(a = col)
+
+  replace <- tibble(x = -1, y = -2)
+
+  expect_identical(
+    replace_na(df, list(a = replace)),
+    expect
+  )
+})
+
+test_that("replacement must be castable to corresponding column", {
+  df <- tibble(a = c(1L, NA))
+  expect_snapshot((expect_error(replace_na(df, list(a = 1.5)))))
 })


### PR DESCRIPTION
Revival of https://github.com/tidyverse/tidyr/pull/1109
Closes #1168 
Closes #912 (by mentioning that you should use `across()` in the NEWS bullet)

This PR updates `replace_na()` to utilize vctrs through `vec_equal_na()` and `vec_assign()`. This has two breaking changes:

- `vec_assign()` always casts the RHS to the LHS, but previously with `[<-` the reverse could be true. I think this is a step in the right direction
  - This means you can't do `replace = 1.5` on an integer vector
  - More practically, it means for lists you can't do `replace = "foo"`, it must be `replace = list("foo")`

- `vec_equal_na()` is now used for detecting missing values. For list-cols, it will only detect `NULL` as missing, while the current implementation will replace `NULL` and empty atomics like `integer()`. Again, I think this is a net positive.

