### PR TITLE
Ensure `nesting()` with no inputs returns a 1 row data frame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,8 +45,10 @@
   * Supplying data frames with 0 columns but >0 rows now works correctly
     (#1189).
   
-  * `expand_grid()`, `expand()`, and `crossing()` now return a 1 row data frame
-    when no inputs are supplied, which is more consistent with `prod() == 1L`.
+  * `expand_grid()`, `expand()`, `nesting()`, and `crossing()` now return a 1
+    row data frame when no inputs are supplied, which is more consistent with
+    `prod() == 1L` and the idea that computations involving the number of
+    combinations computed from an empty set should return 1 (#1258).
 
 * `drop_na()` has been updated to utilize `vctrs::vec_detect_complete()`. This
   has resulted in the following changes:

--- a/R/expand.R
+++ b/R/expand.R
@@ -177,6 +177,12 @@ expand_grid <- function(..., .name_repair = "check_unique") {
 # Helpers -----------------------------------------------------------------
 
 sorted_unique <- function(x) {
+  if (is.data.frame(x) && ncol(x) == 0L) {
+    # vec_sort() bug with 0 column data frames:
+    # https://github.com/r-lib/vctrs/issues/1499
+    return(x)
+  }
+
   if (is.factor(x)) {
     # forcats::fct_unique
     factor(levels(x), levels(x), exclude = NULL, ordered = is.ordered(x))

--- a/R/expand.R
+++ b/R/expand.R
@@ -112,8 +112,17 @@ crossing <- function(..., .name_repair = "check_unique") {
 nesting <- function(..., .name_repair = "check_unique") {
   out <- grid_dots(...)
 
+  if (length(out) == 0L) {
+    # This matches `crossing()`, `expand_grid()`, and `expand()`, which return
+    # a 1 row / 0 col tibble. Computations involving the number of combinations
+    # of an empty set should return 1.
+    size <- 1L
+  } else {
+    size <- NULL
+  }
+
   # Flattens unnamed data frames
-  out <- data_frame(!!!out, .name_repair = .name_repair)
+  out <- data_frame(!!!out, .size = size, .name_repair = .name_repair)
   out <- tibble::new_tibble(out, nrow = vec_size(out))
 
   out <- sorted_unique(out)

--- a/tests/testthat/test-complete.R
+++ b/tests/testthat/test-complete.R
@@ -42,3 +42,13 @@ test_that("not drop unspecified levels in complete", {
   expect <- df[c("z", "x", "y")]
   expect_equal(df2, expect)
 })
+
+test_that("complete() with empty nesting() / crossing() calls 'ignores' them (#1258)", {
+  df <- tibble(x = factor(c("a", "c"), letters[1:3]))
+
+  expect_identical(complete(df, x), complete(df, x, nesting()))
+  expect_identical(complete(df, x), complete(df, x, crossing()))
+
+  expect_identical(complete(df, x), complete(df, x, nesting(NULL)))
+  expect_identical(complete(df, x), complete(df, x, crossing(NULL)))
+})

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -206,11 +206,14 @@ test_that("crossing() / nesting() doesn't overwrite after auto naming (#1092)", 
 test_that("crossing() with no inputs returns a 1 row data frame", {
   # Because it uses expand_grid(), which respects `prod() == 1L`
   expect_identical(crossing(), tibble(.rows = 1L))
+  expect_identical(crossing(NULL), tibble(.rows = 1L))
 })
 
-test_that("nesting() with no inputs returns a 0 row data frame", {
-  # Because it only finds combinations already in the data
-  expect_identical(nesting(), tibble())
+test_that("nesting() with no inputs returns a 1 row data frame", {
+  # Because computations involving the "number of combinations" of an empty
+  # set return 1
+  expect_identical(nesting(), tibble(.rows = 1L))
+  expect_identical(nesting(NULL), tibble(.rows = 1L))
 })
 
 test_that("can use `do.call()` or `reduce()` with `crossing()` (#992)", {

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -100,6 +100,19 @@ test_that("expand() with no inputs returns 1 row", {
   expect_identical(expand(tibble()), tibble(.rows = 1L))
 })
 
+test_that("expand() with empty nesting() / crossing() calls 'ignores' them (#1258)", {
+  df <- tibble(x = factor(c("a", "c"), letters[1:3]))
+
+  expect_identical(expand(df), expand(df, nesting()))
+  expect_identical(expand(df), expand(df, crossing()))
+
+  expect_identical(expand(df, x), expand(df, x, nesting()))
+  expect_identical(expand(df, x), expand(df, x, crossing()))
+
+  expect_identical(expand(df, x), expand(df, x, nesting(NULL)))
+  expect_identical(expand(df, x), expand(df, x, crossing(NULL)))
+})
+
 # ------------------------------------------------------------------------------
 
 test_that("crossing checks for bad inputs", {


### PR DESCRIPTION
Closes #1258 
Followup to https://github.com/tidyverse/tidyr/pull/1230, extending the same idea to `nesting()`

- This composes better when used inside `complete()` and `expand()`, as recycling is applied more intuitively
- This makes more sense overall, I think, as the "number of combinations" you can get from an empty set should be 1? Like how `prod() == 1L` with `expand_grid()`.