### PR TITLE
Implement `id_expand` and `names_expand` for `pivot_wider()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidyr (development version)
 
+* `pivot_wider()` gains new `names_expand` and `id_expand` arguments for turning
+  implicit missing factor levels and variable combinations into explicit ones.
+  This is similar to the `drop` argument from `spread()` (#770).
+
 * `expand()`, `crossing()`, and `nesting()` now correctly retain `NA` values of
   factors (#1275).
 

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -51,11 +51,11 @@
 #'     naming scheme of the form: `value1_name1, value2_name1, value1_name2,
 #'     value2_name2`.
 #' @param names_expand Should the values in the `names_from` columns be expanded
-#'   by [expand()] before pivoting? This results in column names corresponding
-#'   to a complete expansion of all possible values in the `names_from` columns.
-#'   Implicit factor levels that aren't represented in the data will become
-#'   explicit. Additionally, the column names will be sorted, identical
-#'   to what `names_sort` would produce.
+#'   by [expand()] before pivoting? This results in more columns, the output
+#'   will contain column names corresponding to a complete expansion of all
+#'   possible values in `names_from`. Implicit factor levels that aren't
+#'   represented in the data will become explicit. Additionally, the column
+#'   names will be sorted, identical to what `names_sort` would produce.
 #' @param values_fill Optionally, a (scalar) value that specifies what each
 #'   `value` should be filled in with when missing.
 #'

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -21,6 +21,12 @@
 #'   except for the columns specified in `names_from` and `values_from`.
 #'   Typically used when you have redundant variables, i.e. variables whose
 #'   values are perfectly correlated with existing variables.
+#' @param id_expand Should the values in the `id_cols` columns be expanded by
+#'   [expand()] before pivoting? This results in more rows, the output will
+#'   contain a complete expansion of all possible values in `id_cols`. Implicit
+#'   factor levels that aren't represented in the data will become explicit.
+#'   Additionally, the row values corresponding to the expanded `id_cols` will
+#'   be sorted.
 #' @param names_from,values_from <[`tidy-select`][tidyr_tidy_select]> A pair of
 #'   arguments describing which column (or columns) to get the name of the
 #'   output column (`names_from`), and which column (or columns) to get the
@@ -133,6 +139,7 @@
 #'   )
 pivot_wider <- function(data,
                         id_cols = NULL,
+                        id_expand = FALSE,
                         names_from = name,
                         names_prefix = "",
                         names_sep = "_",
@@ -152,6 +159,7 @@ pivot_wider <- function(data,
 #' @export
 pivot_wider.data.frame <- function(data,
                                    id_cols = NULL,
+                                   id_expand = FALSE,
                                    names_from = name,
                                    names_prefix = "",
                                    names_sep = "_",
@@ -190,6 +198,7 @@ pivot_wider.data.frame <- function(data,
     data = data,
     spec = spec,
     id_cols = !!id_cols,
+    id_expand = id_expand,
     names_repair = names_repair,
     values_fill = values_fill,
     values_fn = values_fn
@@ -251,8 +260,11 @@ pivot_wider_spec <- function(data,
                              spec,
                              names_repair = "check_unique",
                              id_cols = NULL,
+                             id_expand = FALSE,
                              values_fill = NULL,
                              values_fn = NULL) {
+  input <- data
+
   spec <- check_pivot_spec(spec)
 
   names_from_cols <- names(spec)[-(1:2)]
@@ -285,11 +297,22 @@ pivot_wider_spec <- function(data,
   }
   values_fill <- values_fill[intersect(names(values_fill), values_from_cols)]
 
-  # Figure out rows in output.
+  if (!is_bool(id_expand)) {
+    abort("`id_expand` must be a single `TRUE` or `FALSE`.")
+  }
+
   # Early conversion to tibble because data.table returns zero rows if
-  # zero cols are selected.
-  rows <- as_tibble(data)
-  rows <- rows[id_cols]
+  # zero cols are selected. Also want to avoid the grouped-df behavior
+  # of `complete()`.
+  data <- as_tibble(data)
+  data <- data[vec_unique(c(id_cols, names_from_cols, values_from_cols))]
+
+  if (id_expand) {
+    data <- complete(data, !!!syms(id_cols), fill = values_fill, explicit = FALSE)
+  }
+
+  # Figure out rows in output
+  rows <- data[id_cols]
   row_id <- vec_group_id(rows)
   nrow <- attr(row_id, "n")
   rows <- vec_slice(rows, vec_unique_loc(row_id))
@@ -374,7 +397,7 @@ pivot_wider_spec <- function(data,
     .name_repair = names_repair
   ))
 
-  reconstruct_tibble(data, out)
+  reconstruct_tibble(input, out)
 }
 
 #' @export

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -13,6 +13,7 @@ pivot_wider(
   names_glue = NULL,
   names_sort = FALSE,
   names_vary = "fastest",
+  names_expand = FALSE,
   names_repair = "check_unique",
   values_from = value,
   values_fill = NULL,
@@ -61,6 +62,13 @@ naming scheme of the form: \verb{value1_name1, value1_name2, value2_name1, value
 \item \code{"slowest"} varies \code{names_from} values slowest, resulting in a column
 naming scheme of the form: \verb{value1_name1, value2_name1, value1_name2, value2_name2}.
 }}
+
+\item{names_expand}{Should the values in the \code{names_from} columns be expanded
+by \code{\link[=expand]{expand()}} before pivoting? This results in column names corresponding
+to a complete expansion of all possible values in the \code{names_from} columns.
+Implicit factor levels that aren't represented in the data will become
+explicit. Additionally, the column names will be sorted, identical
+to what \code{names_sort} would produce.}
 
 \item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -64,11 +64,11 @@ naming scheme of the form: \verb{value1_name1, value2_name1, value1_name2, value
 }}
 
 \item{names_expand}{Should the values in the \code{names_from} columns be expanded
-by \code{\link[=expand]{expand()}} before pivoting? This results in column names corresponding
-to a complete expansion of all possible values in the \code{names_from} columns.
-Implicit factor levels that aren't represented in the data will become
-explicit. Additionally, the column names will be sorted, identical
-to what \code{names_sort} would produce.}
+by \code{\link[=expand]{expand()}} before pivoting? This results in more columns, the output
+will contain column names corresponding to a complete expansion of all
+possible values in \code{names_from}. Implicit factor levels that aren't
+represented in the data will become explicit. Additionally, the column
+names will be sorted, identical to what \code{names_sort} would produce.}
 
 \item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -7,6 +7,7 @@
 pivot_wider(
   data,
   id_cols = NULL,
+  id_expand = FALSE,
   names_from = name,
   names_prefix = "",
   names_sep = "_",
@@ -29,6 +30,13 @@ uniquely identifies each observation. Defaults to all columns in \code{data}
 except for the columns specified in \code{names_from} and \code{values_from}.
 Typically used when you have redundant variables, i.e. variables whose
 values are perfectly correlated with existing variables.}
+
+\item{id_expand}{Should the values in the \code{id_cols} columns be expanded by
+\code{\link[=expand]{expand()}} before pivoting? This results in more rows, the output will
+contain a complete expansion of all possible values in \code{id_cols}. Implicit
+factor levels that aren't represented in the data will become explicit.
+Additionally, the row values corresponding to the expanded \code{id_cols} will
+be sorted.}
 
 \item{names_from, values_from}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A pair of
 arguments describing which column (or columns) to get the name of the

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -109,11 +109,11 @@ naming scheme of the form: \verb{value1_name1, value2_name1, value1_name2, value
 }}
 
 \item{names_expand}{Should the values in the \code{names_from} columns be expanded
-by \code{\link[=expand]{expand()}} before pivoting? This results in column names corresponding
-to a complete expansion of all possible values in the \code{names_from} columns.
-Implicit factor levels that aren't represented in the data will become
-explicit. Additionally, the column names will be sorted, identical
-to what \code{names_sort} would produce.}
+by \code{\link[=expand]{expand()}} before pivoting? This results in more columns, the output
+will contain column names corresponding to a complete expansion of all
+possible values in \code{names_from}. Implicit factor levels that aren't
+represented in the data will become explicit. Additionally, the column
+names will be sorted, identical to what \code{names_sort} would produce.}
 }
 \description{
 This is a low level interface to pivotting, inspired by the cdata package,

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -10,6 +10,7 @@ pivot_wider_spec(
   spec,
   names_repair = "check_unique",
   id_cols = NULL,
+  id_expand = FALSE,
   values_fill = NULL,
   values_fn = NULL
 )
@@ -52,6 +53,13 @@ except for the columns specified in \code{spec$.value} and the columns of the
 \code{spec} that aren't named \code{.name} or \code{.value}. Typically used when you have
 redundant variables, i.e. variables whose values are perfectly correlated
 with existing variables.}
+
+\item{id_expand}{Should the values in the \code{id_cols} columns be expanded by
+\code{\link[=expand]{expand()}} before pivoting? This results in more rows, the output will
+contain a complete expansion of all possible values in \code{id_cols}. Implicit
+factor levels that aren't represented in the data will become explicit.
+Additionally, the row values corresponding to the expanded \code{id_cols} will
+be sorted.}
 
 \item{values_fill}{Optionally, a (scalar) value that specifies what each
 \code{value} should be filled in with when missing.

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -22,7 +22,8 @@ build_wider_spec(
   names_sep = "_",
   names_glue = NULL,
   names_sort = FALSE,
-  names_vary = "fastest"
+  names_vary = "fastest",
+  names_expand = FALSE
 )
 }
 \arguments{
@@ -106,6 +107,13 @@ naming scheme of the form: \verb{value1_name1, value1_name2, value2_name1, value
 \item \code{"slowest"} varies \code{names_from} values slowest, resulting in a column
 naming scheme of the form: \verb{value1_name1, value2_name1, value1_name2, value2_name2}.
 }}
+
+\item{names_expand}{Should the values in the \code{names_from} columns be expanded
+by \code{\link[=expand]{expand()}} before pivoting? This results in column names corresponding
+to a complete expansion of all possible values in the \code{names_from} columns.
+Implicit factor levels that aren't represented in the data will become
+explicit. Additionally, the column names will be sorted, identical
+to what \code{names_sort} would produce.}
 }
 \description{
 This is a low level interface to pivotting, inspired by the cdata package,

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -76,6 +76,19 @@
       <error/rlang_error>
       `names_vary` must be one of "fastest" or "slowest".
 
+# `names_expand` is validated
+
+    Code
+      (expect_error(build_wider_spec(df, names_expand = 1)))
+    Output
+      <error/rlang_error>
+      `names_expand` must be a single `TRUE` or `FALSE`.
+    Code
+      (expect_error(build_wider_spec(df, names_expand = "x")))
+    Output
+      <error/rlang_error>
+      `names_expand` must be a single `TRUE` or `FALSE`.
+
 # duplicated keys produce list column with warning
 
     Code

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -89,6 +89,19 @@
       <error/rlang_error>
       `names_expand` must be a single `TRUE` or `FALSE`.
 
+# `id_expand` is validated
+
+    Code
+      (expect_error(pivot_wider(df, id_expand = 1)))
+    Output
+      <error/rlang_error>
+      `id_expand` must be a single `TRUE` or `FALSE`.
+    Code
+      (expect_error(pivot_wider(df, id_expand = "x")))
+    Output
+      <error/rlang_error>
+      `id_expand` must be a single `TRUE` or `FALSE`.
+
 # duplicated keys produce list column with warning
 
     Code

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -191,6 +191,20 @@ test_that("can fill only implicit missings from `names_expand`", {
   )
 })
 
+test_that("expansion with `id_expand` and `names_expand` works with zero row data frames", {
+  df <- tibble(
+    id = factor(levels = c("b", "a")),
+    name = factor(levels = c("a", "b")),
+    value = integer()
+  )
+
+  res <- pivot_wider(df, names_expand = TRUE, id_expand = TRUE)
+
+  expect_identical(res$id, factor(c("b", "a"), levels = c("b", "a")))
+  expect_identical(res$a, c(NA_integer_, NA_integer_))
+  expect_identical(res$b, c(NA_integer_, NA_integer_))
+})
+
 # column names -------------------------------------------------------------
 
 test_that("names_glue affects output names", {

--- a/vignettes/pivot.Rmd
+++ b/vignettes/pivot.Rmd
@@ -396,6 +396,83 @@ us_rent_income %>%
 
 Note that the name of the variable is automatically appended to the output columns.
 
+## Implicit missing values
+
+Occasionally, you'll come across data where your names variable is encoded as a factor, but not all of the data will be represented.
+
+```{r}
+weekdays <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+daily <- tibble(
+  day = factor(c("Tue", "Thu", "Fri", "Mon"), levels = weekdays),
+  value = c(2, 3, 1, 5)
+)
+
+daily
+```
+
+`pivot_wider()` defaults to generating columns from the values that are actually represented in the data, but you might want to include a column for each possible level in case the data changes in the future.
+
+```{r}
+pivot_wider(daily, names_from = day, values_from = value)
+```
+
+The `names_expand` argument will turn implicit factor levels into explicit ones, forcing them to be represented in the result. It also sorts the column names using the level order, which produces more intuitive results in this case.
+
+```{r}
+pivot_wider(daily, names_from = day, values_from = value, names_expand = TRUE)
+```
+
+If multiple `names_from` columns are provided, `names_expand` will generate a Cartesian product of all possible combinations of the `names_from` values. Notice that the following data has omitted some rows where the percentage value would be `0`. `names_expand` allows us to make those explicit during the pivot.
+
+```{r}
+percentages <- tibble(
+  year = c(2018, 2019, 2020, 2020),
+  type = factor(c("A", "B", "A", "B"), levels = c("A", "B")),
+  percentage = c(100, 100, 40, 60)
+)
+
+percentages
+
+pivot_wider(
+  percentages,
+  names_from = c(year, type),
+  values_from = percentage,
+  names_expand = TRUE,
+  values_fill = 0
+)
+```
+
+A related problem can occur when there are implicit missing factor levels or combinations in the `id_cols`. In this case, there are missing rows (rather than columns) that you'd like to explicitly represent. For this example, we'll modify our `daily` data with a `type` column, and pivot on that instead, keeping `day` as an id column.
+
+```{r}
+daily <- mutate(daily, type = factor(c("A", "B", "B", "A")))
+daily
+```
+
+All of our `type` levels are represented in the columns, but we are missing some rows related to the unrepresented `day` factor levels.
+
+```{r}
+pivot_wider(
+  daily, 
+  names_from = type, 
+  values_from = value,
+  values_fill = 0
+)
+```
+
+We can use `id_expand` in the same way that we used `names_expand`, which will expand out (and sort) the implicit missing rows in the `id_cols`.
+
+```{r}
+pivot_wider(
+  daily, 
+  names_from = type, 
+  values_from = value,
+  values_fill = 0,
+  id_expand = TRUE
+)
+```
+
 ## Contact list
 
 A final challenge is inspired by [Jiena Gu](https://github.com/jienagu/tidyverse_examples/blob/master/example_long_wide.R). Imagine you have a contact list that you've copied and pasted from a website:


### PR DESCRIPTION
Closes #770 
Related to #560 

- `names_expand` calls `expand()` on the `names_from` columns while building out the spec. This should be rather cheap, as we don't have to expand the entire data frame.
- `id_expand` calls `complete()` and completes the `id_cols`. The data frame it completes contains the `id_cols` along with the `names_from` and `values_from` columns. I don't think there is any straightforward way to avoid calling `complete()` in favor of just calling `expand()` on the `id_cols`.
  - During the `complete()` stage, we fill in the previously implicit missing values in the expanded `values_from` columns

---

Is it worth it? I _think_ so, especially when you look at a few examples and consider the alternatives:
- It is very hard to reach the same efficiency as the approach implemented in this PR
- It is often hard to remember how to even get a "correct" result

Here is an example with `names_expand`:

``` r
library(tidyr)
weekdays <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")

daily <- tibble(
  day = factor(c("Tue", "Thu", "Fri", "Mon"), levels = weekdays),
  value = c(2, 3, 1, 5)
)

daily
#> # A tibble: 4 × 2
#>   day   value
#>   <fct> <dbl>
#> 1 Tue       2
#> 2 Thu       3
#> 3 Fri       1
#> 4 Mon       5

# How else can you get this?
pivot_wider(daily, names_from = day, values_from = value, names_expand = TRUE)
#> # A tibble: 1 × 7
#>     Mon   Tue   Wed   Thu   Fri   Sat   Sun
#>   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1     5     2    NA     3     1    NA    NA

# complete() first, then pivot.
# Note that this isn't efficient! When it adds a new row during
# the completing process, it adds NAs for all the other columns (i.e. `value`).
# All we have to do with `names_expand` is `expand(daily, day)`, which is less
# expensive
daily_comp <- complete(daily, day)
daily_comp
#> # A tibble: 7 × 2
#>   day   value
#>   <fct> <dbl>
#> 1 Mon       5
#> 2 Tue       2
#> 3 Wed      NA
#> 4 Thu       3
#> 5 Fri       1
#> 6 Sat      NA
#> 7 Sun      NA

pivot_wider(daily_comp, names_from = day, values_from = value)
#> # A tibble: 1 × 7
#>     Mon   Tue   Wed   Thu   Fri   Sat   Sun
#>   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1     5     2    NA     3     1    NA    NA
```

Here is an example with `id_expand`, which is often harder to remember how to do efficiently!

``` r
library(tidyr)

df <- tibble(
  x = factor(c("x", "x", "y"), levels = c("x", "y", "z")), 
  y = c("a", "b", "b"), 
  z = 11:13
)

df
#> # A tibble: 3 × 3
#>   x     y         z
#>   <fct> <chr> <int>
#> 1 x     a        11
#> 2 x     b        12
#> 3 y     b        13

# How else can we get this?
pivot_wider(df, names_from = y, values_from = z, id_expand = TRUE)
#> # A tibble: 3 × 3
#>   x         a     b
#>   <fct> <int> <int>
#> 1 x        11    12
#> 2 y        NA    13
#> 3 z        NA    NA

# 1 - Naive approach, `complete()`-ing `x`.
# Gives an `NA` column in the result.
df_comp <- complete(df, x)
pivot_wider(df_comp, names_from = y, values_from = z)
#> # A tibble: 3 × 4
#>   x         a     b  `NA`
#>   <fct> <int> <int> <int>
#> 1 x        11    12    NA
#> 2 y        NA    13    NA
#> 3 z        NA    NA    NA

# 2 - Correct but inefficient approach. `complete()`-ing `x` and `y`
df_comp <- complete(df, x, y)
pivot_wider(df_comp, names_from = y, values_from = z)
#> # A tibble: 3 × 3
#>   x         a     b
#>   <fct> <int> <int>
#> 1 x        11    12
#> 2 y        NA    13
#> 3 z        NA    NA

# 3 - Correct and as efficient as `id_expand`, but hard to remember!
# - Build spec on un-completed data
# - Then complete with just `x`
# - Then pivot
spec <- build_wider_spec(df, names_from = y, values_from = z)
df_comp <- complete(df, x)
pivot_wider_spec(df_comp, spec)
#> # A tibble: 3 × 3
#>   x         a     b
#>   <fct> <int> <int>
#> 1 x        11    12
#> 2 y        NA    13
#> 3 z        NA    NA
```

<sup>Created on 2021-12-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>