### PR TITLE
Ensure that pivoting a zero row data frame returns zero rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # tidyr (development version)
 
-* `pivot_wider_spec()` now works with a 0-row data frame and a `spec` that
-  doesn't identify any rows (#1250).
+* `pivot_wider_spec()` now works correctly with a 0-row data frame and a `spec`
+  that doesn't identify any rows (#1250, #1252).
 
 * `pivot_wider()` now throws a more informative error when `values_fn` doesn't
   result in a single summary value (#1238).

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -229,19 +229,14 @@ pivot_wider_spec <- function(data,
   }
   key_vars <- setdiff(key_vars, spec_cols)
 
-  # Figure out rows in output
-  df_rows <- data[key_vars]
-  if (ncol(df_rows) == 0) {
-    rows <- tibble(.rows = 1)
-    nrow <- 1L
-    # use `nrow(data)` here because data.table returns zero rows if no
-    # column is selected
-    row_id <- rep(1L, nrow(data))
-  } else {
-    row_id <- vec_group_id(df_rows)
-    nrow <- attr(row_id, "n")
-    rows <- vec_slice(df_rows, vec_unique_loc(row_id))
-  }
+  # Figure out rows in output.
+  # Early conversion to tibble because data.table returns zero rows if
+  # zero cols are selected.
+  rows <- as_tibble(data)
+  rows <- rows[key_vars]
+  row_id <- vec_group_id(rows)
+  nrow <- attr(row_id, "n")
+  rows <- vec_slice(rows, vec_unique_loc(row_id))
 
   value_specs <- unname(split(spec, spec$.value))
   value_out <- vec_init(list(), length(value_specs))
@@ -286,7 +281,7 @@ pivot_wider_spec <- function(data,
   values <- values[spec$.name]
 
   out <- wrap_error_names(vec_cbind(
-    as_tibble(rows),
+    rows,
     values,
     .name_repair = names_repair
   ))

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -154,6 +154,13 @@ test_that("can pivot a manual spec with spec columns that don't identify any row
   )
 })
 
+test_that("pivoting with a manual spec and zero rows results in zero rows (#1252)", {
+  spec <- tibble(.name = "name", .value = "value", x = 1L)
+
+  df <- tibble(value = integer(), x = integer())
+  expect_identical(pivot_wider_spec(df, spec), tibble(name = integer()))
+})
+
 # column names -------------------------------------------------------------
 
 test_that("names_glue affects output names", {


### PR DESCRIPTION
Closes #1252 

Now that #1253 is merged, we can remove this slightly incorrect conditional code path for the zero column case (because it doesn't handle the zero row case right). But we still need to handle data.table's behavior with `dt[character()]` returning a zero row data table (see https://github.com/tidyverse/tidyr/pull/1073), so we just convert `data` to a tibble early on to avoid this. We do this anyways eventually, so it doesn't affect any behavior.