### PR TITLE
Remove maturing badges for `chop()` and `pack()`

### DIFF
--- a/R/chop.R
+++ b/R/chop.R
@@ -1,8 +1,6 @@
 #' Chop and unchop
 #'
 #' @description
-#' `r lifecycle::badge("maturing")`
-#'
 #' Chopping and unchopping preserve the width of a data frame, changing its
 #' length. `chop()` makes `df` shorter by converting rows within each group
 #' into list-columns. `unchop()` makes `df` longer by expanding list-columns

--- a/R/pack.R
+++ b/R/pack.R
@@ -1,8 +1,6 @@
 #' Pack and unpack
 #'
 #' @description
-#' `r lifecycle::badge("maturing")`
-#'
 #' Packing and unpacking preserve the length of a data frame, changing its
 #' width. `pack()` makes `df` narrow by collapsing a set of columns into a
 #' single df-column. `unpack()` makes `data` wider by expanding df-columns

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -31,8 +31,6 @@ coerce \code{cols} to, overriding the default that will be guessed from
 combining the individual values.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#maturing}{\figure{lifecycle-maturing.svg}{options: alt='[Maturing]'}}}{\strong{[Maturing]}}
-
 Chopping and unchopping preserve the width of a data frame, changing its
 length. \code{chop()} makes \code{df} shorter by converting rows within each group
 into list-columns. \code{unchop()} makes \code{df} longer by expanding list-columns

--- a/man/pack.Rd
+++ b/man/pack.Rd
@@ -45,8 +45,6 @@ See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on 
 strategies used to enforce them.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#maturing}{\figure{lifecycle-maturing.svg}{options: alt='[Maturing]'}}}{\strong{[Maturing]}}
-
 Packing and unpacking preserve the length of a data frame, changing its
 width. \code{pack()} makes \code{df} narrow by collapsing a set of columns into a
 single df-column. \code{unpack()} makes \code{data} wider by expanding df-columns


### PR DESCRIPTION
Closes #1086 

Upon review:

Changed:
- `chop()` and `pack()` were maturing, but I think they are stable now

Unchanged:
- `spread()` is marked as superseded
- `gather()` is marked as superseded
- `nest_legacy()` and `unnest_legacy()` are marked as superseded
- `nest()` has two deprecated arguments
   - Unnamed `...`
   - `.key`
- `unnest()` has four deprecated arguments
   - `.drop` / `.preserve`
   -   `.id`
   - `.sep`
- We have deprecated lazy eval versions of the tidyr verbs

I doubt any of this should be changed right now

At first I thought that the lazy eval versions might could be removed, but you have this in the 1.0.0 NEWS:

> All other lazyeval functions have been formally deprecated, and will be made defunct in the next major release.