### PR TITLE
Avoid dropping duplicately named elements in `hoist()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* `hoist()` no longer accidentally removes elements that have duplicated names
+  (#1259).
+
 * `pivot_wider()` no longer accidentally retains `values_from` when pivoting
   a zero row data frame (#1249).
 

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -272,8 +272,10 @@ strike <- function(x, indices) {
   index <- indices[[1L]]
   indices <- indices[-1L]
 
+  size <- vec_size(x)
+
   is_valid_index <-
-    (is.numeric(index) && (index <= vec_size(x))) ||
+    (is.numeric(index) && (index <= size)) ||
     (is.character(index) && has_name(x, index))
 
   if (!is_valid_index) {
@@ -281,15 +283,11 @@ strike <- function(x, indices) {
     return(x)
   }
 
+  index <- vec_as_location(index, n = size, names = names(x))
+
   if (n_indices == 1L) {
     # At base index, remove it
-    if (is.numeric(index)) {
-      x <- x[-index]
-    } else if (is.character(index)) {
-      x <- x[setdiff(names(x), index)]
-    } else {
-      abort("Internal error: Only character and numeric values are valid indices.")
-    }
+    x <- x[-index]
   } else {
     # Not at base index yet, continue recursion
     x[[index]] <- strike(x[[index]], indices)


### PR DESCRIPTION
Closes #1259 

This isn't completely perfect, but is an improvement over the current behavior in #1259. It fixes both cases there, but I've added a test to show where it still fails. If you try to use the same plucker twice to extract both duplicated names, then you won't get the expected results since we don't strike after every pluck. This seems like it would be hard to implement correctly, and probably isn't worth it, so I have left that alone.