### PR TITLE
Only signal the duplicate warning once, and mention all affected cols

### DIFF
--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -73,16 +73,27 @@
       * Use `values_fn = length` to identify where the duplicates arise.
       * Use `values_fn = {summary_fun}` to summarise duplicates.
 
-# duplicated key warning occurs for each applicable column
+# duplicated key warning mentions every applicable column
+
+    Code
+      pivot_wider(df, names_from = key, values_from = c(a, b, c))
+    Warning <warning>
+      Values from `a`, `b` and `c` are not uniquely identified; output will contain list-cols.
+      * Use `values_fn = list` to suppress this warning.
+      * Use `values_fn = length` to identify where the duplicates arise.
+      * Use `values_fn = {summary_fun}` to summarise duplicates.
+    Output
+      # A tibble: 1 x 3
+        a_x       b_x       c_x      
+        <list>    <list>    <list>   
+      1 <dbl [2]> <dbl [2]> <dbl [2]>
+
+---
 
     Code
       pivot_wider(df, names_from = key, values_from = c(a, b, c), values_fn = list(b = sum))
     Warning <warning>
-      Values from `a` are not uniquely identified; output will contain list-cols.
-      * Use `values_fn = list` to suppress this warning.
-      * Use `values_fn = length` to identify where the duplicates arise.
-      * Use `values_fn = {summary_fun}` to summarise duplicates.
-      Values from `c` are not uniquely identified; output will contain list-cols.
+      Values from `a` and `c` are not uniquely identified; output will contain list-cols.
       * Use `values_fn = list` to suppress this warning.
       * Use `values_fn = length` to identify where the duplicates arise.
       * Use `values_fn = {summary_fun}` to summarise duplicates.

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -268,12 +268,20 @@ test_that("duplicated keys produce list column with warning", {
   expect_equal(as.list(pv$x), list(c(1L, 2L), 3L))
 })
 
-test_that("duplicated key warning occurs for each applicable column", {
+test_that("duplicated key warning mentions every applicable column", {
   df <- tibble(
     key = c("x", "x"),
     a = c(1, 2),
     b = c(3, 4),
     c = c(5, 6)
+  )
+
+  expect_snapshot(
+    pivot_wider(
+      df,
+      names_from = key,
+      values_from = c(a, b, c)
+    )
   )
 
   expect_snapshot(


### PR DESCRIPTION
Implements a fix for #1102 even though I closed that already. CC @mgirlich, it turns out I was able to make this a little cleaner. Here is the new warning:

``` r
library(tidyr)

df <- tibble::tribble(
  ~x, ~y, ~z, ~w,
  "a",  2,  4, 6,
  "a",  3,  5, 7
)

df
#> # A tibble: 2 × 4
#>   x         y     z     w
#>   <chr> <dbl> <dbl> <dbl>
#> 1 a         2     4     6
#> 2 a         3     5     7

df %>% 
  pivot_wider(
    names_from = x,
    values_from = c(y, z, w),
    values_fn = list(y = sum)
  )
#> Warning: Values from `w` and `z` are not uniquely identified; output will contain list-cols.
#> * Use `values_fn = list` to suppress this warning.
#> * Use `values_fn = length` to identify where the duplicates arise.
#> * Use `values_fn = {summary_fun}` to summarise duplicates.
#> # A tibble: 1 × 3
#>     y_a z_a       w_a      
#>   <dbl> <list>    <list>   
#> 1     5 <dbl [2]> <dbl [2]>
```

<sup>Created on 2021-12-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>