### PR TITLE
Only use `c()` when there are >1 unnamed inputs

### DIFF
--- a/R/nest.R
+++ b/R/nest.R
@@ -128,7 +128,13 @@ nest <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
 
     .key <- if (missing(.key)) "data" else as.character(ensym(.key))
 
-    cols_fixed_expr <- expr(c(!!!cols_bad))
+    if (length(cols_bad) == 1L) {
+      cols_bad <- cols_bad[[1]]
+      cols_fixed_expr <- expr(!!cols_bad)
+    } else {
+      cols_fixed_expr <- expr(c(!!!cols_bad))
+    }
+
     cols_fixed_label <- as_label(cols_fixed_expr)
     cols_fixed <- quos(!!.key := !!cols_fixed_expr)
 

--- a/tests/testthat/_snaps/nest.md
+++ b/tests/testthat/_snaps/nest.md
@@ -44,7 +44,15 @@
       out <- nest(df, y)
     Warning <warning>
       All elements of `...` must be named.
-      Did you want `data = c(y)`?
+      Did you want `data = y`?
+
+---
+
+    Code
+      out <- nest(df, -y)
+    Warning <warning>
+      All elements of `...` must be named.
+      Did you want `data = -y`?
 
 # only warn about unnamed inputs (#1175)
 
@@ -68,7 +76,7 @@
       out <- nest(df, y, .key = "y")
     Warning <warning>
       All elements of `...` must be named.
-      Did you want `y = c(y)`?
+      Did you want `y = y`?
 
 # can control output column name when nested
 

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -311,8 +311,12 @@ test_that("unnest keeps list cols", {
 
 test_that("warn about old style interface", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
+
   expect_snapshot(out <- nest(df, y))
   expect_named(out, c("x", "data"))
+
+  expect_snapshot(out <- nest(df, -y))
+  expect_named(out, c("y", "data"))
 })
 
 test_that("only warn about unnamed inputs (#1175)", {


### PR DESCRIPTION
Small improvement to the `nest()` generic warning regarding unnamed inputs. If we only have one input, then we don't need to wrap it in `c()`