### PR TITLE
Patch `replace_na(NULL)` until vctrs fix is released

### DIFF
--- a/R/replace_na.R
+++ b/R/replace_na.R
@@ -34,7 +34,14 @@ replace_na <- function(data, replace, ...) {
 #' @export
 replace_na.default <- function(data, replace = NA, ...) {
   check_replacement(replace, "data")
-  missing <- vec_equal_na(data)
+
+  if (is.null(data)) {
+    # TODO: Remove branch when https://github.com/r-lib/vctrs/pull/1497 is fixed
+    missing <- logical(0L)
+  } else {
+    missing <- vec_equal_na(data)
+  }
+
   vec_assign(data, missing, replace, x_arg = "data", value_arg = "replace")
 }
 

--- a/tests/testthat/test-replace_na.R
+++ b/tests/testthat/test-replace_na.R
@@ -46,6 +46,11 @@ test_that("empty atomic elements are not replaced in lists (#1168)", {
   )
 })
 
+test_that("can replace value in `NULL` (#1292)", {
+  expect_identical(replace_na(NULL, replace = "NA"), NULL)
+  expect_identical(replace_na(NULL, replace = 1L), NULL)
+})
+
 # data frame -------------------------------------------------------------
 
 test_that("empty call does nothing", {


### PR DESCRIPTION
For crosstable in #1292 