### PR TITLE
Update `wrap_error_names()` to override vctrs name repair `arg`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* `pivot_wider()` and `pivot_longer()` now generate more informative
+  errors related to name repair (#987).
+
 * The `values_fn` argument of `pivot_wider()` now correctly allows anonymous
   functions (#1114).
 

--- a/R/pivot.R
+++ b/R/pivot.R
@@ -16,16 +16,11 @@ check_spec <- function(spec) {
 }
 
 wrap_error_names <- function(code) {
-  tryCatch(
+  withCallingHandlers(
     code,
     vctrs_error_names = function(cnd) {
-      abort(
-        c(
-          "Failed to create output due to bad names.",
-          "Choose another strategy with `names_repair`"
-        ),
-        parent = cnd
-      )
+      cnd$arg <- "names_repair"
+      cnd_signal(cnd)
     }
   )
 }

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -1,3 +1,23 @@
+# error when overwriting existing column
+
+    Code
+      (expect_error(pivot_longer(df, y, names_to = "x")))
+    Output
+      <error/vctrs_error_names_must_be_unique>
+      Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
+      i Use argument `names_repair` to specify repair strategy.
+
+---
+
+    Code
+      out <- pivot_longer(df, y, names_to = "x", names_repair = "unique")
+    Message <simpleMessage>
+      New names:
+      * x -> x...1
+      * x -> x...2
+
 # `names_to` is validated
 
     Code

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -1,3 +1,23 @@
+# error when overwriting existing column
+
+    Code
+      (expect_error(pivot_wider(df, names_from = key, values_from = val)))
+    Output
+      <error/vctrs_error_names_must_be_unique>
+      Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
+      i Use argument `names_repair` to specify repair strategy.
+
+---
+
+    Code
+      out <- pivot_wider(df, names_from = key, values_from = val, names_repair = "unique")
+    Message <simpleMessage>
+      New names:
+      * a -> a...1
+      * a -> a...2
+
 # duplicated keys produce list column with warning
 
     Code

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -144,6 +144,19 @@ test_that("type error message use variable names", {
   expect_equal(err$y_arg, "xyz")
 })
 
+test_that("error when overwriting existing column", {
+  df <- tibble(x = 1, y = 2)
+
+  expect_snapshot(
+    (expect_error(pivot_longer(df, y, names_to = "x")))
+  )
+
+  expect_snapshot(
+    out <- pivot_longer(df, y, names_to = "x", names_repair = "unique")
+  )
+  expect_named(out, c("x...1", "x...2", "value"))
+})
+
 test_that("grouping is preserved", {
   df <- tibble(g = 1, x1 = 1, x2 = 2)
   out <- df %>%

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -29,10 +29,15 @@ test_that("error when overwriting existing column", {
     key = c("a", "b"),
     val = c(1, 2)
   )
-  expect_error(
-    pivot_wider(df, names_from = key, values_from = val),
-    "bad names"
+
+  expect_snapshot(
+    (expect_error(pivot_wider(df, names_from = key, values_from = val)))
   )
+
+  expect_snapshot(
+    out <- pivot_wider(df, names_from = key, values_from = val, names_repair = "unique")
+  )
+  expect_named(out, c("a...1", "a...2", "b"))
 })
 
 test_that("grouping is preserved", {


### PR DESCRIPTION
Closes #987 