### PR TITLE
Move hard coded `expect_error()` tests to `expect_snapshot(expect_error())`

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -58,7 +58,7 @@ str_extract <- function(x, into, regex, convert = FALSE) {
   out <- str_match_first(x, regex)
   if (length(out) != length(into)) {
     stop(
-      "`regex` should define ", length(into), " groups; ", ncol(matches), " found.",
+      "`regex` should define ", length(into), " groups; ", length(out), " found.",
       call. = FALSE
     )
   }

--- a/tests/testthat/_snaps/append.md
+++ b/tests/testthat/_snaps/append.md
@@ -1,0 +1,7 @@
+# after must be integer or character
+
+    Code
+      (expect_error(append_df(df1, df2, after = 1)))
+    Output
+      <simpleError: `after` must be character or integer>
+

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -1,0 +1,11 @@
+# informative error message if wrong number of groups
+
+    Code
+      (expect_error(extract(df, x, "y", ".")))
+    Output
+      <simpleError: `regex` should define 1 groups; 0 found.>
+    Code
+      (expect_error(extract(df, x, c("y", "z"), ".")))
+    Output
+      <simpleError: `regex` should define 2 groups; 0 found.>
+

--- a/tests/testthat/_snaps/full_seq.md
+++ b/tests/testthat/_snaps/full_seq.md
@@ -1,0 +1,11 @@
+# full_seq errors if sequence isn't regular
+
+    Code
+      (expect_error(full_seq(c(1, 3, 4), 2)))
+    Output
+      <simpleError: `x` is not a regular sequence.>
+    Code
+      (expect_error(full_seq(c(0, 10, 20), 11, tol = 1.8)))
+    Output
+      <simpleError: `x` is not a regular sequence.>
+

--- a/tests/testthat/_snaps/gather.md
+++ b/tests/testthat/_snaps/gather.md
@@ -1,3 +1,36 @@
+# gather throws error for POSIXlt
+
+    Code
+      (expect_error(gather(df, key, val, -x)))
+    Output
+      <simpleError: 'x' is a POSIXlt. Please convert to POSIXct.>
+    Code
+      (expect_error(gather(df, key, val, -y)))
+    Output
+      <simpleError: Column 1 is a POSIXlt. Please convert to POSIXct.>
+
+# gather throws error for weird objects
+
+    Code
+      (expect_error(gather(df, key, val, -x)))
+    Output
+      <simpleError: All columns must be atomic vectors or lists. Problem with 'x'>
+    Code
+      (expect_error(gather(df, key, val, -y)))
+    Output
+      <simpleError: All columns be atomic vectors or lists (not expression)>
+
+---
+
+    Code
+      (expect_error(gather(df, key, val, -x)))
+    Output
+      <simpleError: All columns must be atomic vectors or lists. Problem with 'x'>
+    Code
+      (expect_error(gather(df, key, val, -y)))
+    Output
+      <simpleError: All columns must be atomic vectors or lists. Problem with column 2.>
+
 # factors coerced to characters, not integers
 
     Code

--- a/tests/testthat/_snaps/nest-legacy.md
+++ b/tests/testthat/_snaps/nest-legacy.md
@@ -1,0 +1,24 @@
+# can't combine vectors and data frames
+
+    Code
+      (expect_error(unnest_legacy(df)))
+    Output
+      <error/rlang_error>
+      Each column must either be a list of vectors or a list of data frames [x]
+
+# multiple columns must be same length
+
+    Code
+      (expect_error(unnest_legacy(df)))
+    Output
+      <error/rlang_error>
+      All nested columns must have the same number of elements.
+
+---
+
+    Code
+      (expect_error(unnest_legacy(df)))
+    Output
+      <error/rlang_error>
+      All nested columns must have the same number of elements.
+

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -1,0 +1,13 @@
+# all inputs must be named
+
+    Code
+      (expect_error(pack(df, a = c(a1, a2), c(b1, b2))))
+    Output
+      <error/rlang_error>
+      All elements of `...` must be named
+    Code
+      (expect_error(pack(df, c(a1, a2), c(b1, b2))))
+    Output
+      <error/rlang_error>
+      All elements of `...` must be named
+

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -18,6 +18,36 @@
       * x -> x...1
       * x -> x...2
 
+# multiple names requires names_sep/names_pattern
+
+    Code
+      (expect_error(build_longer_spec(df, x_y, names_to = c("a", "b"))))
+    Output
+      <error/rlang_error>
+      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+    Code
+      (expect_error(build_longer_spec(df, x_y, names_to = c("a", "b"), names_sep = "x",
+      names_pattern = "x")))
+    Output
+      <error/rlang_error>
+      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+
+# names_sep fails with single name
+
+    Code
+      (expect_error(build_longer_spec(df, x_y, names_to = "x", names_sep = "_")))
+    Output
+      <error/rlang_error>
+      `names_sep` can't be used with a length 1 `names_to`.
+
+# Error if the `col` can't be selected.
+
+    Code
+      (expect_error(pivot_longer(iris, matches("foo"))))
+    Output
+      <error/rlang_error>
+      `cols` must select at least one column.
+
 # `names_to` is validated
 
     Code

--- a/tests/testthat/_snaps/pivot.md
+++ b/tests/testthat/_snaps/pivot.md
@@ -1,3 +1,14 @@
+# basic sanity checks for spec occur
+
+    Code
+      (expect_error(check_spec(1)))
+    Output
+      <simpleError: `spec` must be a data frame>
+    Code
+      (expect_error(check_spec(mtcars)))
+    Output
+      <simpleError: `spec` must have `.name` and `.value` columns>
+
 # `.name` column must be a character vector
 
     Code

--- a/tests/testthat/_snaps/replace_na.md
+++ b/tests/testthat/_snaps/replace_na.md
@@ -1,3 +1,11 @@
+# can only be length 0
+
+    Code
+      (expect_error(replace_na(1, 1:10)))
+    Output
+      <error/rlang_error>
+      Replacement for `data` is length 10, not length 1.
+
 # replacement must be castable to `data`
 
     Code

--- a/tests/testthat/_snaps/separate.md
+++ b/tests/testthat/_snaps/separate.md
@@ -38,3 +38,16 @@
       1 a     b     <NA> 
       2 a     b     c    
 
+# checks type of `into` and `sep`
+
+    Code
+      (expect_error(separate(df, x, "x", FALSE)))
+    Output
+      <error/rlang_error>
+      `sep` must be either numeric or character
+    Code
+      (expect_error(separate(df, x, FALSE)))
+    Output
+      <error/rlang_error>
+      `into` must be a character vector
+

--- a/tests/testthat/_snaps/spread.md
+++ b/tests/testthat/_snaps/spread.md
@@ -1,0 +1,10 @@
+# duplicate values for one key is an error
+
+    Code
+      (expect_error(spread(df, x, y)))
+    Output
+      <error/rlang_error>
+      Each row of output must be identified by a unique combination of keys.
+      Keys are shared for 2 rows:
+      * 2, 3
+

--- a/tests/testthat/_snaps/uncount.md
+++ b/tests/testthat/_snaps/uncount.md
@@ -1,0 +1,8 @@
+# errors on negative weights
+
+    Code
+      (expect_error(uncount(df, w)))
+    Output
+      <error/rlang_error>
+      all elements of `weights` must be >= 0
+

--- a/tests/testthat/test-append.R
+++ b/tests/testthat/test-append.R
@@ -9,7 +9,7 @@ test_that("after must be integer or character", {
   df1 <- data.frame(x = 1)
   df2 <- data.frame(x = 2)
 
-  expect_error(append_df(df1, df2, after = 1), "must be character or integer")
+  expect_snapshot((expect_error(append_df(df1, df2, after = 1))))
 })
 
 

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -47,8 +47,10 @@ test_that("groups are preserved", {
 
 test_that("informative error message if wrong number of groups", {
   df <- tibble(x = "a")
-  expect_error(extract(df, x, "y", "."), "should define 1 groups")
-  expect_error(extract(df, x, c("y", "z"), "."), "should define 2 groups")
+  expect_snapshot({
+    (expect_error(extract(df, x, "y", ".")))
+    (expect_error(extract(df, x, c("y", "z"), ".")))
+  })
 })
 
 test_that("str_match_first handles edge cases", {

--- a/tests/testthat/test-full_seq.R
+++ b/tests/testthat/test-full_seq.R
@@ -1,6 +1,8 @@
 test_that("full_seq errors if sequence isn't regular", {
-  expect_error(full_seq(c(1, 3, 4), 2), "not a regular sequence")
-  expect_error(full_seq(c(0, 10, 20), 11, tol = 1.8), "not a regular sequence")
+  expect_snapshot({
+    (expect_error(full_seq(c(1, 3, 4), 2)))
+    (expect_error(full_seq(c(0, 10, 20), 11, tol = 1.8)))
+  })
 })
 
 test_that("full_seq with tol > 0 allows sequences to fall short of period", {

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -118,22 +118,30 @@ test_that("gather throws error for POSIXlt", {
   df <- data.frame(y = 1)
   df$x <- as.POSIXlt(Sys.time())
 
-  expect_error(gather(df, key, val, -x), "a POSIXlt")
-  expect_error(gather(df, key, val, -y), "a POSIXlt")
+  expect_snapshot({
+    (expect_error(gather(df, key, val, -x)))
+    (expect_error(gather(df, key, val, -y)))
+  })
 })
 
 test_that("gather throws error for weird objects", {
   df <- data.frame(y = 1)
   df$x <- expression(x)
-  expect_error(gather(df, key, val, -x), "atomic vectors or lists")
-  expect_error(gather(df, key, val, -y), "atomic vectors or lists")
+
+  expect_snapshot({
+    (expect_error(gather(df, key, val, -x)))
+    (expect_error(gather(df, key, val, -y)))
+  })
 
   e <- new.env(parent = emptyenv())
   e$x <- 1
   df <- data.frame(y = 1)
   df$x <- e
-  expect_error(gather(df, key, val, -x), "atomic vectors or list")
-  expect_error(gather(df, key, val, -y), "atomic vectors or list")
+
+  expect_snapshot({
+    (expect_error(gather(df, key, val, -x)))
+    (expect_error(gather(df, key, val, -y)))
+  })
 })
 
 

--- a/tests/testthat/test-nest-legacy.R
+++ b/tests/testthat/test-nest-legacy.R
@@ -141,15 +141,15 @@ test_that("elements must all be of same type", {
 
 test_that("can't combine vectors and data frames", {
   df <- tibble(x = list(1, tibble(1)))
-  expect_error(unnest_legacy(df), "a list of vectors or a list of data frames")
+  expect_snapshot((expect_error(unnest_legacy(df))))
 })
 
 test_that("multiple columns must be same length", {
   df <- tibble(x = list(1), y = list(1:2))
-  expect_error(unnest_legacy(df), "same number of elements")
+  expect_snapshot((expect_error(unnest_legacy(df))))
 
   df <- tibble(x = list(1), y = list(tibble(x = 1:2)))
-  expect_error(unnest_legacy(df), "same number of elements")
+  expect_snapshot((expect_error(unnest_legacy(df))))
 })
 
 test_that("nested is split as a list (#84)", {

--- a/tests/testthat/test-pack.R
+++ b/tests/testthat/test-pack.R
@@ -22,8 +22,11 @@ test_that("can strip outer names from inner names", {
 
 test_that("all inputs must be named", {
   df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
-  expect_error(pack(df, a = c(a1, a2), c(b1, b2)), "must be named")
-  expect_error(pack(df, c(a1, a2), c(b1, b2)), "must be named")
+
+  expect_snapshot({
+    (expect_error(pack(df, a = c(a1, a2), c(b1, b2))))
+    (expect_error(pack(df, c(a1, a2), c(b1, b2))))
+  })
 })
 
 test_that("grouping is preserved", {

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -199,19 +199,20 @@ test_that("no names doesn't generate names (#1120)", {
 
 test_that("multiple names requires names_sep/names_pattern", {
   df <- tibble(x_y = 1)
-  expect_error(
-    build_longer_spec(df, x_y, names_to = c("a", "b")),
-    "multiple names"
-  )
 
-  expect_error(
-    build_longer_spec(df, x_y,
-      names_to = c("a", "b"),
-      names_sep = "x",
-      names_pattern = "x"
-    ),
-    "one of `names_sep` or `names_pattern"
-  )
+  expect_snapshot({
+    (expect_error(build_longer_spec(df, x_y, names_to = c("a", "b"))))
+
+    (expect_error(
+      build_longer_spec(
+        df,
+        x_y,
+        names_to = c("a", "b"),
+        names_sep = "x",
+        names_pattern = "x"
+      )
+    ))
+  })
 })
 
 test_that("names_sep generates correct spec", {
@@ -224,7 +225,10 @@ test_that("names_sep generates correct spec", {
 
 test_that("names_sep fails with single name", {
   df <- tibble(x_y = 1)
-  expect_error(build_longer_spec(df, x_y, names_to = "x", names_sep = "_"), "`names_sep`")
+
+  expect_snapshot({
+    (expect_error(build_longer_spec(df, x_y, names_to = "x", names_sep = "_")))
+  })
 })
 
 test_that("names_pattern generates correct spec", {
@@ -276,7 +280,9 @@ test_that("transform is applied before cast (#1233)", {
 })
 
 test_that("Error if the `col` can't be selected.", {
-  expect_error(pivot_longer(iris, matches("foo")), "select at least one")
+  expect_snapshot({
+    (expect_error(pivot_longer(iris, matches("foo"))))
+  })
 })
 
 test_that("`names_to` is validated", {

--- a/tests/testthat/test-pivot.R
+++ b/tests/testthat/test-pivot.R
@@ -1,6 +1,8 @@
 test_that("basic sanity checks for spec occur", {
-  expect_error(check_spec(1), "data.frame")
-  expect_error(check_spec(mtcars), ".name")
+  expect_snapshot({
+    (expect_error(check_spec(1)))
+    (expect_error(check_spec(mtcars)))
+  })
 })
 
 test_that("`.name` column must be a character vector", {

--- a/tests/testthat/test-replace_na.R
+++ b/tests/testthat/test-replace_na.R
@@ -11,7 +11,7 @@ test_that("missing values are replaced", {
 })
 
 test_that("can only be length 0", {
-  expect_error(replace_na(1, 1:10), "length 10, not length 1")
+  expect_snapshot((expect_error(replace_na(1, 1:10))))
 })
 
 test_that("can replace missing rows in arrays", {

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -107,14 +107,11 @@ test_that("drops NA columns", {
 
 test_that("checks type of `into` and `sep`", {
   df <- tibble(x = "a:b")
-  expect_error(
-    separate(df, x, "x", FALSE),
-    "must be either numeric or character"
-  )
-  expect_error(
-    separate(df, x, FALSE),
-    "must be a character vector"
-  )
+
+  expect_snapshot({
+    (expect_error(separate(df, x, "x", FALSE)))
+    (expect_error(separate(df, x, FALSE)))
+  })
 })
 
 # helpers -----------------------------------------------------------------

--- a/tests/testthat/test-spread.R
+++ b/tests/testthat/test-spread.R
@@ -22,8 +22,7 @@ test_that("convert turns strings into integers", {
 
 test_that("duplicate values for one key is an error", {
   df <- tibble(x = factor(c("a", "b", "b")), y = c(1, 2, 2), z = c(1, 2, 2))
-  expect_error(spread(df, x, y),
-               "Keys are shared for 2 rows:")
+  expect_snapshot((expect_error(spread(df, x, y))))
 })
 
 test_that("factors are spread into columns (#35)", {

--- a/tests/testthat/test-uncount.R
+++ b/tests/testthat/test-uncount.R
@@ -41,5 +41,5 @@ test_that("works with 0 weights", {
 
 test_that("errors on negative weights", {
   df <- tibble(x = 1, w = -1)
-  expect_error(uncount(df, w), "all elements of `weights` must be >= 0")
+  expect_snapshot((expect_error(uncount(df, w))))
 })


### PR DESCRIPTION
This is a preparatory PR for figuring out how much dev rlang is going to touch the error messages