### PR TITLE
Implement `names_vary` for `pivot_wider()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidyr (development version)
 
+* `pivot_wider()` gains a new `names_vary` argument for controlling the
+  ordering when combining `names_from` values with `values_from` column names
+  (#839).
+
 * `pivot_wider()` now gives better advice about how to identify duplicates when
   values are not uniquely identified (#1113).
 

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -12,6 +12,7 @@ pivot_wider(
   names_sep = "_",
   names_glue = NULL,
   names_sort = FALSE,
+  names_vary = "fastest",
   names_repair = "check_unique",
   values_from = value,
   values_fill = NULL,
@@ -50,6 +51,16 @@ a glue specification that uses the \code{names_from} columns (and special
 
 \item{names_sort}{Should the column names be sorted? If \code{FALSE}, the default,
 column names are ordered by first appearance.}
+
+\item{names_vary}{When \code{names_from} identifies a column (or columns) with
+multiple unique values, and multiple \code{values_from} columns are provided,
+in what order should the resulting column names be combined?
+\itemize{
+\item \code{"fastest"} varies \code{names_from} values fastest, resulting in a column
+naming scheme of the form: \verb{value1_name1, value1_name2, value2_name1, value2_name2}. This is the default.
+\item \code{"slowest"} varies \code{names_from} values slowest, resulting in a column
+naming scheme of the form: \verb{value1_name1, value2_name1, value1_name2, value2_name2}.
+}}
 
 \item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.
@@ -99,7 +110,19 @@ fish_encounters \%>\%
 # Generate column names from multiple variables
 us_rent_income
 us_rent_income \%>\%
-  pivot_wider(names_from = variable, values_from = c(estimate, moe))
+  pivot_wider(
+    names_from = variable,
+    values_from = c(estimate, moe)
+  )
+
+# You can control whether `names_from` values vary fastest or slowest
+# relative to the `values_from` column names using `names_vary`.
+us_rent_income \%>\%
+  pivot_wider(
+    names_from = variable,
+    values_from = c(estimate, moe),
+    names_vary = "slowest"
+  )
 
 # When there are multiple `names_from` or `values_from`, you can use
 # use `names_sep` or `names_glue` to control the output variable names

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -21,7 +21,8 @@ build_wider_spec(
   names_prefix = "",
   names_sep = "_",
   names_glue = NULL,
-  names_sort = FALSE
+  names_sort = FALSE,
+  names_vary = "fastest"
 )
 }
 \arguments{
@@ -95,6 +96,16 @@ a glue specification that uses the \code{names_from} columns (and special
 
 \item{names_sort}{Should the column names be sorted? If \code{FALSE}, the default,
 column names are ordered by first appearance.}
+
+\item{names_vary}{When \code{names_from} identifies a column (or columns) with
+multiple unique values, and multiple \code{values_from} columns are provided,
+in what order should the resulting column names be combined?
+\itemize{
+\item \code{"fastest"} varies \code{names_from} values fastest, resulting in a column
+naming scheme of the form: \verb{value1_name1, value1_name2, value2_name1, value2_name2}. This is the default.
+\item \code{"slowest"} varies \code{names_from} values slowest, resulting in a column
+naming scheme of the form: \verb{value1_name1, value2_name1, value1_name2, value2_name2}.
+}}
 }
 \description{
 This is a low level interface to pivotting, inspired by the cdata package,

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -63,6 +63,19 @@
       Applying `values_fn` to `value` must result in a single summary value per key.
       x Applying `values_fn` resulted in a value with length 2.
 
+# `names_vary` is validated
+
+    Code
+      (expect_error(build_wider_spec(df, names_vary = 1)))
+    Output
+      <error/rlang_error>
+      `names_vary` must be a character vector.
+    Code
+      (expect_error(build_wider_spec(df, names_vary = "x")))
+    Output
+      <error/rlang_error>
+      `names_vary` must be one of "fastest" or "slowest".
+
 # duplicated keys produce list column with warning
 
     Code

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -188,6 +188,28 @@ test_that("can sort column names", {
   expect_equal(spec$.name, levels(df$fac))
 })
 
+test_that("can vary `names_from` values slowest (#839)", {
+  df <- tibble(
+    name = c("name1", "name2"),
+    value1 = c(1, 2),
+    value2 = c(4, 5)
+  )
+
+  spec <- build_wider_spec(df, names_from = name, values_from = c(value1, value2))
+
+  expect_identical(
+    spec$.name,
+    c("value1_name1", "value1_name2", "value2_name1", "value2_name2")
+  )
+
+  spec <- build_wider_spec(df, names_from = name, values_from = c(value1, value2), names_vary = "slowest")
+
+  expect_identical(
+    spec$.name,
+    c("value1_name1", "value2_name1", "value1_name2", "value2_name2")
+  )
+})
+
 # keys ---------------------------------------------------------
 
 test_that("can override default keys", {

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -210,6 +210,15 @@ test_that("can vary `names_from` values slowest (#839)", {
   )
 })
 
+test_that("`names_vary` is validated", {
+  df <- tibble(name = c("a", "b"), value = c(1, 2))
+
+  expect_snapshot({
+    (expect_error(build_wider_spec(df, names_vary = 1)))
+    (expect_error(build_wider_spec(df, names_vary = "x")))
+  })
+})
+
 # keys ---------------------------------------------------------
 
 test_that("can override default keys", {


### PR DESCRIPTION
Closes #839 

Implements `names_vary`, as described compactly by this comment https://github.com/tidyverse/tidyr/issues/839#issuecomment-993924527

The actual coding of this is fairly straightforward. It just swaps `vec_rep()` for `vec_rep_each()` and vice versa while creating the spec columns.

As shown in https://github.com/tidyverse/tidyr/issues/839#issuecomment-993932843, this can currently be accomplished using `arrange()` on a spec generated by `build_wider_spec()`. But this _feels_ like it might be worth adding an argument for, since it seems to come up fairly often (2 issues and at least 2 stack overflow questions).