### PR TITLE
Clarify that both `character()` and `NULL` are allowed for `names_to`

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -16,16 +16,25 @@
 #' @param data A data frame to pivot.
 #' @param cols <[`tidy-select`][tidyr_tidy_select]> Columns to pivot into
 #'   longer format.
-#' @param names_to A string specifying the name of the column to create
-#'   from the data stored in the column names of `data`.
+#' @param names_to A character vector specifying the new column or columns to
+#'   create from the information stored in the column names of `data` specified
+#'   by `cols`.
 #'
-#'   Can be a character vector, creating multiple columns, if `names_sep`
-#'   or `names_pattern` is provided. In this case, there are two special
-#'   values you can take advantage of:
+#'   * If length 0, or if `NULL` is supplied, no columns will be created.
 #'
-#'   * `NA` will discard that component of the name.
-#'   * `.value` indicates that component of the name defines the name of the
-#'     column containing the cell values, overriding `values_to`.
+#'   * If length 1, a single column will be created which will contain the
+#'     column names specified by `cols`.
+#'
+#'   * If length >1, multiple columns will be created. In this case, one of
+#'     `names_sep` or `names_pattern` must be supplied to specify how the
+#'     column names should be split. There are also two additional character
+#'     values you can take advantage of:
+#'
+#'     * `NA` will discard the corresponding component of the column name.
+#'
+#'     * `".value"` indicates that the corresponding component of the column
+#'       name defines the name of the output column containing the cell values,
+#'       overriding `values_to` entirely.
 #' @param names_prefix A regular expression used to remove matching text
 #'   from the start of each variable name.
 #' @param names_sep,names_pattern If `names_to` contains multiple values,

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -27,16 +27,23 @@ pivot_longer(
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pivot into
 longer format.}
 
-\item{names_to}{A string specifying the name of the column to create
-from the data stored in the column names of \code{data}.
-
-Can be a character vector, creating multiple columns, if \code{names_sep}
-or \code{names_pattern} is provided. In this case, there are two special
+\item{names_to}{A character vector specifying the new column or columns to
+create from the information stored in the column names of \code{data} specified
+by \code{cols}.
+\itemize{
+\item If length 0, or if \code{NULL} is supplied, no columns will be created.
+\item If length 1, a single column will be created which will contain the
+column names specified by \code{cols}.
+\item If length >1, multiple columns will be created. In this case, one of
+\code{names_sep} or \code{names_pattern} must be supplied to specify how the
+column names should be split. There are also two additional character
 values you can take advantage of:
 \itemize{
-\item \code{NA} will discard that component of the name.
-\item \code{.value} indicates that component of the name defines the name of the
-column containing the cell values, overriding \code{values_to}.
+\item \code{NA} will discard the corresponding component of the column name.
+\item \code{".value"} indicates that the corresponding component of the column
+name defines the name of the output column containing the cell values,
+overriding \code{values_to} entirely.
+}
 }}
 
 \item{names_prefix}{A regular expression used to remove matching text

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -71,16 +71,23 @@ will be the common type of the input columns used to generate them.}
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pivot into
 longer format.}
 
-\item{names_to}{A string specifying the name of the column to create
-from the data stored in the column names of \code{data}.
-
-Can be a character vector, creating multiple columns, if \code{names_sep}
-or \code{names_pattern} is provided. In this case, there are two special
+\item{names_to}{A character vector specifying the new column or columns to
+create from the information stored in the column names of \code{data} specified
+by \code{cols}.
+\itemize{
+\item If length 0, or if \code{NULL} is supplied, no columns will be created.
+\item If length 1, a single column will be created which will contain the
+column names specified by \code{cols}.
+\item If length >1, multiple columns will be created. In this case, one of
+\code{names_sep} or \code{names_pattern} must be supplied to specify how the
+column names should be split. There are also two additional character
 values you can take advantage of:
 \itemize{
-\item \code{NA} will discard that component of the name.
-\item \code{.value} indicates that component of the name defines the name of the
-column containing the cell values, overriding \code{values_to}.
+\item \code{NA} will discard the corresponding component of the column name.
+\item \code{".value"} indicates that the corresponding component of the column
+name defines the name of the output column containing the cell values,
+overriding \code{values_to} entirely.
+}
 }}
 
 \item{values_to}{A string specifying the name of the column to create

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -1,0 +1,19 @@
+# `names_to` is validated
+
+    Code
+      (expect_error(build_longer_spec(df, x, names_to = 1)))
+    Output
+      <error/rlang_error>
+      `names_to` must be a character vector or `NULL`.
+    Code
+      (expect_error(build_longer_spec(df, x, names_to = c("x", "y"))))
+    Output
+      <error/rlang_error>
+      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+    Code
+      (expect_error(build_longer_spec(df, x, names_to = c("x", "y"), names_sep = "_",
+      names_pattern = "x")))
+    Output
+      <error/rlang_error>
+      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -170,10 +170,16 @@ test_that("validates inputs", {
   )
 })
 
-test_that("no names doesn't generate names", {
+test_that("no names doesn't generate names (#1120)", {
   df <- tibble(x = 1)
-  expect_equal(
+
+  expect_identical(
     colnames(build_longer_spec(df, x, names_to = character())),
+    c(".name", ".value")
+  )
+
+  expect_identical(
+    colnames(build_longer_spec(df, x, names_to = NULL)),
     c(".name", ".value")
   )
 })
@@ -244,4 +250,14 @@ test_that("can cast to custom type", {
 
 test_that("Error if the `col` can't be selected.", {
   expect_error(pivot_longer(iris, matches("foo")), "select at least one")
+})
+
+test_that("`names_to` is validated", {
+  df <- tibble(x = 1)
+
+  expect_snapshot({
+    (expect_error(build_longer_spec(df, x, names_to = 1)))
+    (expect_error(build_longer_spec(df, x, names_to = c("x", "y"))))
+    (expect_error(build_longer_spec(df, x, names_to = c("x", "y"), names_sep = "_", names_pattern = "x")))
+  })
 })


### PR DESCRIPTION
Closes #1120 

Ultimately since...
- We already allow `character()` and `NULL` in the CRAN version
- Both seem reasonable

...I went ahead and documented that both are allowed. Also refreshed the docs to explicitly describe the 3 cases which should also help avoid confusion like we had in https://github.com/tidyverse/tidyr/pull/1215