### PR TITLE
Reorder values columns before combining with id columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # tidyr (development version)
 
+* `pivot_wider()` now correctly handles the case where an id column name
+  collides with a value from `names_from` (#1107).
+
+* `pivot_wider()` and `pivot_longer()` now both check that the spec columns
+  `.name` and `.value` are character vectors. Additionally, the `.name`
+  column must be unique (#1107).
+  
 * The `names_from` and `values_from` arguments to `pivot_wider()` are now
   required if their default values of `name` and `value` don't correspond to
   columns in `data`. Additionally, they must identify at least 1 column

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -279,16 +279,19 @@ pivot_wider_spec <- function(data,
     value_out[[i]] <- wrap_vec(out, spec_i$.name)
   }
 
-  out <- wrap_error_names(vec_cbind(as_tibble(rows), !!!value_out, .name_repair = names_repair))
+  # `check_spec()` ensures `.name` is unique. Name repair shouldn't be needed.
+  values <- vec_cbind(!!!value_out, .name_repair = "minimal")
 
-  # recreate desired column order
-  # https://github.com/r-lib/vctrs/issues/227
-  if (all(spec$.name %in% names(out))) {
-    out <- out[c(names(rows), spec$.name)]
-  }
+  # Recreate desired column order of the new spec columns (#569)
+  values <- values[spec$.name]
+
+  out <- wrap_error_names(vec_cbind(
+    as_tibble(rows),
+    values,
+    .name_repair = names_repair
+  ))
 
   reconstruct_tibble(data, out)
-
 }
 
 #' @export

--- a/R/pivot.R
+++ b/R/pivot.R
@@ -10,6 +10,17 @@ check_spec <- function(spec) {
     stop("`spec` must have `.name` and `.value` columns", call. = FALSE)
   }
 
+  if (!is.character(spec$.name)) {
+    abort("The `.name` column must be a character vector.")
+  }
+  if (vec_duplicate_any(spec$.name)) {
+    abort("The `.name` column must be unique.")
+  }
+
+  if (!is.character(spec$.value)) {
+    abort("The `.value` column must be a character vector.")
+  }
+
   # Ensure .name and .value come first
   vars <- union(c(".name", ".value"), names(spec))
   spec[vars]

--- a/tests/testthat/_snaps/pivot.md
+++ b/tests/testthat/_snaps/pivot.md
@@ -1,0 +1,24 @@
+# `.name` column must be a character vector
+
+    Code
+      (expect_error(check_spec(df)))
+    Output
+      <error/rlang_error>
+      The `.name` column must be a character vector.
+
+# `.value` column must be a character vector
+
+    Code
+      (expect_error(check_spec(df)))
+    Output
+      <error/rlang_error>
+      The `.value` column must be a character vector.
+
+# `.name` column must be unique
+
+    Code
+      (expect_error(check_spec(df)))
+    Output
+      <error/rlang_error>
+      The `.name` column must be unique.
+

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -40,6 +40,34 @@ test_that("error when overwriting existing column", {
   expect_named(out, c("a...1", "a...2", "b"))
 })
 
+test_that("`names_repair` happens after spec column reorganization (#1107)", {
+  df <- tibble(
+    test = c("a", "b"),
+    name = c("test", "test2"),
+    value = c(1, 2)
+  )
+
+  out <- pivot_wider(df, names_repair = ~make.unique(.x))
+
+  expect_identical(out$test, c("a", "b"))
+  expect_identical(out$test.1, c(1, NA))
+  expect_identical(out$test2, c(NA, 2))
+})
+
+test_that("minimal `names_repair` doesn't overwrite a value column that collides with key column (#1107)", {
+  df <- tibble(
+    test = c("a", "b"),
+    name = c("test", "test2"),
+    value = c(1, 2)
+  )
+
+  out <- pivot_wider(df, names_repair = "minimal")
+
+  expect_identical(out[[1]], c("a", "b"))
+  expect_identical(out[[2]], c(1, NA))
+  expect_identical(out[[3]], c(NA, 2))
+})
+
 test_that("grouping is preserved", {
   df <- tibble(g = 1, k = "x", v = 2)
   out <- df %>%

--- a/tests/testthat/test-pivot.R
+++ b/tests/testthat/test-pivot.R
@@ -2,3 +2,18 @@ test_that("basic sanity checks for spec occur", {
   expect_error(check_spec(1), "data.frame")
   expect_error(check_spec(mtcars), ".name")
 })
+
+test_that("`.name` column must be a character vector", {
+  df <- tibble(.name = 1:2, .value = c("a", "b"))
+  expect_snapshot((expect_error(check_spec(df))))
+})
+
+test_that("`.value` column must be a character vector", {
+  df <- tibble(.name = c("x", "y"), .value = 1:2)
+  expect_snapshot((expect_error(check_spec(df))))
+})
+
+test_that("`.name` column must be unique", {
+  df <- tibble(.name = c("x", "x"), .value = c("a", "b"))
+  expect_snapshot((expect_error(check_spec(df))))
+})


### PR DESCRIPTION
Closes #1107 

This one is a little tricky to fix, but I think this should work nicely.

It relies on a check that the `.name` column of a spec must be unique. I think this is reasonable, because I can't think of a case where it would be meaningful in either `pivot_wider()` or `pivot_longer()`.

With that restriction in mind, we can preemptively cbind all of the values columns together and reorder them immediately using the original `spec$.name` column. This should contain all of the values column names, and no name repair should have needed to be applied when they were cbind-ed since `.name` is unique.

Only then do we combine the correctly ordered columns with the id columns, and also apply name repair in case any id columns collide with one of the new values columns.