### PR TITLE
Implement optional simplification on a per column basis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,9 @@
   * If a `ptype` is supplied, but that column can't be simplified, the result
     will be a list-of column where each element has type `ptype` (#998).
     
+  * `simplify` now accepts a named list of `TRUE` or `FALSE` to control
+    simplification on a per column basis (#995).
+    
   * `unnest_wider()` has a new `strict` argument which controls whether or not
     strict vctrs typing rules should be applied. It defaults to `FALSE` for
     backwards compatibility, and because it is often more useful to be lax

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -70,7 +70,10 @@ components are removed from \code{.col}, then \code{.col} will be removed from t
 result entirely.}
 
 \item{.simplify, simplify}{If \code{TRUE}, will attempt to simplify lists of
-length-1 vectors to an atomic vector.}
+length-1 vectors to an atomic vector. Can also be a named list containing
+\code{TRUE} or \code{FALSE} declaring whether or not to attempt to simplify a
+particular column. If a named list is provided, the default for any
+unspecified columns is \code{TRUE}.}
 
 \item{.ptype, ptype}{Optionally, a named list of prototypes declaring the
 desired output type of each component. Use this argument if you want to
@@ -206,6 +209,10 @@ df
 
 # Turn all components of metadata into columns
 df \%>\% unnest_wider(metadata)
+
+# Choose not to simplify list-cols of length-1 elements
+df \%>\% unnest_wider(metadata, simplify = FALSE)
+df \%>\% unnest_wider(metadata, simplify = list(color = FALSE))
 
 # Extract only specified components
 df \%>\% hoist(metadata,

--- a/tests/testthat/_snaps/rectangle.md
+++ b/tests/testthat/_snaps/rectangle.md
@@ -196,17 +196,27 @@
       (expect_error(df_simplify(data.frame(), simplify = 1)))
     Output
       <error/rlang_error>
-      `simplify` must be a single `TRUE` or `FALSE`.
+      `simplify` must be a list or a single `TRUE` or `FALSE`.
     Code
       (expect_error(df_simplify(data.frame(), simplify = NA)))
     Output
       <error/rlang_error>
-      `simplify` must be a single `TRUE` or `FALSE`.
+      `simplify` must be a list or a single `TRUE` or `FALSE`.
     Code
       (expect_error(df_simplify(data.frame(), simplify = c(TRUE, FALSE))))
     Output
       <error/rlang_error>
-      `simplify` must be a single `TRUE` or `FALSE`.
+      `simplify` must be a list or a single `TRUE` or `FALSE`.
+    Code
+      (expect_error(df_simplify(data.frame(), simplify = list(1))))
+    Output
+      <error/rlang_error>
+      All elements of `simplify` must be named.
+    Code
+      (expect_error(df_simplify(data.frame(), simplify = list(x = 1, x = 1))))
+    Output
+      <error/rlang_error>
+      The names of `simplify` must be unique.
 
 # `ptype` is validated
 

--- a/tests/testthat/test-rectangle.R
+++ b/tests/testthat/test-rectangle.R
@@ -159,6 +159,20 @@ test_that("hoist() input must be a data frame (#1224)", {
   expect_snapshot((expect_error(hoist(1))))
 })
 
+test_that("hoist() can simplify on a per column basis (#995)", {
+  df <- tibble(
+    x = list(
+      list(a = 1, b = 1),
+      list(a = 2, b = 2)
+    )
+  )
+
+  expect_identical(
+    hoist(df, x, a = "a", b = "b", .simplify = list(a = FALSE)),
+    tibble(a = list(1, 2), b = c(1, 2))
+  )
+})
+
 # strike ------------------------------------------------------------------
 
 test_that("strike can remove using a list", {
@@ -804,6 +818,8 @@ test_that("`simplify` is validated", {
     (expect_error(df_simplify(data.frame(), simplify = 1)))
     (expect_error(df_simplify(data.frame(), simplify = NA)))
     (expect_error(df_simplify(data.frame(), simplify = c(TRUE, FALSE))))
+    (expect_error(df_simplify(data.frame(), simplify = list(1))))
+    (expect_error(df_simplify(data.frame(), simplify = list(x = 1, x = 1))))
   })
 })
 
@@ -821,6 +837,29 @@ test_that("`transform` is validated", {
     (expect_error(df_simplify(data.frame(), transform = list(1))))
     (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))
   })
+})
+
+test_that("`simplify` can be a named list (#995)", {
+  df <- tibble(x = list(1), y = list("a"))
+
+  expect_identical(
+    df_simplify(df, simplify = list(x = FALSE)),
+    data_frame(x = list(1), y = "a")
+  )
+
+  expect_identical(
+    df_simplify(df, simplify = list(x = TRUE, y = FALSE)),
+    data_frame(x = 1, y = list("a"))
+  )
+})
+
+test_that("`simplify` elements are ignored if they don't correspond to a column", {
+  df <- tibble(x = list(1), y = list("a"))
+
+  expect_identical(
+    df_simplify(df, simplify = list(z = FALSE)),
+    data_frame(x = 1, y = "a")
+  )
 })
 
 # col_simplify -----------------------------------------------------------


### PR DESCRIPTION
Closes #995 

The best interface we could come up with is to provide a named list of `TRUE` or `FALSE`. This:
- Matches `ptype` and `transform` pretty well
- Isn't ambiguous with a single `TRUE` or `FALSE` in any way
- Is easy to program with internally