### PR TITLE
Disallow access to group columns in `expand()` and `complete()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,11 @@
 
 * `complete()` gains a grouped data frame method. This generates a more correct
   completed data frame when groups are involved (#396, #966).
+  
+* `complete()` and `expand()` no longer allow you to complete or expand on a
+  grouping column. This was never well-defined since completion/expansion on a
+  grouped data frame happens "within" each group and otherwise has the
+  potential to produce erroneous results (#1299).
 
 ## Missing values
 

--- a/R/complete.R
+++ b/R/complete.R
@@ -5,7 +5,8 @@
 #' completing missing combinations of data.
 #'
 #' @details
-#' With grouped data frames, `complete()` operates _within_ each group.
+#' With grouped data frames, `complete()` operates _within_ each group. Because
+#' of this, you cannot complete a grouping column.
 #'
 #' @inheritParams expand
 #' @param fill A named list that for each variable supplies a single value to
@@ -99,7 +100,7 @@ complete.grouped_df <- function(data,
   dplyr::summarise(
     data,
     complete(
-      data = dplyr::cur_data_all(),
+      data = dplyr::cur_data(),
       ...,
       fill = fill,
       explicit = explicit

--- a/R/expand.R
+++ b/R/expand.R
@@ -14,6 +14,10 @@
 #'  * use it with `anti_join()` to figure out which combinations are missing
 #'    (e.g., identify gaps in your data frame).
 #'
+#' @details
+#' With grouped data frames, `expand()` operates _within_ each group. Because of
+#' this, you cannot expand on a grouping column.
+#'
 #' @inheritParams expand_grid
 #' @param data A data frame.
 #' @param ... Specification of columns to expand. Columns can be atomic vectors
@@ -43,7 +47,7 @@
 #' @examples
 #' fruits <- tibble(
 #'   type   = c("apple", "orange", "apple", "orange", "orange", "orange"),
-#'   year   = c(2010, 2010, 2012, 2010, 2010, 2012),
+#'   year   = c(2010, 2010, 2012, 2010, 2011, 2012),
 #'   size  =  factor(
 #'     c("XS", "S",  "M", "S", "S", "M"),
 #'     levels = c("XS", "S", "M", "L")
@@ -66,7 +70,7 @@
 #' # Other uses -------------------------------------------------------
 #' # Use with `full_seq()` to fill in values of continuous variables
 #' fruits %>% expand(type, size, full_seq(year, 1))
-#' fruits %>% expand(type, size, 2010:2012)
+#' fruits %>% expand(type, size, 2010:2013)
 #'
 #' # Use `anti_join()` to determine which observations are missing
 #' all <- fruits %>% expand(type, size, year)
@@ -75,6 +79,9 @@
 #'
 #' # Use with `right_join()` to fill in missing rows
 #' fruits %>% dplyr::right_join(all)
+#'
+#' # Use with `group_by()` to expand within each group
+#' fruits %>% dplyr::group_by(type) %>% expand(year, size)
 expand <- function(data, ..., .name_repair = "check_unique") {
   UseMethod("expand")
 }
@@ -95,7 +102,7 @@ expand.grouped_df <- function(data, ..., .name_repair = "check_unique") {
   dplyr::summarise(
     data,
     expand(
-      data = dplyr::cur_data_all(),
+      data = dplyr::cur_data(),
       ...,
       .name_repair = .name_repair
     ),

--- a/man/complete.Rd
+++ b/man/complete.Rd
@@ -45,7 +45,8 @@ around \code{\link[=expand]{expand()}}, \code{\link[dplyr:mutate-joins]{dplyr::f
 completing missing combinations of data.
 }
 \details{
-With grouped data frames, \code{complete()} operates \emph{within} each group.
+With grouped data frames, \code{complete()} operates \emph{within} each group. Because
+of this, you cannot complete a grouping column.
 }
 \examples{
 library(dplyr, warn.conflicts = FALSE)

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -68,10 +68,14 @@ explicit missing values (e.g., fill in gaps in your data frame).
 (e.g., identify gaps in your data frame).
 }
 }
+\details{
+With grouped data frames, \code{expand()} operates \emph{within} each group. Because of
+this, you cannot expand on a grouping column.
+}
 \examples{
 fruits <- tibble(
   type   = c("apple", "orange", "apple", "orange", "orange", "orange"),
-  year   = c(2010, 2010, 2012, 2010, 2010, 2012),
+  year   = c(2010, 2010, 2012, 2010, 2011, 2012),
   size  =  factor(
     c("XS", "S",  "M", "S", "S", "M"),
     levels = c("XS", "S", "M", "L")
@@ -94,7 +98,7 @@ fruits \%>\% expand(nesting(type, size, year))
 # Other uses -------------------------------------------------------
 # Use with `full_seq()` to fill in values of continuous variables
 fruits \%>\% expand(type, size, full_seq(year, 1))
-fruits \%>\% expand(type, size, 2010:2012)
+fruits \%>\% expand(type, size, 2010:2013)
 
 # Use `anti_join()` to determine which observations are missing
 all <- fruits \%>\% expand(type, size, year)
@@ -103,6 +107,9 @@ all \%>\% dplyr::anti_join(fruits)
 
 # Use with `right_join()` to fill in missing rows
 fruits \%>\% dplyr::right_join(all)
+
+# Use with `group_by()` to expand within each group
+fruits \%>\% dplyr::group_by(type) \%>\% expand(year, size)
 }
 \seealso{
 \code{\link[=complete]{complete()}} to expand list objects. \code{\link[=expand_grid]{expand_grid()}}

--- a/tests/testthat/test-complete.R
+++ b/tests/testthat/test-complete.R
@@ -9,33 +9,87 @@ test_that("basic invocation works", {
   expect_equal(out$z, c(3, NA, NA, 4))
 })
 
-test_that("preserves grouping", {
-  local_options(lifecycle_verbosity = "quiet")
+test_that("will complete within each group (#396)", {
+  levels <- c("a", "b", "c")
 
-  df <- tibble(x = 1:2, y = 1:2, z = 3:4) %>% dplyr::group_by(x)
-  out <- complete(df, x, y)
-  expect_s3_class(out, "grouped_df")
-  expect_equal(dplyr::group_vars(out), dplyr::group_vars(df))
-})
-
-test_that("complete allows expanding on grouping variable (#396)", {
   df <- tibble(
-    g = factor(c("a", "b", "b")),
-    a = c(1, 1, 3),
-    x = c(1, 2, 3)
+    g = c("a", "b", "a"),
+    a = c(1L, 1L, 2L),
+    b = factor(c("a", "a", "b"), levels = levels),
+    c = c(4, 5, 6)
   )
   gdf <- dplyr::group_by(df, g)
 
-  out <- complete(gdf, g, a)
+  out <- complete(gdf, a, b)
 
-  # Same as split by group, complete, combine
-  expect <- vec_rbind(
-    complete(df[1,], g, a),
-    complete(df[2:3,], g, a)
+  # Still grouped
+  expect_identical(dplyr::group_vars(out), "g")
+
+  out <- nest(out, data = -g)
+
+  expect_identical(
+    out$data[[1]],
+    tibble(
+      a = vec_rep_each(c(1L, 2L), times = 3),
+      b = factor(vec_rep(c("a", "b", "c"), times = 2)),
+      c = c(4, NA, NA, NA, 6, NA)
+    )
   )
-  expect <- dplyr::group_by(expect, g)
 
-  expect_identical(out, expect)
+  expect_identical(
+    out$data[[2]],
+    tibble(
+      a = 1L,
+      b = factor(c("a", "b", "c")),
+      c = c(5, NA, NA)
+    )
+  )
+})
+
+test_that("complete does not allow expansion on grouping variable (#1299)", {
+  df <- tibble(
+    g = "x",
+    a = 1L
+  )
+  gdf <- dplyr::group_by(df, g)
+
+  # This is a dplyr error that we don't own
+  expect_error(complete(gdf, g))
+})
+
+test_that("can use `.drop = FALSE` with complete (#1299)", {
+  levels <- c("a", "b", "c")
+
+  df <- tibble(
+    g = factor(c("a", "b", "a"), levels = levels),
+    a = c(1L, 1L, 2L),
+    b = factor(c("a", "a", "b"), levels = levels)
+  )
+  gdf <- dplyr::group_by(df, g, .drop = FALSE)
+
+  # No data in group "c" for `a`, so we don't get that in the result
+  expect_identical(
+    complete(gdf, a),
+    vec_sort(gdf)
+  )
+
+  expect <- crossing(g = factor(levels = levels), b = factor(levels = levels))
+  expect <- dplyr::group_by(expect, g, .drop = FALSE)
+  expect <- dplyr::full_join(expect, df, c("g", "b"))
+
+  # Levels of empty vector in `b` are expanded for group "c"
+  expect_identical(complete(gdf, b), expect)
+})
+
+test_that("complete moves the grouping and completing variables to the front", {
+  df <- tibble(
+    a = 1L,
+    g = "x",
+    b = 2L
+  )
+  gdf <- dplyr::group_by(df, g)
+
+  expect_named(complete(gdf, b), c("g", "b", "a"))
 })
 
 test_that("expands empty factors", {
@@ -104,6 +158,19 @@ test_that("can limit the fill to only implicit missing values with `explicit` (#
     complete(df, x, fill = list(a = 0), explicit = FALSE),
     tibble(x = factor(1:3), a = c(1, NA, 0))
   )
+})
+
+test_that("can't fill a grouping column", {
+  df <- tibble(
+    g = c(1, NA),
+    x = factor(1:2, levels = 1:3)
+  )
+  gdf <- dplyr::group_by(df, g)
+
+  # Silently ignore it
+  out <- complete(gdf, x, fill = list(g = 0))
+
+  expect_identical(out$g, c(1, 1, 1, NA, NA, NA))
 })
 
 test_that("if the completing variables have missings, `fill` will fill them after expansion", {


### PR DESCRIPTION
Closes #1299
Follow up to #1289 

In #1289 we added a grouped-df method for `complete()` that calls `complete()` "within" each group. This would send the entire group slice of data (including the grouping column) into the inner call to `complete()`. This turns out to be buggy, since it can generate missing values in the grouping columns if the within-group-expansion adds rows:

``` r
library(tidyr)
library(dplyr, warn.conflicts = FALSE)

df <- tibble(
  g = c("x", "x", "y"),
  a = c(1, 2, 2),
  b = c(1, 2, 2)
)
gdf <- group_by(df, g)
gdf
#> # A tibble: 3 × 3
#> # Groups:   g [2]
#>   g         a     b
#>   <chr> <dbl> <dbl>
#> 1 x         1     1
#> 2 x         2     2
#> 3 y         2     2

# The `NA`s should be `"x"` values.
# Columns `a` and `b` should be completed "within" each group of `g`
complete(gdf, a, b)
#> # A tibble: 5 × 3
#> # Groups:   g [3]
#>   g         a     b
#>   <chr> <dbl> <dbl>
#> 1 x         1     1
#> 2 <NA>      1     2
#> 3 <NA>      2     1
#> 4 x         2     2
#> 5 y         2     2
```

We never saw this with `expand()`, because each call to `expand()` "within" each group would only return the expansion columns, then the outer `summarize()` would add the group columns back on.

``` r
expand(gdf, a, b)
#> # A tibble: 5 × 3
#> # Groups:   g [2]
#>   g         a     b
#>   <chr> <dbl> <dbl>
#> 1 x         1     1
#> 2 x         1     2
#> 3 x         2     1
#> 4 x         2     2
#> 5 y         2     2
```

Compare this with `complete()`, where each inner call to `complete()` "within" each group returns all the columns in the data frame. This includes the grouping columns if they are passed through, and `summarize()` won't overwrite those, which is why we ended up with the problem above.

The fix is to use `cur_data()` rather than `cur_data_all()`, forcing `summarize()` to handle the re-addition of any group columns. This means you can no longer attempt to "complete" or "expand" on a group column, but that was pretty much undefined behavior previously, since conceptually you should be completing/expanding "within" each group, meaning you don't have access to that group info.