### PR TITLE
Throw a useful error when `values_fn` doesn't result in a single value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* `pivot_wider()` now throws a more informative error when `values_fn` doesn't
+  result in a single summary value (#1238).
+
 * `pivot_wider()` now correctly handles the case where an id column name
   collides with a value from `names_from` (#1107).
 

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -363,9 +363,26 @@ vals_dedup <- function(key, val, value, values_fn = NULL) {
 
   out <- vec_split(val, key)
   if (!is.null(values_fn) && !identical(values_fn, list)) {
-    # This is only correct if `values_fn` always returns a single value
-    # Needs https://github.com/r-lib/vctrs/issues/183
-    out$val <- vec_c(!!!map(out$val, values_fn))
+    val <- map(out$val, values_fn)
+
+    sizes <- list_sizes(val)
+    invalid_sizes <- sizes != 1L
+
+    if (any(invalid_sizes)) {
+      size <- sizes[invalid_sizes][[1]]
+
+      header <- glue(
+        "Applying `values_fn` to `{value}` must result in ",
+        "a single summary value per key."
+      )
+      bullet <- c(
+        x = glue("Applying `values_fn` resulted in a value with length {size}.")
+      )
+
+      abort(c(header, bullet))
+    }
+
+    out$val <- vec_c(!!!val)
   }
 
   out

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -54,6 +54,15 @@
       <error/rlang_error>
       `values_from` must select at least one column.
 
+# `values_fn` emits an informative error when it doesn't result in unique values (#1238)
+
+    Code
+      (expect_error(pivot_wider(df, values_fn = list(value = ~.x))))
+    Output
+      <error/rlang_error>
+      Applying `values_fn` to `value` must result in a single summary value per key.
+      x Applying `values_fn` resulted in a value with length 2.
+
 # duplicated keys produce list column with warning
 
     Code

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -128,6 +128,13 @@ test_that("`values_from` must identify at least 1 column (#1240)", {
   )
 })
 
+test_that("`values_fn` emits an informative error when it doesn't result in unique values (#1238)", {
+  df <- tibble(name = c("a", "a"), value = c(1, 2))
+  expect_snapshot(
+    (expect_error(pivot_wider(df, values_fn = list(value = ~.x))))
+  )
+})
+
 # column names -------------------------------------------------------------
 
 test_that("names_glue affects output names", {


### PR DESCRIPTION
Closes #1238 