### PR TITLE
Add backwards compat support for `list()` in `names/values_ptypes`

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -82,6 +82,10 @@
 #'   confirm that the created columns are the types that you expect. Note that
 #'   if you want to change (instead of confirm) the types of specific columns,
 #'   you should use `names_transform` or `values_transform` instead.
+#'
+#'   For backwards compatibility reasons, supplying `list()` is interpreted as
+#'   being identical to `NULL` rather than as using a list prototype on all
+#'   columns. Expect this to change in the future.
 #' @param ... Additional arguments passed on to methods.
 #' @export
 #' @examples
@@ -232,6 +236,10 @@ pivot_longer_spec <- function(data,
   value_keys <- split(spec[-(1:2)], v_fct)
   keys <- vec_unique(spec[-(1:2)])
 
+  if (identical(values_ptypes, list())) {
+    # TODO: Remove me after https://github.com/tidyverse/tidyr/issues/1296
+    values_ptypes <- NULL
+  }
   values_ptypes <- check_list_of_ptypes(values_ptypes, value_names, "values_ptypes")
   values_transform <- check_list_of_functions(values_transform, value_names, "values_transform")
 
@@ -344,6 +352,10 @@ build_longer_spec <- function(data,
     vec_assert(values_to, ptype = character(), size = 1)
   }
 
+  if (identical(names_ptypes, list())) {
+    # TODO: Remove me after https://github.com/tidyverse/tidyr/issues/1296
+    names_ptypes <- NULL
+  }
   names_ptypes <- check_list_of_ptypes(names_ptypes, names(names), "names_ptypes")
   names_transform <- check_list_of_functions(names_transform, names(names), "names_transform")
 

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -70,7 +70,11 @@ zero-length vector (like \code{integer()} or \code{numeric()}) that defines the 
 class, and attributes of a vector. Use these arguments if you want to
 confirm that the created columns are the types that you expect. Note that
 if you want to change (instead of confirm) the types of specific columns,
-you should use \code{names_transform} or \code{values_transform} instead.}
+you should use \code{names_transform} or \code{values_transform} instead.
+
+For backwards compatibility reasons, supplying \code{list()} is interpreted as
+being identical to \code{NULL} rather than as using a list prototype on all
+columns. Expect this to change in the future.}
 
 \item{names_transform, values_transform}{Optionally, a list of column
 name-function pairs. Alternatively, a single function can be supplied,

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -58,7 +58,11 @@ zero-length vector (like \code{integer()} or \code{numeric()}) that defines the 
 class, and attributes of a vector. Use these arguments if you want to
 confirm that the created columns are the types that you expect. Note that
 if you want to change (instead of confirm) the types of specific columns,
-you should use \code{names_transform} or \code{values_transform} instead.}
+you should use \code{names_transform} or \code{values_transform} instead.
+
+For backwards compatibility reasons, supplying \code{list()} is interpreted as
+being identical to \code{NULL} rather than as using a list prototype on all
+columns. Expect this to change in the future.}
 
 \item{values_transform}{Optionally, a list of column
 name-function pairs. Alternatively, a single function can be supplied,
@@ -136,7 +140,11 @@ zero-length vector (like \code{integer()} or \code{numeric()}) that defines the 
 class, and attributes of a vector. Use these arguments if you want to
 confirm that the created columns are the types that you expect. Note that
 if you want to change (instead of confirm) the types of specific columns,
-you should use \code{names_transform} or \code{values_transform} instead.}
+you should use \code{names_transform} or \code{values_transform} instead.
+
+For backwards compatibility reasons, supplying \code{list()} is interpreted as
+being identical to \code{NULL} rather than as using a list prototype on all
+columns. Expect this to change in the future.}
 
 \item{names_transform}{Optionally, a list of column
 name-function pairs. Alternatively, a single function can be supplied,

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -336,6 +336,21 @@ test_that("`values_transform` works with single functions (#1284)", {
   expect_identical(res$y, "2")
 })
 
+test_that("`names/values_ptypes = list()` is currently the same as `NULL` (#1296)", {
+  # Because of some backwards compatibility support
+
+  df <- tibble(x = 1)
+
+  expect_identical(
+    pivot_longer(df, x, names_ptypes = list()),
+    pivot_longer(df, x, names_ptypes = NULL)
+  )
+  expect_identical(
+    pivot_longer(df, x, values_ptypes = list()),
+    pivot_longer(df, x, values_ptypes = NULL)
+  )
+})
+
 test_that("Error if the `col` can't be selected.", {
   expect_snapshot({
     (expect_error(pivot_longer(iris, matches("foo"))))


### PR DESCRIPTION
Closes #1291 
See also #1296 