### PR TITLE
Rework grid functions to be more robust to duplicate auto names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # tidyr (development version)
 
+* A number of bugs have been fixed for the grid functions, `expand_grid()`,
+  `nesting()`, `crossing()`, and `expand()`:
+  
+  * Automatically named input now has unique name repair applied to it silently.
+    This avoids a number of issues resulting from duplicate truncated names
+    (#1116, #1221, #1092, #1037, #992).
+    
+  * Columns from unnamed data frames can now be used in expressions after that
+    data frame was specified, like `expand_grid(tibble(x = 1), y = x)`. This
+    is more consistent with how `tibble()` behaves.
+    
+  * Supplying data frames with 0 columns but >0 rows now works correctly
+    (#1189).
+  
+  * `expand_grid()`, `expand()`, and `crossing()` now return a 1 row data frame
+    when no inputs are supplied, which is more consistent with `prod() == 1L`.
+
 * `drop_na()` has been updated to utilize `vctrs::vec_detect_complete()`. This
   has resulted in the following changes:
   

--- a/R/expand.R
+++ b/R/expand.R
@@ -100,11 +100,25 @@ expand.grouped_df <- function(data, ..., .name_repair = "check_unique") {
 #' @rdname expand
 #' @export
 crossing <- function(..., .name_repair = "check_unique") {
-  cols <- dots_cols(...)
-  cols[] <- map(cols, sorted_unique)
+  out <- grid_dots(...)
+  out <- map(out, sorted_unique)
 
-  out <- expand_grid(!!!cols, .name_repair = .name_repair)
-  flatten_nested(out, attr(cols, "named"), .name_repair)
+  # Flattens unnamed data frames returned from `grid_dots()`
+  expand_grid(!!!out, .name_repair = .name_repair)
+}
+
+#' @rdname expand
+#' @export
+nesting <- function(..., .name_repair = "check_unique") {
+  out <- grid_dots(...)
+
+  # Flattens unnamed data frames
+  out <- data_frame(!!!out, .name_repair = .name_repair)
+  out <- tibble::new_tibble(out, nrow = vec_size(out))
+
+  out <- sorted_unique(out)
+
+  out
 }
 
 sorted_unique <- function(x) {
@@ -116,14 +130,6 @@ sorted_unique <- function(x) {
   } else {
     vec_sort(vec_unique(x))
   }
-}
-
-#' @rdname expand
-#' @export
-nesting <- function(..., .name_repair = "check_unique") {
-  cols <- dots_cols(...)
-  out <- sorted_unique(tibble(!!!cols, .name_repair = .name_repair))
-  flatten_nested(out, attr(cols, "named"), .name_repair)
 }
 
 # expand_grid -------------------------------------------------------------

--- a/R/pack.R
+++ b/R/pack.R
@@ -142,3 +142,32 @@ strip_names <- function(df, base, names_sep) {
 
   set_names(df, names)
 }
+
+flatten_at <- function(x, to_flatten) {
+  if (!any(to_flatten)) {
+    return(x)
+  }
+
+  cols <- rep(1L, length(x))
+  cols[to_flatten] <- map_int(x[to_flatten], length)
+
+  out <- vector("list", sum(cols))
+  names <- vector("character", sum(cols))
+  j <- 1
+  for (i in seq_along(x)) {
+    if (cols[[i]] == 0) {
+      next
+    }
+
+    if (to_flatten[[i]]) {
+      out[j:(j + cols[[i]] - 1)] <- x[[i]]
+      names[j:(j + cols[[i]] - 1)] <- names(x[[i]])
+    } else {
+      out[[j]] <- x[[i]]
+      names[[j]] <- names(x)[[i]]
+    }
+    j <- j + cols[[i]]
+  }
+  names(out) <- names
+  out
+}

--- a/tests/testthat/_snaps/expand.md
+++ b/tests/testthat/_snaps/expand.md
@@ -1,0 +1,27 @@
+# expand_grid() can control name_repair
+
+    Code
+      (expect_error(expand_grid(x = x, x = x)))
+    Output
+      <error/vctrs_error_names_must_be_unique>
+      Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
+
+---
+
+    Code
+      out <- expand_grid(x = x, x = x, .name_repair = "unique")
+    Message <simpleMessage>
+      New names:
+      * x -> x...1
+      * x -> x...2
+
+# grid_dots() reject non-vector input
+
+    Code
+      (expect_error(grid_dots(lm(1 ~ 1))))
+    Output
+      <error/vctrs_error_scalar_type>
+      `..1` must be a vector, not a <lm> object.
+

--- a/tests/testthat/_snaps/expand.md
+++ b/tests/testthat/_snaps/expand.md
@@ -6,6 +6,15 @@
       <error/vctrs_error_scalar_type>
       `..2` must be a vector, not a symbol.
 
+# expand() respects `.name_repair`
+
+    Code
+      out <- df %>% expand(x = x, x = x, .name_repair = "unique")
+    Message <simpleMessage>
+      New names:
+      * x -> x...1
+      * x -> x...2
+
 # crossing() / nesting() respect `.name_repair`
 
     Code

--- a/tests/testthat/_snaps/expand.md
+++ b/tests/testthat/_snaps/expand.md
@@ -1,3 +1,29 @@
+# crossing checks for bad inputs
+
+    Code
+      (expect_error(crossing(x = 1:10, y = quote(a))))
+    Output
+      <error/vctrs_error_scalar_type>
+      `..2` must be a vector, not a symbol.
+
+# crossing() / nesting() respect `.name_repair`
+
+    Code
+      out <- crossing(x = x, x = x, .name_repair = "unique")
+    Message <simpleMessage>
+      New names:
+      * x -> x...1
+      * x -> x...2
+
+---
+
+    Code
+      out <- nesting(x = x, x = x, .name_repair = "unique")
+    Message <simpleMessage>
+      New names:
+      * x -> x...1
+      * x -> x...2
+
 # expand_grid() can control name_repair
 
     Code

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -10,7 +10,7 @@ test_that("multiple variables in one arg doesn't expand", {
   expect_equal(nrow(out), 2)
 })
 
-test_that("nesting doesn't expand values", {
+test_that("expand with nesting doesn't expand values", {
   df <- tibble(x = 1:2, y = 1:2)
   expect_equal(expand(df, nesting(x, y)), df)
 })
@@ -39,7 +39,7 @@ test_that("expand works with non-standard col names", {
   expect_equal(nrow(out), 4)
 })
 
-test_that("expand excepts expressions", {
+test_that("expand accepts expressions", {
   df <- expand(data.frame(), x = 1:3, y = 3:1)
   expect_equal(df, crossing(x = 1:3, y = 3:1))
 })
@@ -64,22 +64,9 @@ test_that("preserves ordered factors", {
   expect_equal(df$a, ordered("a"))
 })
 
-test_that("preserves NAs", {
-  x <- c("A", "B", NA)
-  expect_equal(crossing(x)$x, x)
-  expect_equal(nesting(x)$x, x)
-})
-
-test_that("crossing preserves factor levels", {
-  x_na_lev_extra <- factor(c("a", NA), levels = c("a", "b", NA), exclude = NULL)
-  expect_equal(levels(crossing(x = x_na_lev_extra)$x), c("a", "b", NA))
-})
-
 test_that("NULL inputs", {
   tb <- tibble(x = 1:5)
   expect_equal(expand(tb, x, y = NULL), tb)
-  expect_equal(nesting(x = tb$x, y = NULL), tb)
-  expect_equal(crossing(x = tb$x, y = NULL), tb)
 })
 
 test_that("zero length input gives zero length output", {
@@ -109,8 +96,31 @@ test_that("expand() reconstructs input dots is empty", {
   expect_s3_class(expand(as_tibble(mtcars)), "tbl_df")
 })
 
+test_that("expand() with no inputs returns 1 row", {
+  expect_identical(expand(tibble()), tibble(.rows = 1L))
+})
+
+# ------------------------------------------------------------------------------
+
 test_that("crossing checks for bad inputs", {
   expect_snapshot((expect_error(crossing(x = 1:10, y = quote(a)))))
+})
+
+test_that("preserves NAs", {
+  x <- c("A", "B", NA)
+  expect_equal(crossing(x)$x, x)
+  expect_equal(nesting(x)$x, x)
+})
+
+test_that("crossing() preserves factor levels", {
+  x_na_lev_extra <- factor(c("a", NA), levels = c("a", "b", NA), exclude = NULL)
+  expect_equal(levels(crossing(x = x_na_lev_extra)$x), c("a", "b", NA))
+})
+
+test_that("NULL inputs", {
+  tb <- tibble(x = 1:5)
+  expect_equal(nesting(x = tb$x, y = NULL), tb)
+  expect_equal(crossing(x = tb$x, y = NULL), tb)
 })
 
 test_that("crossing handles list columns", {
@@ -214,13 +224,6 @@ test_that("can use `do.call()` or `reduce()` with `crossing()` (#992)", {
     crossing(crossing(x[[1]], x[[2]]), x[[3]]),
     purrr::reduce(x, crossing)
   )
-})
-
-# dots_cols supports lazy evaluation --------------------------------------
-
-test_that("dots_cols evaluates each expression in turn", {
-  out <- dots_cols(x = seq(-2, 2), y = x)
-  expect_equal(out$x, out$y)
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -138,9 +138,10 @@ test_that("expand() respects `.name_repair`", {
   x <- 1:2
   df <- tibble(x)
 
-  suppressMessages(
-    expect_named(df %>% expand(x, x, .name_repair = "unique"), c("x...1", "x...2"))
+  expect_snapshot(
+    out <- df %>% expand(x = x, x = x, .name_repair = "unique")
   )
+  expect_named(out, c("x...1", "x...2"))
 })
 
 test_that("crossing() / nesting() respect `.name_repair`", {


### PR DESCRIPTION
Related to auto-naming:
Closes #1221 
Closes #1116 
Closes #1092 
Closes #1037 
Closes #992 

Other:
Closes #1189 

This was a tricky one to fix.

Ultimately, I combined a few ideas together:
- We essentially use `quos_auto_name(repair_auto = "unique", repair_quiet = TRUE)` from https://github.com/r-lib/rlang/pull/1194, but that is in rlang 1.0.0 and we don't use dev rlang yet. So I've just inlined the idea of it for now. Notably, that only performs unique repair on the auto-named inputs, which is definitely the right approach. This avoids getting duplicate names like `<int>` or truncated names like `tibble(...)` when a long tibble expression is inlined.
- We take an approach more similar to `tibble:::tibble_quos()` for iterative expressions (i.e. when the user does `x = 1, y = x`). This involves setting up a data mask that is separate from the actual output object.
- Unnamed data frames are given a list element name of `""` before returning from `grid_dots()`, which serves as a signal that they should be unpacked when supplied to `data_frame()`. This means we were able to get rid of all usage of `flatten_at()` and `flatten_nested()`.

No changes to worse in revdeps