### PR TITLE
Require at least 1 column selection for `names_from` and `values_from`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tidyr (development version)
 
+* The `names_from` and `values_from` arguments to `pivot_wider()` are now
+  required if their default values of `name` and `value` don't correspond to
+  columns in `data`. Additionally, they must identify at least 1 column
+  in `data` (#1240).
+
 * The `names_ptypes` argument of `pivot_longer()` is now applied after
   `names_transform` for consistency with the rectangling functions
   (i.e. `hoist()`) (#1233).

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -305,6 +305,13 @@ build_wider_spec <- function(data,
   names_from <- tidyselect::eval_select(enquo(names_from), data)
   values_from <- tidyselect::eval_select(enquo(values_from), data)
 
+  if (is_empty(names_from)) {
+    abort("`names_from` must select at least one column.")
+  }
+  if (is_empty(values_from)) {
+    abort("`values_from` must select at least one column.")
+  }
+
   row_ids <- vec_unique(data[names_from])
   if (names_sort) {
     row_ids <- vec_sort(row_ids)

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -334,9 +334,6 @@ build_wider_spec <- function(data,
   out
 }
 
-# quiet R CMD check
-name <- value <- NULL
-
 # Helpers -----------------------------------------------------------------
 
 # Not a great name as it now also casts

--- a/R/tidyr.R
+++ b/R/tidyr.R
@@ -12,7 +12,7 @@
 #' @useDynLib tidyr, .registration = TRUE
 "_PACKAGE"
 
-globalVariables(".")
+globalVariables(c(".", "name", "value"))
 
 #' @importFrom tibble tribble
 #' @export

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -36,6 +36,24 @@
       Can't subset columns that don't exist.
       x Column `value` doesn't exist.
 
+# `names_from` must identify at least 1 column (#1240)
+
+    Code
+      (expect_error(pivot_wider(df, names_from = starts_with("foo"), values_from = val))
+      )
+    Output
+      <error/rlang_error>
+      `names_from` must select at least one column.
+
+# `values_from` must identify at least 1 column (#1240)
+
+    Code
+      (expect_error(pivot_wider(df, names_from = key, values_from = starts_with("foo")))
+      )
+    Output
+      <error/rlang_error>
+      `values_from` must select at least one column.
+
 # duplicated keys produce list column with warning
 
     Code

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -18,6 +18,24 @@
       * a -> a...1
       * a -> a...2
 
+# `names_from` must be supplied if `name` isn't in `data` (#1240)
+
+    Code
+      (expect_error(pivot_wider(df, values_from = val)))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Can't subset columns that don't exist.
+      x Column `name` doesn't exist.
+
+# `values_from` must be supplied if `value` isn't in `data` (#1240)
+
+    Code
+      (expect_error(pivot_wider(df, names_from = key)))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Can't subset columns that don't exist.
+      x Column `value` doesn't exist.
+
 # duplicated keys produce list column with warning
 
     Code

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -76,6 +76,15 @@ test_that("works with data.table and empty key_vars", {
   )
 })
 
+test_that("`names_from` must be supplied if `name` isn't in `data` (#1240)", {
+  df <- tibble(key = "x", val = 1)
+  expect_snapshot((expect_error(pivot_wider(df, values_from = val))))
+})
+
+test_that("`values_from` must be supplied if `value` isn't in `data` (#1240)", {
+  df <- tibble(key = "x", val = 1)
+  expect_snapshot((expect_error(pivot_wider(df, names_from = key))))
+})
 
 # column names -------------------------------------------------------------
 

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -86,6 +86,20 @@ test_that("`values_from` must be supplied if `value` isn't in `data` (#1240)", {
   expect_snapshot((expect_error(pivot_wider(df, names_from = key))))
 })
 
+test_that("`names_from` must identify at least 1 column (#1240)", {
+  df <- tibble(key = "x", val = 1)
+  expect_snapshot(
+    (expect_error(pivot_wider(df, names_from = starts_with("foo"), values_from = val)))
+  )
+})
+
+test_that("`values_from` must identify at least 1 column (#1240)", {
+  df <- tibble(key = "x", val = 1)
+  expect_snapshot(
+    (expect_error(pivot_wider(df, names_from = key, values_from = starts_with("foo"))))
+  )
+})
+
 # column names -------------------------------------------------------------
 
 test_that("names_glue affects output names", {


### PR DESCRIPTION
Closes #1240 

`pivot_longer()` does the same thing with `cols` already, so in some ways this is making `pivot_wider()` more consistent with that.