### PR TITLE
Use `vec_paste0()` in place of `paste0()` to avoid recycling issues

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -67,7 +67,7 @@ str_extract <- function(x, into, regex, convert = FALSE) {
   if (anyDuplicated(into)) {
     pieces <- split(out, into)
     into <- names(pieces)
-    out <- map(pieces, pmap_chr, paste0, sep = "")
+    out <- map(pieces, pmap_chr, vec_paste0)
   }
 
   into <- as_utf8_character(into)

--- a/R/pack.R
+++ b/R/pack.R
@@ -134,7 +134,7 @@ rename_with_names_sep <- function(x, outer, names_sep) {
 }
 
 strip_names <- function(df, base, names_sep) {
-  base <- paste0(base, names_sep)
+  base <- vec_paste0(base, names_sep)
   names <- names(df)
 
   has_prefix <- regexpr(base, names, fixed = TRUE) == 1L

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -279,7 +279,7 @@ build_longer_spec <- function(data, cols,
   if (is.null(names_prefix)) {
     names <- names(cols)
   } else {
-    names <- gsub(paste0("^", names_prefix), "", names(cols))
+    names <- gsub(vec_paste0("^", names_prefix), "", names(cols))
   }
 
   if (length(names_to) > 1) {

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -302,7 +302,7 @@ build_wider_spec <- function(data,
   row_names <- exec(paste, !!!row_ids, sep = names_sep)
 
   out <- tibble(
-    .name = paste0(names_prefix, row_names)
+    .name = vec_paste0(names_prefix, row_names)
   )
 
   if (length(values_from) == 1) {
@@ -310,7 +310,7 @@ build_wider_spec <- function(data,
   } else {
     out <- vec_rep(out, vec_size(values_from))
     out$.value <- vec_rep_each(names(values_from), vec_size(row_ids))
-    out$.name <- paste0(out$.value, names_sep, out$.name)
+    out$.name <- vec_paste0(out$.value, names_sep, out$.name)
 
     row_ids <- vec_rep(row_ids, vec_size(values_from))
   }

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -336,7 +336,7 @@ unnest_longer <- function(data,
   }
 
   if (is.null(indices_to)) {
-    indices_to <- paste0(values_to, "_id")
+    indices_to <- vec_paste0(values_to, "_id")
   } else {
     if (is_false(indices_include)) {
       abort("Can't set `indices_include` to `FALSE` when `indices_to` is supplied.")

--- a/R/spread.R
+++ b/R/spread.R
@@ -91,7 +91,7 @@ spread.data.frame <- function(data, key, value, fill = NA, convert = FALSE,
     shared <- sum(map_int(groups, length))
 
     str <- map_chr(groups, function(x) paste0(x, collapse = ", "))
-    rows <- paste0(paste0("* ", str, "\n"), collapse = "")
+    rows <- paste0(vec_paste0("* ", str, "\n"), collapse = "")
     abort(glue(
       "Each row of output must be identified by a unique combination of keys.",
       "\nKeys are shared for {shared} rows:",

--- a/R/utils.R
+++ b/R/utils.R
@@ -207,3 +207,9 @@ check_present <- function(x) {
   }
 
 }
+
+vec_paste0 <- function(...) {
+  # Use tidyverse recycling rules to avoid size zero recycling bugs
+  args <- vec_recycle_common(...)
+  exec(paste0, !!!args)
+}


### PR DESCRIPTION
Closes #1185 

- This ensures a mix of size 0 and size 1 inputs result in a size 0 output
- No `collapse` argument, because that is fundamentally a different operation that should always return a size 1 result

