### PR TITLE
Update to rlang 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     lifecycle,
     magrittr,
     purrr,
-    rlang,
+    rlang (>= 1.0.0),
     tibble (>= 2.1.1),
     tidyselect (>= 1.1.0),
     utils,

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -22,7 +22,7 @@ extract(
 \code{\link[tidyselect:vars_pull]{tidyselect::vars_pull()}}.
 
 This argument is passed by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names or column positions).}
 
 \item{into}{Names of new variables to create as character vector.

--- a/man/gather.Rd
+++ b/man/gather.Rd
@@ -21,9 +21,9 @@ gather(
 symbols.
 
 This argument is passed by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote strings
+\link[rlang:topic-inject]{quasiquotation} (you can unquote strings
 and symbols). The name is captured from the expression with
-\code{\link[rlang:nse-defuse]{rlang::ensym()}} (note that this kind of interface where
+\code{\link[rlang:defusing-advanced]{rlang::ensym()}} (note that this kind of interface where
 symbols do not represent actual objects is now discouraged in the
 tidyverse; we support it here for backward compatibility).}
 

--- a/man/nest_legacy.Rd
+++ b/man/nest_legacy.Rd
@@ -17,8 +17,8 @@ functions of variables. If omitted, defaults to all list-cols.}
 
 \item{.key}{The name of the new column, as a string or symbol. This argument
 is passed by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote strings and
-symbols). The name is captured from the expression with \code{\link[rlang:nse-defuse]{rlang::ensym()}}
+\link[rlang:topic-inject]{quasiquotation} (you can unquote strings and
+symbols). The name is captured from the expression with \code{\link[rlang:defusing-advanced]{rlang::ensym()}}
 (note that this kind of interface where symbols do not represent actual
 objects is now discouraged in the tidyverse; we support it here for
 backward compatibility).}

--- a/man/separate.Rd
+++ b/man/separate.Rd
@@ -24,7 +24,7 @@ separate(
 \code{\link[tidyselect:vars_pull]{tidyselect::vars_pull()}}.
 
 This argument is passed by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names or column positions).}
 
 \item{into}{Names of new variables to create as character vector.

--- a/man/spread.Rd
+++ b/man/spread.Rd
@@ -13,7 +13,7 @@ spread(data, key, value, fill = NA, convert = FALSE, drop = TRUE, sep = NULL)
 \code{\link[tidyselect:vars_pull]{tidyselect::vars_pull()}}.
 
 These arguments are passed by expression and support
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names or column positions).}
 
 \item{fill}{If set, missing values will be replaced with this value. Note

--- a/man/unite.Rd
+++ b/man/unite.Rd
@@ -12,9 +12,9 @@ unite(data, col, ..., sep = "_", remove = TRUE, na.rm = FALSE)
 \item{col}{The name of the new column, as a string or symbol.
 
 This argument is passed by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote strings
+\link[rlang:topic-inject]{quasiquotation} (you can unquote strings
 and symbols). The name is captured from the expression with
-\code{\link[rlang:nse-defuse]{rlang::ensym()}} (note that this kind of interface where
+\code{\link[rlang:defusing-advanced]{rlang::ensym()}} (note that this kind of interface where
 symbols do not represent actual objects is now discouraged in the
 tidyverse; we support it here for backward compatibility).}
 

--- a/tests/testthat/_snaps/chop.md
+++ b/tests/testthat/_snaps/chop.md
@@ -4,7 +4,8 @@
       (expect_error(chop(df)))
     Output
       <error/rlang_error>
-      Argument `cols` is missing with no default
+      Error in `check_present()`:
+      ! Argument `cols` is missing with no default
 
 # incompatible sizes are caught
 
@@ -12,7 +13,8 @@
       (expect_error(unchop(df, c(x, y))))
     Output
       <error/rlang_error>
-      In row 1, can't recycle input of size 2 to size 3.
+      Error in `fn()`:
+      ! In row 1, can't recycle input of size 2 to size 3.
 
 # empty typed inputs are considered in common size, but NULLs aren't
 
@@ -20,5 +22,6 @@
       (expect_error(unchop(df, c(x, y))))
     Output
       <error/rlang_error>
-      In row 1, can't recycle input of size 0 to size 2.
+      Error in `fn()`:
+      ! In row 1, can't recycle input of size 0 to size 2.
 

--- a/tests/testthat/_snaps/drop-na.md
+++ b/tests/testthat/_snaps/drop-na.md
@@ -4,7 +4,8 @@
       (expect_error(drop_na(df, list())))
     Output
       <error/vctrs_error_subscript_type>
-      Must subset columns with a valid subscript vector.
+      Error:
+      ! Must subset columns with a valid subscript vector.
       x Subscript has the wrong type `list`.
       i It must be numeric or character.
 
@@ -14,6 +15,7 @@
       (expect_error(drop_na(df, "z")))
     Output
       <error/vctrs_error_subscript_oob>
-      Can't subset columns that don't exist.
+      Error in `stop_subscript()`:
+      ! Can't subset columns that don't exist.
       x Column `z` doesn't exist.
 

--- a/tests/testthat/_snaps/expand.md
+++ b/tests/testthat/_snaps/expand.md
@@ -4,13 +4,14 @@
       (expect_error(crossing(x = 1:10, y = quote(a))))
     Output
       <error/vctrs_error_scalar_type>
-      `..2` must be a vector, not a symbol.
+      Error in `stop_vctrs()`:
+      ! `..2` must be a vector, not a symbol.
 
 # expand() respects `.name_repair`
 
     Code
       out <- df %>% expand(x = x, x = x, .name_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * x -> x...1
       * x -> x...2
@@ -19,7 +20,7 @@
 
     Code
       out <- crossing(x = x, x = x, .name_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * x -> x...1
       * x -> x...2
@@ -28,7 +29,7 @@
 
     Code
       out <- nesting(x = x, x = x, .name_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * x -> x...1
       * x -> x...2
@@ -39,7 +40,8 @@
       (expect_error(expand_grid(x = x, x = x)))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Names must be unique.
+      Error in `stop_vctrs()`:
+      ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1 and 2.
 
@@ -47,7 +49,7 @@
 
     Code
       out <- expand_grid(x = x, x = x, .name_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * x -> x...1
       * x -> x...2
@@ -58,5 +60,6 @@
       (expect_error(grid_dots(lm(1 ~ 1))))
     Output
       <error/vctrs_error_scalar_type>
-      `..1` must be a vector, not a <lm> object.
+      Error in `stop_vctrs()`:
+      ! `..1` must be a vector, not a <lm> object.
 

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -15,5 +15,6 @@
       (expect_error(extract(df, x, "x", regex = regex)))
     Output
       <error/rlang_error>
-      `regex` can't use modifiers from stringr.
+      Error in `check_not_stringr_pattern()`:
+      ! `regex` can't use modifiers from stringr.
 

--- a/tests/testthat/_snaps/gather.md
+++ b/tests/testthat/_snaps/gather.md
@@ -35,7 +35,8 @@
 
     Code
       out <- gather(df, k, v)
-    Warning <warning>
+    Condition
+      Warning:
       attributes are not identical across measure variables;
       they will be dropped
 
@@ -43,7 +44,8 @@
 
     Code
       gather(df, k, v)
-    Warning <warning>
+    Condition
+      Warning:
       attributes are not identical across measure variables;
       they will be dropped
     Output

--- a/tests/testthat/_snaps/nest-legacy.md
+++ b/tests/testthat/_snaps/nest-legacy.md
@@ -4,7 +4,8 @@
       (expect_error(unnest_legacy(df)))
     Output
       <error/rlang_error>
-      Each column must either be a list of vectors or a list of data frames [x]
+      Error in `unnest_legacy()`:
+      ! Each column must either be a list of vectors or a list of data frames [x]
 
 # multiple columns must be same length
 
@@ -12,7 +13,8 @@
       (expect_error(unnest_legacy(df)))
     Output
       <error/rlang_error>
-      All nested columns must have the same number of elements.
+      Error in `unnest_legacy()`:
+      ! All nested columns must have the same number of elements.
 
 ---
 
@@ -20,5 +22,6 @@
       (expect_error(unnest_legacy(df)))
     Output
       <error/rlang_error>
-      All nested columns must have the same number of elements.
+      Error in `unnest_legacy()`:
+      ! All nested columns must have the same number of elements.
 

--- a/tests/testthat/_snaps/nest.md
+++ b/tests/testthat/_snaps/nest.md
@@ -2,7 +2,8 @@
 
     Code
       out <- nest(df)
-    Warning <warning>
+    Condition
+      Warning:
       `...` must not be empty for ungrouped data frames.
       Did you want `data = everything()`?
 
@@ -12,7 +13,8 @@
       (expect_error(unnest(df, y)))
     Output
       <error/vctrs_error_scalar_type>
-      Input must be a vector, not a function.
+      Error in `stop_vctrs()`:
+      ! Input must be a vector, not a function.
 
 # multiple columns must be same length
 
@@ -20,7 +22,8 @@
       (expect_error(unnest(df, c(x, y))))
     Output
       <error/rlang_error>
-      In row 1, can't recycle input of size 2 to size 3.
+      Error in `fn()`:
+      ! In row 1, can't recycle input of size 2 to size 3.
 
 ---
 
@@ -28,7 +31,8 @@
       (expect_error(unnest(df, c(x, y))))
     Output
       <error/rlang_error>
-      In row 1, can't recycle input of size 2 to size 3.
+      Error in `fn()`:
+      ! In row 1, can't recycle input of size 2 to size 3.
 
 # unnesting column of mixed vector / data frame input is an error
 
@@ -36,13 +40,15 @@
       (expect_error(unnest(df, x)))
     Output
       <error/vctrs_error_incompatible_type>
-      Can't combine `..1` <double> and `..2` <tbl_df>.
+      Error in `stop_vctrs()`:
+      ! Can't combine `..1` <double> and `..2` <tbl_df>.
 
 # warn about old style interface
 
     Code
       out <- nest(df, y)
-    Warning <warning>
+    Condition
+      Warning:
       All elements of `...` must be named.
       Did you want `data = y`?
 
@@ -50,7 +56,8 @@
 
     Code
       out <- nest(df, -y)
-    Warning <warning>
+    Condition
+      Warning:
       All elements of `...` must be named.
       Did you want `data = -y`?
 
@@ -58,7 +65,8 @@
 
     Code
       out <- nest(df, x, y, foo = z)
-    Warning <warning>
+    Condition
+      Warning:
       All elements of `...` must be named.
       Did you want `data = c(x, y)`?
 
@@ -66,7 +74,8 @@
 
     Code
       out <- nest(df, x, starts_with("z"))
-    Warning <warning>
+    Condition
+      Warning:
       All elements of `...` must be named.
       Did you want `data = c(x, starts_with("z"))`?
 
@@ -74,7 +83,8 @@
 
     Code
       out <- nest(df, y, .key = "y")
-    Warning <warning>
+    Condition
+      Warning:
       All elements of `...` must be named.
       Did you want `y = y`?
 
@@ -82,21 +92,24 @@
 
     Code
       out <- nest(df, .key = "y")
-    Warning <warning>
+    Condition
+      Warning:
       `.key` is deprecated
 
 # .key gets warning with new interface
 
     Code
       out <- nest(df, y = y, .key = "y")
-    Warning <warning>
+    Condition
+      Warning:
       `.key` is deprecated
 
 # cols must go in cols
 
     Code
       unnest(df, x, y)
-    Warning <warning>
+    Condition
+      Warning:
       unnest() has a new interface. See ?unnest for details.
       Try `df %>% unnest(c(x, y))`, with `mutate()` if needed
     Output
@@ -110,7 +123,8 @@
 
     Code
       unnest(df)
-    Warning <warning>
+    Condition
+      Warning:
       `cols` is now required when using unnest().
       Please use `cols = c(y)`
     Output
@@ -124,7 +138,8 @@
 
     Code
       out <- df %>% unnest(c(x, y), .sep = "_")
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       The `.sep` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       Use `names_sep = '_'` instead.
 
@@ -132,7 +147,8 @@
 
     Code
       out <- df %>% unnest(z = map(y, `+`, 1))
-    Warning <warning>
+    Condition
+      Warning:
       unnest() has a new interface. See ?unnest for details.
       Try `df %>% unnest(c(z))`, with `mutate()` if needed
 
@@ -140,7 +156,8 @@
 
     Code
       df %>% unnest(x, .preserve = y)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       The `.preserve` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       All list-columns are now preserved
     Output
@@ -154,7 +171,8 @@
 
     Code
       df %>% unnest(x, .drop = FALSE)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       The `.drop` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       All list-columns are now preserved.
     Output
@@ -168,7 +186,8 @@
 
     Code
       out <- unnest(df, y, .id = "name")
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       The `.id` argument of `unnest()` is deprecated as of tidyr 1.0.0.
       Manually create column of names instead.
 

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -4,10 +4,12 @@
       (expect_error(pack(df, a = c(a1, a2), c(b1, b2))))
     Output
       <error/rlang_error>
-      All elements of `...` must be named
+      Error in `pack()`:
+      ! All elements of `...` must be named
     Code
       (expect_error(pack(df, c(a1, a2), c(b1, b2))))
     Output
       <error/rlang_error>
-      All elements of `...` must be named
+      Error in `pack()`:
+      ! All elements of `...` must be named
 

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -4,7 +4,8 @@
       (expect_error(pivot_longer(df, y, names_to = "x")))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Names must be unique.
+      Error in `stop_vctrs()`:
+      ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1 and 2.
       i Use argument `names_repair` to specify repair strategy.
@@ -13,7 +14,7 @@
 
     Code
       out <- pivot_longer(df, y, names_to = "x", names_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * x -> x...1
       * x -> x...2
@@ -24,13 +25,15 @@
       (expect_error(build_longer_spec(df, x_y, names_to = c("a", "b"))))
     Output
       <error/rlang_error>
-      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+      Error in `build_longer_spec()`:
+      ! If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
     Code
       (expect_error(build_longer_spec(df, x_y, names_to = c("a", "b"), names_sep = "x",
       names_pattern = "x")))
     Output
       <error/rlang_error>
-      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+      Error in `build_longer_spec()`:
+      ! If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
 
 # names_sep fails with single name
 
@@ -38,7 +41,8 @@
       (expect_error(build_longer_spec(df, x_y, names_to = "x", names_sep = "_")))
     Output
       <error/rlang_error>
-      `names_sep` can't be used with a length 1 `names_to`.
+      Error in `build_longer_spec()`:
+      ! `names_sep` can't be used with a length 1 `names_to`.
 
 # Error if the `col` can't be selected.
 
@@ -46,7 +50,8 @@
       (expect_error(pivot_longer(iris, matches("foo"))))
     Output
       <error/rlang_error>
-      `cols` must select at least one column.
+      Error in `build_longer_spec()`:
+      ! `cols` must select at least one column.
 
 # `names_to` is validated
 
@@ -54,18 +59,21 @@
       (expect_error(build_longer_spec(df, x, names_to = 1)))
     Output
       <error/rlang_error>
-      `names_to` must be a character vector or `NULL`.
+      Error in `build_longer_spec()`:
+      ! `names_to` must be a character vector or `NULL`.
     Code
       (expect_error(build_longer_spec(df, x, names_to = c("x", "y"))))
     Output
       <error/rlang_error>
-      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+      Error in `build_longer_spec()`:
+      ! If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
     Code
       (expect_error(build_longer_spec(df, x, names_to = c("x", "y"), names_sep = "_",
       names_pattern = "x")))
     Output
       <error/rlang_error>
-      If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
+      Error in `build_longer_spec()`:
+      ! If you supply multiple names in `names_to` you must also supply one of `names_sep` or `names_pattern`.
 
 # `names_ptypes` is validated
 
@@ -73,12 +81,14 @@
       (expect_error(build_longer_spec(df, x, names_ptypes = 1)))
     Output
       <error/rlang_error>
-      `names_ptypes` must be `NULL`, an empty ptype, or a named list of ptypes.
+      Error in `check_list_of_ptypes()`:
+      ! `names_ptypes` must be `NULL`, an empty ptype, or a named list of ptypes.
     Code
       (expect_error(build_longer_spec(df, x, names_ptypes = list(integer()))))
     Output
       <error/rlang_error>
-      All elements of `names_ptypes` must be named.
+      Error in `check_list_of_ptypes()`:
+      ! All elements of `names_ptypes` must be named.
 
 # `names_transform` is validated
 
@@ -86,12 +96,14 @@
       (expect_error(build_longer_spec(df, x, names_transform = 1)))
     Output
       <error/rlang_error>
-      Can't convert a double vector to function
+      Error in `map()`:
+      ! Can't convert `.x[[i]]`, a number, to a function.
     Code
       (expect_error(build_longer_spec(df, x, names_transform = list(~.x))))
     Output
       <error/rlang_error>
-      All elements of `names_transform` must be named.
+      Error in `check_list_of_functions()`:
+      ! All elements of `names_transform` must be named.
 
 # `values_ptypes` is validated
 
@@ -99,12 +111,14 @@
       (expect_error(pivot_longer(df, x, values_ptypes = 1)))
     Output
       <error/rlang_error>
-      `values_ptypes` must be `NULL`, an empty ptype, or a named list of ptypes.
+      Error in `check_list_of_ptypes()`:
+      ! `values_ptypes` must be `NULL`, an empty ptype, or a named list of ptypes.
     Code
       (expect_error(pivot_longer(df, x, values_ptypes = list(integer()))))
     Output
       <error/rlang_error>
-      All elements of `values_ptypes` must be named.
+      Error in `check_list_of_ptypes()`:
+      ! All elements of `values_ptypes` must be named.
 
 # `values_transform` is validated
 
@@ -112,10 +126,12 @@
       (expect_error(pivot_longer(df, x, values_transform = 1)))
     Output
       <error/rlang_error>
-      Can't convert a double vector to function
+      Error in `map()`:
+      ! Can't convert `.x[[i]]`, a number, to a function.
     Code
       (expect_error(pivot_longer(df, x, values_transform = list(~.x))))
     Output
       <error/rlang_error>
-      All elements of `values_transform` must be named.
+      Error in `check_list_of_functions()`:
+      ! All elements of `values_transform` must be named.
 

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -4,7 +4,8 @@
       (expect_error(pivot_wider(df, names_from = key, values_from = val)))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Names must be unique.
+      Error in `stop_vctrs()`:
+      ! Names must be unique.
       x These names are duplicated:
         * "a" at locations 1 and 2.
       i Use argument `names_repair` to specify repair strategy.
@@ -13,7 +14,7 @@
 
     Code
       out <- pivot_wider(df, names_from = key, values_from = val, names_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * a -> a...1
       * a -> a...2
@@ -24,7 +25,8 @@
       (expect_error(pivot_wider(df, values_from = val)))
     Output
       <error/vctrs_error_subscript_oob>
-      Can't subset columns that don't exist.
+      Error in `stop_subscript()`:
+      ! Can't subset columns that don't exist.
       x Column `name` doesn't exist.
 
 # `values_from` must be supplied if `value` isn't in `data` (#1240)
@@ -33,7 +35,8 @@
       (expect_error(pivot_wider(df, names_from = key)))
     Output
       <error/vctrs_error_subscript_oob>
-      Can't subset columns that don't exist.
+      Error in `stop_subscript()`:
+      ! Can't subset columns that don't exist.
       x Column `value` doesn't exist.
 
 # `names_from` must identify at least 1 column (#1240)
@@ -43,7 +46,8 @@
       )
     Output
       <error/rlang_error>
-      `names_from` must select at least one column.
+      Error in `build_wider_spec()`:
+      ! `names_from` must select at least one column.
 
 # `values_from` must identify at least 1 column (#1240)
 
@@ -52,7 +56,8 @@
       )
     Output
       <error/rlang_error>
-      `values_from` must select at least one column.
+      Error in `build_wider_spec()`:
+      ! `values_from` must select at least one column.
 
 # `values_fn` emits an informative error when it doesn't result in unique values (#1238)
 
@@ -60,7 +65,8 @@
       (expect_error(pivot_wider(df, values_fn = list(value = ~.x))))
     Output
       <error/rlang_error>
-      Applying `values_fn` to `value` must result in a single summary value per key.
+      Error in `value_summarize()`:
+      ! Applying `values_fn` to `value` must result in a single summary value per key.
       x Applying `values_fn` resulted in a value with length 2.
 
 # `names_vary` is validated
@@ -69,12 +75,14 @@
       (expect_error(build_wider_spec(df, names_vary = 1)))
     Output
       <error/rlang_error>
-      `names_vary` must be a character vector.
+      Error in `arg_match0()`:
+      ! `names_vary` must be a string or character vector.
     Code
       (expect_error(build_wider_spec(df, names_vary = "x")))
     Output
       <error/rlang_error>
-      `names_vary` must be one of "fastest" or "slowest".
+      Error in `build_wider_spec()`:
+      ! `names_vary` must be one of "fastest" or "slowest", not "x".
 
 # `names_expand` is validated
 
@@ -82,12 +90,14 @@
       (expect_error(build_wider_spec(df, names_expand = 1)))
     Output
       <error/rlang_error>
-      `names_expand` must be a single `TRUE` or `FALSE`.
+      Error in `build_wider_spec()`:
+      ! `names_expand` must be a single `TRUE` or `FALSE`.
     Code
       (expect_error(build_wider_spec(df, names_expand = "x")))
     Output
       <error/rlang_error>
-      `names_expand` must be a single `TRUE` or `FALSE`.
+      Error in `build_wider_spec()`:
+      ! `names_expand` must be a single `TRUE` or `FALSE`.
 
 # `id_expand` is validated
 
@@ -95,18 +105,21 @@
       (expect_error(pivot_wider(df, id_expand = 1)))
     Output
       <error/rlang_error>
-      `id_expand` must be a single `TRUE` or `FALSE`.
+      Error in `pivot_wider_spec()`:
+      ! `id_expand` must be a single `TRUE` or `FALSE`.
     Code
       (expect_error(pivot_wider(df, id_expand = "x")))
     Output
       <error/rlang_error>
-      `id_expand` must be a single `TRUE` or `FALSE`.
+      Error in `pivot_wider_spec()`:
+      ! `id_expand` must be a single `TRUE` or `FALSE`.
 
 # duplicated keys produce list column with warning
 
     Code
       pv <- pivot_wider(df, names_from = key, values_from = val)
-    Warning <warning>
+    Condition
+      Warning:
       Values from `val` are not uniquely identified; output will contain list-cols.
       * Use `values_fn = list` to suppress this warning.
       * Use `values_fn = {summary_fun}` to summarise duplicates.
@@ -120,7 +133,8 @@
 
     Code
       pivot_wider(df, names_from = key, values_from = c(a, b, c))
-    Warning <warning>
+    Condition
+      Warning:
       Values from `a`, `b` and `c` are not uniquely identified; output will contain list-cols.
       * Use `values_fn = list` to suppress this warning.
       * Use `values_fn = {summary_fun}` to summarise duplicates.
@@ -139,7 +153,8 @@
 
     Code
       pivot_wider(df, names_from = key, values_from = c(a, b, c), values_fn = list(b = sum))
-    Warning <warning>
+    Condition
+      Warning:
       Values from `a` and `c` are not uniquely identified; output will contain list-cols.
       * Use `values_fn = list` to suppress this warning.
       * Use `values_fn = {summary_fun}` to summarise duplicates.
@@ -158,7 +173,8 @@
 
     Code
       pv <- pivot_wider(df, names_from = `the-key`, values_from = val)
-    Warning <warning>
+    Condition
+      Warning:
       Values from `val` are not uniquely identified; output will contain list-cols.
       * Use `values_fn = list` to suppress this warning.
       * Use `values_fn = {summary_fun}` to summarise duplicates.
@@ -174,7 +190,8 @@
       (expect_error(pivot_wider(df, values_fn = 1)))
     Output
       <error/rlang_error>
-      Can't convert a double vector to function
+      Error in `map()`:
+      ! Can't convert `.x[[i]]`, a number, to a function.
 
 # `unused_fn` must result in single summary values
 
@@ -182,7 +199,8 @@
       (expect_error(pivot_wider(df, id_cols = id, unused_fn = identity)))
     Output
       <error/rlang_error>
-      Applying `unused_fn` to `unused` must result in a single summary value per key.
+      Error in `value_summarize()`:
+      ! Applying `unused_fn` to `unused` must result in a single summary value per key.
       x Applying `unused_fn` resulted in a value with length 2.
 
 # `unused_fn` is validated
@@ -191,5 +209,6 @@
       (expect_error(pivot_wider(df, id_cols = id, unused_fn = 1)))
     Output
       <error/rlang_error>
-      Can't convert a double vector to function
+      Error in `map()`:
+      ! Can't convert `.x[[i]]`, a number, to a function.
 

--- a/tests/testthat/_snaps/pivot.md
+++ b/tests/testthat/_snaps/pivot.md
@@ -4,12 +4,14 @@
       (expect_error(check_pivot_spec(1)))
     Output
       <error/rlang_error>
-      `spec` must be a data frame.
+      Error in `check_pivot_spec()`:
+      ! `spec` must be a data frame.
     Code
       (expect_error(check_pivot_spec(mtcars)))
     Output
       <error/rlang_error>
-      `spec` must have `.name` and `.value` columns.
+      Error in `check_pivot_spec()`:
+      ! `spec` must have `.name` and `.value` columns.
 
 # `.name` column must be a character vector
 
@@ -17,7 +19,8 @@
       (expect_error(check_pivot_spec(df)))
     Output
       <error/rlang_error>
-      The `.name` column of `spec` must be a character vector.
+      Error in `check_pivot_spec()`:
+      ! The `.name` column of `spec` must be a character vector.
 
 # `.value` column must be a character vector
 
@@ -25,7 +28,8 @@
       (expect_error(check_pivot_spec(df)))
     Output
       <error/rlang_error>
-      The `.value` column of `spec` must be a character vector.
+      Error in `check_pivot_spec()`:
+      ! The `.value` column of `spec` must be a character vector.
 
 # `.name` column must be unique
 
@@ -33,5 +37,6 @@
       (expect_error(check_pivot_spec(df)))
     Output
       <error/rlang_error>
-      The `.name` column of `spec` must be unique.
+      Error in `check_pivot_spec()`:
+      ! The `.name` column of `spec` must be unique.
 

--- a/tests/testthat/_snaps/rectangle.md
+++ b/tests/testthat/_snaps/rectangle.md
@@ -4,7 +4,8 @@
       (expect_error(hoist(df, x, "b", .ptype = list(b = double()))))
     Output
       <error/vctrs_error_incompatible_type>
-      Can't convert <list> to <double>.
+      Error in `stop_vctrs()`:
+      ! Can't convert <list> to <double>.
 
 # non-vectors generate a cast error if a ptype is supplied
 
@@ -12,7 +13,8 @@
       (expect_error(hoist(df, x, "b", .ptype = list(b = integer()))))
     Output
       <error/vctrs_error_scalar_type>
-      Input must be a vector, not a symbol.
+      Error in `stop_vctrs()`:
+      ! Input must be a vector, not a symbol.
 
 # input validation catches problems
 
@@ -20,17 +22,20 @@
       (expect_error(df %>% hoist(y)))
     Output
       <error/rlang_error>
-      `.col` must identify a list-column.
+      Error in `hoist()`:
+      ! `.col` must identify a list-column.
     Code
       (expect_error(df %>% hoist(x, 1)))
     Output
       <error/rlang_error>
-      All elements of `...` must be named.
+      Error in `check_pluckers()`:
+      ! All elements of `...` must be named.
     Code
       (expect_error(df %>% hoist(x, a = "a", a = "b")))
     Output
       <error/rlang_error>
-      The names of `...` must be unique.
+      Error in `check_pluckers()`:
+      ! The names of `...` must be unique.
 
 # can't hoist() from a data frame column
 
@@ -38,7 +43,8 @@
       (expect_error(hoist(df, a, xx = 1)))
     Output
       <error/rlang_error>
-      `.col` must identify a list-column.
+      Error in `hoist()`:
+      ! `.col` must identify a list-column.
 
 # hoist() input must be a data frame (#1224)
 
@@ -46,7 +52,8 @@
       (expect_error(hoist(1)))
     Output
       <error/rlang_error>
-      `.data` must be a data frame.
+      Error in `hoist()`:
+      ! `.data` must be a data frame.
 
 # unnest_wider - bad inputs generate errors
 
@@ -54,13 +61,14 @@
       (expect_error(unnest_wider(df, y)))
     Output
       <error/rlang_error>
-      Column `y` must contain a list of vectors.
+      Error in `.f()`:
+      ! Column `y` must contain a list of vectors.
 
 # can unnest a vector with a mix of named/unnamed elements (#1200 comment)
 
     Code
       out <- unnest_wider(df, x, names_sep = "_")
-    Message <simpleMessage>
+    Message
       New names:
       * `` -> ...1
 
@@ -68,7 +76,7 @@
 
     Code
       out <- unnest_wider(df, col, names_sep = "_")
-    Message <simpleMessage>
+    Message
       New names:
       * `` -> ...1
 
@@ -76,7 +84,7 @@
 
     Code
       out <- unnest_wider(df, col, names_sep = "_")
-    Message <simpleMessage>
+    Message
       New names:
       * `` -> ...1
       * `` -> ...2
@@ -85,7 +93,7 @@
 
     Code
       out1 <- unnest_wider(df, col)
-    Message <simpleMessage>
+    Message
       New names:
       * `` -> ...1
       New names:
@@ -95,7 +103,7 @@
 
     Code
       out2 <- unnest_wider(df, col, names_sep = "_")
-    Message <simpleMessage>
+    Message
       New names:
       * NA -> ...1
       New names:
@@ -107,7 +115,8 @@
       (expect_error(unnest_wider(df, col)))
     Output
       <error/vctrs_error_incompatible_type>
-      Can't combine `..1$a` <list> and `..3$a` <list_of<integer>>.
+      Error in `stop_vctrs()`:
+      ! Can't combine `..1$a` <list> and `..3$a` <list_of<integer>>.
 
 # unnest_wider() input must be a data frame (#1224)
 
@@ -115,7 +124,8 @@
       (expect_error(unnest_wider(1)))
     Output
       <error/rlang_error>
-      `data` must be a data frame.
+      Error in `unnest_wider()`:
+      ! `data` must be a data frame.
 
 # unnest_longer - bad inputs generate errors
 
@@ -123,7 +133,8 @@
       (expect_error(unnest_longer(df, y)))
     Output
       <error/rlang_error>
-      Column `y` must contain a list of vectors.
+      Error in `elt_to_long()`:
+      ! Column `y` must contain a list of vectors.
 
 # can't mix `indices_to` with `indices_include = FALSE`
 
@@ -132,7 +143,8 @@
       )
     Output
       <error/rlang_error>
-      Can't set `indices_include` to `FALSE` when `indices_to` is supplied.
+      Error in `unnest_longer()`:
+      ! Can't set `indices_include` to `FALSE` when `indices_to` is supplied.
 
 # unnest_longer() input must be a data frame (#1224)
 
@@ -140,7 +152,8 @@
       (expect_error(unnest_longer(1)))
     Output
       <error/rlang_error>
-      `data` must be a data frame.
+      Error in `unnest_longer()`:
+      ! `data` must be a data frame.
 
 # `values_to` is validated
 
@@ -148,12 +161,14 @@
       (expect_error(unnest_longer(mtcars, mpg, values_to = 1)))
     Output
       <error/rlang_error>
-      `values_to` must be a single string or `NULL`.
+      Error in `unnest_longer()`:
+      ! `values_to` must be a single string or `NULL`.
     Code
       (expect_error(unnest_longer(mtcars, mpg, values_to = c("x", "y"))))
     Output
       <error/rlang_error>
-      `values_to` must be a single string or `NULL`.
+      Error in `unnest_longer()`:
+      ! `values_to` must be a single string or `NULL`.
 
 # `indices_to` is validated
 
@@ -161,12 +176,14 @@
       (expect_error(unnest_longer(mtcars, mpg, indices_to = 1)))
     Output
       <error/rlang_error>
-      `indices_to` must be a single string or `NULL`.
+      Error in `unnest_longer()`:
+      ! `indices_to` must be a single string or `NULL`.
     Code
       (expect_error(unnest_longer(mtcars, mpg, indices_to = c("x", "y"))))
     Output
       <error/rlang_error>
-      `indices_to` must be a single string or `NULL`.
+      Error in `unnest_longer()`:
+      ! `indices_to` must be a single string or `NULL`.
 
 # `indices_include` is validated
 
@@ -174,12 +191,14 @@
       (expect_error(unnest_longer(mtcars, mpg, indices_include = 1)))
     Output
       <error/rlang_error>
-      `indices_include` must be `NULL` or a single `TRUE` or `FALSE`.
+      Error in `unnest_longer()`:
+      ! `indices_include` must be `NULL` or a single `TRUE` or `FALSE`.
     Code
       (expect_error(unnest_longer(mtcars, mpg, indices_include = c(TRUE, FALSE))))
     Output
       <error/rlang_error>
-      `indices_include` must be `NULL` or a single `TRUE` or `FALSE`.
+      Error in `unnest_longer()`:
+      ! `indices_include` must be `NULL` or a single `TRUE` or `FALSE`.
 
 # `simplify` is validated
 
@@ -187,27 +206,32 @@
       (expect_error(df_simplify(data.frame(), simplify = 1)))
     Output
       <error/rlang_error>
-      `simplify` must be a list or a single `TRUE` or `FALSE`.
+      Error in `df_simplify()`:
+      ! `simplify` must be a list or a single `TRUE` or `FALSE`.
     Code
       (expect_error(df_simplify(data.frame(), simplify = NA)))
     Output
       <error/rlang_error>
-      `simplify` must be a list or a single `TRUE` or `FALSE`.
+      Error in `df_simplify()`:
+      ! `simplify` must be a list or a single `TRUE` or `FALSE`.
     Code
       (expect_error(df_simplify(data.frame(), simplify = c(TRUE, FALSE))))
     Output
       <error/rlang_error>
-      `simplify` must be a list or a single `TRUE` or `FALSE`.
+      Error in `df_simplify()`:
+      ! `simplify` must be a list or a single `TRUE` or `FALSE`.
     Code
       (expect_error(df_simplify(data.frame(), simplify = list(1))))
     Output
       <error/rlang_error>
-      All elements of `simplify` must be named.
+      Error in `df_simplify()`:
+      ! All elements of `simplify` must be named.
     Code
       (expect_error(df_simplify(data.frame(), simplify = list(x = 1, x = 1))))
     Output
       <error/rlang_error>
-      The names of `simplify` must be unique.
+      Error in `df_simplify()`:
+      ! The names of `simplify` must be unique.
 
 # `ptype` is validated
 
@@ -215,17 +239,20 @@
       (expect_error(df_simplify(data.frame(), ptype = 1)))
     Output
       <error/rlang_error>
-      `ptype` must be `NULL`, an empty ptype, or a named list of ptypes.
+      Error in `check_list_of_ptypes()`:
+      ! `ptype` must be `NULL`, an empty ptype, or a named list of ptypes.
     Code
       (expect_error(df_simplify(data.frame(), ptype = list(1))))
     Output
       <error/rlang_error>
-      All elements of `ptype` must be named.
+      Error in `check_list_of_ptypes()`:
+      ! All elements of `ptype` must be named.
     Code
       (expect_error(df_simplify(data.frame(), ptype = list(x = 1, x = 1))))
     Output
       <error/rlang_error>
-      The names of `ptype` must be unique.
+      Error in `check_list_of_ptypes()`:
+      ! The names of `ptype` must be unique.
 
 # `transform` is validated
 
@@ -233,30 +260,35 @@
       (expect_error(df_simplify(data.frame(), transform = list(~.x))))
     Output
       <error/rlang_error>
-      All elements of `transform` must be named.
+      Error in `check_list_of_functions()`:
+      ! All elements of `transform` must be named.
     Code
       (expect_error(df_simplify(data.frame(x = 1), transform = 1)))
     Output
       <error/rlang_error>
-      Can't convert a double vector to function
+      Error in `map()`:
+      ! Can't convert `.x[[i]]`, a number, to a function.
     Code
       (expect_error(df_simplify(data.frame(), transform = list(x = 1))))
     Output
       <error/rlang_error>
-      Can't convert a double vector to function
+      Error in `map()`:
+      ! Can't convert `.x[[i]]`, a number, to a function.
     Code
       (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))
     Output
       <error/rlang_error>
-      The names of `transform` must be unique.
+      Error in `check_list_of_functions()`:
+      ! The names of `transform` must be unique.
 
 # ptype is applied after transform
 
     Code
-      (expect_error(col_simplify(list(1, 2, 3), ptype = integer(), transform = ~.x +
+      (expect_error(col_simplify(list(1, 2, 3), ptype = integer(), transform = ~ .x +
         1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Can't convert from <double> to <integer> due to loss of precision.
+      Error in `stop_vctrs()`:
+      ! Can't convert from <double> to <integer> due to loss of precision.
       * Locations: 1
 

--- a/tests/testthat/_snaps/replace_na.md
+++ b/tests/testthat/_snaps/replace_na.md
@@ -4,7 +4,8 @@
       (expect_error(replace_na(1, 1:10)))
     Output
       <error/rlang_error>
-      Replacement for `data` is length 10, not length 1.
+      Error in `check_replacement()`:
+      ! Replacement for `data` is length 10, not length 1.
 
 # replacement must be castable to `data`
 
@@ -12,7 +13,8 @@
       (expect_error(replace_na(x, 1.5)))
     Output
       <error/vctrs_error_cast_lossy>
-      Can't convert from `replace` <double> to `data` <integer> due to loss of precision.
+      Error in `stop_vctrs()`:
+      ! Can't convert from `replace` <double> to `data` <integer> due to loss of precision.
       * Locations: 1
 
 # replacement must be castable to corresponding column
@@ -21,6 +23,7 @@
       (expect_error(replace_na(df, list(a = 1.5))))
     Output
       <error/vctrs_error_cast_lossy>
-      Can't convert from `replace$a` <double> to `data$a` <integer> due to loss of precision.
+      Error in `stop_vctrs()`:
+      ! Can't convert from `replace$a` <double> to `data$a` <integer> due to loss of precision.
       * Locations: 1
 

--- a/tests/testthat/_snaps/separate.md
+++ b/tests/testthat/_snaps/separate.md
@@ -2,7 +2,8 @@
 
     Code
       separate(df, x, c("x", "y"))
-    Warning <warning>
+    Condition
+      Warning:
       Expected 2 pieces. Additional pieces discarded in 1 rows [2].
     Output
       # A tibble: 2 x 2
@@ -15,8 +16,10 @@
 
     Code
       separate(df, x, c("x", "y"), extra = "error")
-    Warning <warning>
+    Condition
+      Warning:
       `extra = "error"` is deprecated. Please use `extra = "warn"` instead
+      Warning:
       Expected 2 pieces. Additional pieces discarded in 1 rows [2].
     Output
       # A tibble: 2 x 2
@@ -29,7 +32,8 @@
 
     Code
       separate(df, x, c("x", "y", "z"))
-    Warning <warning>
+    Condition
+      Warning:
       Expected 3 pieces. Missing pieces filled with `NA` in 1 rows [1].
     Output
       # A tibble: 2 x 3
@@ -44,12 +48,14 @@
       (expect_error(separate(df, x, "x", FALSE)))
     Output
       <error/rlang_error>
-      `sep` must be either numeric or character
+      Error in `str_separate()`:
+      ! `sep` must be either numeric or character
     Code
       (expect_error(separate(df, x, FALSE)))
     Output
       <error/rlang_error>
-      `into` must be a character vector
+      Error in `str_separate()`:
+      ! `into` must be a character vector
 
 # informative error if using stringr modifier functions (#693)
 
@@ -57,5 +63,6 @@
       (expect_error(separate(df, x, sep = sep)))
     Output
       <error/rlang_error>
-      `sep` can't use modifiers from stringr.
+      Error in `check_not_stringr_pattern()`:
+      ! `sep` can't use modifiers from stringr.
 

--- a/tests/testthat/_snaps/spread.md
+++ b/tests/testthat/_snaps/spread.md
@@ -4,7 +4,8 @@
       (expect_error(spread(df, x, y)))
     Output
       <error/rlang_error>
-      Each row of output must be identified by a unique combination of keys.
+      Error in `spread()`:
+      ! Each row of output must be identified by a unique combination of keys.
       Keys are shared for 2 rows:
       * 2, 3
 

--- a/tests/testthat/_snaps/uncount.md
+++ b/tests/testthat/_snaps/uncount.md
@@ -4,5 +4,6 @@
       (expect_error(uncount(df, w)))
     Output
       <error/rlang_error>
-      all elements of `weights` must be >= 0
+      Error in `uncount()`:
+      ! all elements of `weights` must be >= 0
 


### PR DESCRIPTION
- Require rlang >= 1.0.0
- Update documentation with new rlang aliases
- Update snapshot tests with new rlang error style (not passing through error calls yet)