### PR TITLE
Implement `unused_fn` for summarizing unused columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidyr (development version)
 
+* `pivot_wider()` gains a new `unused_fn` argument for controlling how to
+  summarize unused columns that aren't involved in the pivoting process (#990,
+  thanks to @mgirlich for an initial implementation).
+  
 * `pivot_wider()` gains new `names_expand` and `id_expand` arguments for turning
   implicit missing factor levels and variable combinations into explicit ones.
   This is similar to the `drop` argument from `spread()` (#770).

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -151,38 +151,6 @@
 #'     values_from = breaks,
 #'     values_fn = ~mean(.x, na.rm = TRUE)
 #'   )
-#'
-#' # Unused columns that aren't involved in the pivoting process are dropped
-#' # from the result by default. If you want to keep them, you can summarize
-#' # them with `unused_fn`. In this case, we'd like to retain the most recent
-#' # `update` date while pivoting on `name`.
-#' df <- tibble(
-#'   id = rep(1:5, each = 3),
-#'   update = as.Date("2020-07-01") + 1:15,
-#'   name = rep(c("a", "b", "c"), times = 5),
-#'   value = 1:15
-#' )
-#' df
-#'
-#' # You have to explicitly specify `id_cols` here, which allows `update` to
-#' # be recognized as an unused column
-#' pivot_wider(
-#'   data = df,
-#'   id_cols = id,
-#'   names_from = name,
-#'   values_from = value,
-#'   unused_fn = max
-#' )
-#'
-#' # Alternatively, you can keep all of the data and opt out of
-#' # immediately summarizing by converting to a list
-#' pivot_wider(
-#'   data = df,
-#'   id_cols = id,
-#'   names_from = name,
-#'   values_from = value,
-#'   unused_fn = list
-#' )
 pivot_wider <- function(data,
                         id_cols = NULL,
                         id_expand = FALSE,

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -19,6 +19,7 @@ pivot_wider(
   values_from = value,
   values_fill = NULL,
   values_fn = NULL,
+  unused_fn = NULL,
   ...
 )
 }
@@ -98,6 +99,21 @@ observation.
 This can be a named list if you want to apply different aggregations
 to different \code{values_from} columns.}
 
+\item{unused_fn}{Optionally, a function applied to summarize the values from
+the unused columns (i.e. columns not identified by \code{id_cols},
+\code{names_from}, or \code{values_from}).
+
+The default drops all unused columns from the result.
+
+This can be a named list if you want to apply different aggregations
+to different unused columns.
+
+\code{id_cols} must be supplied for \code{unused_fn} to be useful, since otherwise
+all unspecified columns will be considered \code{id_cols}.
+
+This is similar to grouping by the \code{id_cols} then summarizing the
+unused columns using \code{unused_fn}.}
+
 \item{...}{Additional arguments passed on to methods.}
 }
 \description{
@@ -174,6 +190,38 @@ warpbreaks \%>\%
     values_from = breaks,
     values_fn = ~mean(.x, na.rm = TRUE)
   )
+
+# Unused columns that aren't involved in the pivoting process are dropped
+# from the result by default. If you want to keep them, you can summarize
+# them with `unused_fn`. In this case, we'd like to retain the most recent
+# `update` date while pivoting on `name`.
+df <- tibble(
+  id = rep(1:5, each = 3),
+  update = as.Date("2020-07-01") + 1:15,
+  name = rep(c("a", "b", "c"), times = 5),
+  value = 1:15
+)
+df
+
+# You have to explicitly specify `id_cols` here, which allows `update` to
+# be recognized as an unused column
+pivot_wider(
+  data = df,
+  id_cols = id,
+  names_from = name,
+  values_from = value,
+  unused_fn = max
+)
+
+# Alternatively, you can keep all of the data and opt out of
+# immediately summarizing by converting to a list
+pivot_wider(
+  data = df,
+  id_cols = id,
+  names_from = name,
+  values_from = value,
+  unused_fn = list
+)
 }
 \seealso{
 \code{\link[=pivot_wider_spec]{pivot_wider_spec()}} to pivot "by hand" with a data frame that

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -190,38 +190,6 @@ warpbreaks \%>\%
     values_from = breaks,
     values_fn = ~mean(.x, na.rm = TRUE)
   )
-
-# Unused columns that aren't involved in the pivoting process are dropped
-# from the result by default. If you want to keep them, you can summarize
-# them with `unused_fn`. In this case, we'd like to retain the most recent
-# `update` date while pivoting on `name`.
-df <- tibble(
-  id = rep(1:5, each = 3),
-  update = as.Date("2020-07-01") + 1:15,
-  name = rep(c("a", "b", "c"), times = 5),
-  value = 1:15
-)
-df
-
-# You have to explicitly specify `id_cols` here, which allows `update` to
-# be recognized as an unused column
-pivot_wider(
-  data = df,
-  id_cols = id,
-  names_from = name,
-  values_from = value,
-  unused_fn = max
-)
-
-# Alternatively, you can keep all of the data and opt out of
-# immediately summarizing by converting to a list
-pivot_wider(
-  data = df,
-  id_cols = id,
-  names_from = name,
-  values_from = value,
-  unused_fn = list
-)
 }
 \seealso{
 \code{\link[=pivot_wider_spec]{pivot_wider_spec()}} to pivot "by hand" with a data frame that

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -12,7 +12,8 @@ pivot_wider_spec(
   id_cols = NULL,
   id_expand = FALSE,
   values_fill = NULL,
-  values_fn = NULL
+  values_fn = NULL,
+  unused_fn = NULL
 )
 
 build_wider_spec(
@@ -74,6 +75,21 @@ observation.
 
 This can be a named list if you want to apply different aggregations
 to different \code{values_from} columns.}
+
+\item{unused_fn}{Optionally, a function applied to summarize the values from
+the unused columns (i.e. columns not identified by \code{id_cols},
+\code{names_from}, or \code{values_from}).
+
+The default drops all unused columns from the result.
+
+This can be a named list if you want to apply different aggregations
+to different unused columns.
+
+\code{id_cols} must be supplied for \code{unused_fn} to be useful, since otherwise
+all unspecified columns will be considered \code{id_cols}.
+
+This is similar to grouping by the \code{id_cols} then summarizing the
+unused columns using \code{unused_fn}.}
 
 \item{names_from}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A pair of
 arguments describing which column (or columns) to get the name of the

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -176,3 +176,20 @@
       <error/rlang_error>
       Can't convert a double vector to function
 
+# `unused_fn` must result in single summary values
+
+    Code
+      (expect_error(pivot_wider(df, id_cols = id, unused_fn = identity)))
+    Output
+      <error/rlang_error>
+      Applying `unused_fn` to `unused` must result in a single summary value per key.
+      x Applying `unused_fn` resulted in a value with length 2.
+
+# `unused_fn` is validated
+
+    Code
+      (expect_error(pivot_wider(df, id_cols = id, unused_fn = 1)))
+    Output
+      <error/rlang_error>
+      Can't convert a double vector to function
+

--- a/vignettes/pivot.Rmd
+++ b/vignettes/pivot.Rmd
@@ -473,6 +473,56 @@ pivot_wider(
 )
 ```
 
+## Unused columns
+
+Imagine you've found yourself in a situation where you have columns in your data that are completely unrelated to the pivoting process, but you'd still like to retain their information somehow. For example, in `updates` we'd like to pivot on the `system` column to create one row summaries of each county's system updates.
+
+```{r}
+updates <- tibble(
+  county = c("Wake", "Wake", "Wake", "Guilford", "Guilford"),
+  date = c(as.Date("2020-01-01") + 0:2, as.Date("2020-01-03") + 0:1),
+  system = c("A", "B", "C", "A", "C"),
+  value = c(3.2, 4, 5.5, 2, 1.2)
+)
+
+updates
+```
+
+We could do that with a typical `pivot_wider()` call, but we completely lose all information about the `date` column.
+
+```{r}
+pivot_wider(
+  updates, 
+  id_cols = county, 
+  names_from = system, 
+  values_from = value
+)
+```
+
+For this example, we'd like to retain the most recent update date across all systems in a particular county. To accomplish that we can use the `unused_fn` argument, which allows us to summarize values from the columns not utilized in the pivoting process.
+
+```{r}
+pivot_wider(
+  updates, 
+  id_cols = county, 
+  names_from = system, 
+  values_from = value,
+  unused_fn = list(date = max)
+)
+```
+
+You can also retain the data but delay the aggregation entirely by using `list()` as the summary function.
+
+```{r}
+pivot_wider(
+  updates, 
+  id_cols = county, 
+  names_from = system, 
+  values_from = value,
+  unused_fn = list(date = list)
+)
+```
+
 ## Contact list
 
 A final challenge is inspired by [Jiena Gu](https://github.com/jienagu/tidyverse_examples/blob/master/example_long_wide.R). Imagine you have a contact list that you've copied and pasted from a website:


### PR DESCRIPTION
Closes #990 
Closes #1076 (CC @mgirlich I've built off your PR from there and mentioned you in the NEWS)

~_This means we have to tweak https://github.com/tidyverse/tidyr/pull/1277 to also include the columns identified by `unused_fn` when performing the `id_expand` `complete()` step._~ Done in this PR

I was initially a little resistant to this feature, but I've come around and actually think it is pretty neat and solves an otherwise clunky problem. @hadley what do you think? I know we are starting to add quite a few arguments to pivot-wider...

The only _slightly_ weird thing about it is that in order for `unused_fn` to be useful, you have to specify `id_cols` explicitly, otherwise all unspecified cols are treated as `id_cols`! I have mentioned this in the docs.

The original issue uses the following data, and wants to retain the maximum `update` date for each key while pivoting.

``` r
library(tidyr)

df <- tibble(
  id = rep(1:5, each = 3),
  update = as.Date("2020-07-01") + 1:15,
  key = rep(c("a", "b", "c"), times = 5),
  val = 1:15
)
df
#> # A tibble: 15 × 4
#>       id update     key     val
#>    <int> <date>     <chr> <int>
#>  1     1 2020-07-02 a         1
#>  2     1 2020-07-03 b         2
#>  3     1 2020-07-04 c         3
#>  4     2 2020-07-05 a         4
#>  5     2 2020-07-06 b         5
#>  6     2 2020-07-07 c         6
#>  7     3 2020-07-08 a         7
#>  8     3 2020-07-09 b         8
#>  9     3 2020-07-10 c         9
#> 10     4 2020-07-11 a        10
#> 11     4 2020-07-12 b        11
#> 12     4 2020-07-13 c        12
#> 13     5 2020-07-14 a        13
#> 14     5 2020-07-15 b        14
#> 15     5 2020-07-16 c        15

# Pivot on `name` with a key of `id`, but retain the most recent `update` date
pivot_wider(
  data = df, 
  id_cols = id, 
  names_from = key, 
  values_from = val, 
  unused_fn = list(update = max)
)
#> # A tibble: 5 × 5
#>      id     a     b     c update    
#>   <int> <int> <int> <int> <date>    
#> 1     1     1     2     3 2020-07-04
#> 2     2     4     5     6 2020-07-07
#> 3     3     7     8     9 2020-07-10
#> 4     4    10    11    12 2020-07-13
#> 5     5    13    14    15 2020-07-16

# Same as above, but delay the aggregation altogether, instead just chopping
# the `update` column into a list column
pivot_wider(
  data = df, 
  id_cols = id, 
  names_from = key, 
  values_from = val, 
  unused_fn = list(update = list)
)
#> # A tibble: 5 × 5
#>      id     a     b     c update    
#>   <int> <int> <int> <int> <list>    
#> 1     1     1     2     3 <date [3]>
#> 2     2     4     5     6 <date [3]>
#> 3     3     7     8     9 <date [3]>
#> 4     4    10    11    12 <date [3]>
#> 5     5    13    14    15 <date [3]>
```

<sup>Created on 2021-12-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>