### PR TITLE
Improve `id_cols` OOB error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     lifecycle,
     magrittr,
     purrr,
-    rlang (>= 1.0.0),
+    rlang (>= 1.0.1),
     tibble (>= 2.1.1),
     tidyselect (>= 1.1.0),
     utils,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # tidyr (development version)
 
-* Improved the error message returned when a column selected by `names_from` or
-  `values_from` is also selected by `id_cols` (#1318).
+* Improved the error message returned by `pivot_wider()` when a column selected
+  by `names_from` or `values_from` is also selected by `id_cols` (#1318).
 
 # tidyr 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* Improved the error message returned when a column selected by `names_from` or
+  `values_from` is also selected by `id_cols` (#1318).
+
 # tidyr 1.2.0
 
 ## Pivoting

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -574,7 +574,8 @@ rethrow_id_cols_oob <- function(cnd, non_id_cols) {
   if (i %in% non_id_cols) {
     stop_id_cols_oob(i)
   } else {
-    cnd_signal(cnd)
+    # Zap this special handler, throw the normal condition
+    zap()
   }
 }
 

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -582,7 +582,7 @@ rethrow_id_cols_oob <- function(cnd, non_id_cols) {
 stop_id_cols_oob <- function(i) {
   message <- c(
     "`id_cols` can't select a column already selected by `names_from` or `values_from`.",
-    x = glue("Column `{i}` has already been selected.")
+    i = glue("Column `{i}` has already been selected.")
   )
   abort(message, parent = NA)
 }

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -17,10 +17,14 @@
 #'   defines a pivotting specification.
 #' @inheritParams pivot_longer
 #' @param id_cols <[`tidy-select`][tidyr_tidy_select]> A set of columns that
-#'   uniquely identifies each observation. Defaults to all columns in `data`
-#'   except for the columns specified in `names_from` and `values_from`.
-#'   Typically used when you have redundant variables, i.e. variables whose
-#'   values are perfectly correlated with existing variables.
+#'   uniquely identify each observation. Typically used when you have
+#'   redundant variables, i.e. variables whose values are perfectly correlated
+#'   with existing variables.
+#'
+#'   Defaults to all columns in `data` except for the columns specified through
+#'   `names_from` and `values_from`. If a tidyselect expression is supplied, it
+#'   will be evaluated on `data` after removing the columns specified through
+#'   `names_from` and `values_from`.
 #' @param id_expand Should the values in the `id_cols` columns be expanded by
 #'   [expand()] before pivoting? This results in more rows, the output will
 #'   contain a complete expansion of all possible values in `id_cols`. Implicit

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -27,10 +27,14 @@ pivot_wider(
 \item{data}{A data frame to pivot.}
 
 \item{id_cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A set of columns that
-uniquely identifies each observation. Defaults to all columns in \code{data}
-except for the columns specified in \code{names_from} and \code{values_from}.
-Typically used when you have redundant variables, i.e. variables whose
-values are perfectly correlated with existing variables.}
+uniquely identify each observation. Typically used when you have
+redundant variables, i.e. variables whose values are perfectly correlated
+with existing variables.
+
+Defaults to all columns in \code{data} except for the columns specified through
+\code{names_from} and \code{values_from}. If a tidyselect expression is supplied, it
+will be evaluated on \code{data} after removing the columns specified through
+\code{names_from} and \code{values_from}.}
 
 \item{id_expand}{Should the values in the \code{id_cols} columns be expanded by
 \code{\link[=expand]{expand()}} before pivoting? This results in more rows, the output will

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -99,6 +99,35 @@
       Error in `build_wider_spec()`:
       ! `names_expand` must be a single `TRUE` or `FALSE`.
 
+# `id_cols` can't select columns from `names_from` or `values_from` (#1318)
+
+    Code
+      (expect_error(pivot_wider(df, id_cols = name, names_from = name, values_from = value))
+      )
+    Output
+      <error/rlang_error>
+      Error in `select_wider_id_cols()`:
+      ! `id_cols` can't select a column already selected by `names_from` or `values_from`.
+      x Column `name` has already been selected.
+    Code
+      (expect_error(pivot_wider(df, id_cols = value, names_from = name, values_from = value))
+      )
+    Output
+      <error/rlang_error>
+      Error in `select_wider_id_cols()`:
+      ! `id_cols` can't select a column already selected by `names_from` or `values_from`.
+      x Column `value` has already been selected.
+
+# `id_cols` returns a tidyselect error if a column selection is OOB (#1318)
+
+    Code
+      (expect_error(pivot_wider(df, id_cols = foo)))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `stop_subscript()`:
+      ! Can't subset columns that don't exist.
+      x Column `foo` doesn't exist.
+
 # `id_expand` is validated
 
     Code

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -108,7 +108,7 @@
       <error/rlang_error>
       Error in `select_wider_id_cols()`:
       ! `id_cols` can't select a column already selected by `names_from` or `values_from`.
-      x Column `name` has already been selected.
+      i Column `name` has already been selected.
     Code
       (expect_error(pivot_wider(df, id_cols = value, names_from = name, values_from = value))
       )
@@ -116,7 +116,7 @@
       <error/rlang_error>
       Error in `select_wider_id_cols()`:
       ! `id_cols` can't select a column already selected by `names_from` or `values_from`.
-      x Column `value` has already been selected.
+      i Column `value` has already been selected.
 
 # `id_cols` returns a tidyselect error if a column selection is OOB (#1318)
 

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -107,7 +107,7 @@
     Output
       <error/rlang_error>
       Error in `select_wider_id_cols()`:
-      ! `id_cols` can't select a column already selected by `names_from` or `values_from`.
+      ! `id_cols` can't select a column already selected by `names_from`.
       i Column `name` has already been selected.
     Code
       (expect_error(pivot_wider(df, id_cols = value, names_from = name, values_from = value))
@@ -115,7 +115,7 @@
     Output
       <error/rlang_error>
       Error in `select_wider_id_cols()`:
-      ! `id_cols` can't select a column already selected by `names_from` or `values_from`.
+      ! `id_cols` can't select a column already selected by `values_from`.
       i Column `value` has already been selected.
 
 # `id_cols` returns a tidyselect error if a column selection is OOB (#1318)

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -321,6 +321,24 @@ test_that("`id_cols = everything()` excludes `names_from` and `values_from`", {
   )
 })
 
+test_that("`id_cols` can't select columns from `names_from` or `values_from` (#1318)", {
+  df <- tibble(name = c("x", "y"), value = c(1, 2))
+
+  # And gives a nice error message!
+  expect_snapshot({
+    (expect_error(pivot_wider(df, id_cols = name, names_from = name, values_from = value)))
+    (expect_error(pivot_wider(df, id_cols = value, names_from = name, values_from = value)))
+  })
+})
+
+test_that("`id_cols` returns a tidyselect error if a column selection is OOB (#1318)", {
+  df <- tibble(name = c("x", "y"), value = c(1, 2))
+
+  expect_snapshot(
+    (expect_error(pivot_wider(df, id_cols = foo)))
+  )
+})
+
 test_that("pivoting a zero row data frame drops `names_from` and `values_from` (#1249)", {
   df <- tibble(key = character(), name = character(), value = integer())
 


### PR DESCRIPTION
Closes #1318 

This PR improves on the `id_cols` error message that occurs when a column selected by `id_cols` was also selected by `names_from` or `values_from` (which meant that it was already removed at this point, resulting in the OOB error).

``` r
library(tidyr)

df <- tibble(name = c("x", "y"), value = c(1, 2))

# `name` and `value` already removed from `df`, so evaluating the `id_cols = name` tidyselect gives this error:
pivot_wider(df, id_cols = name, names_from = name, values_from = value)

# before
#> Error in `stop_subscript()`:
#> ! Can't subset columns that don't exist.
#> x Column `name` doesn't exist.

# after
#> Error in `select_wider_id_cols()`:
#> ! `id_cols` can't select a column already selected by `names_from` or `values_from`.
#> x Column `name` has already been selected.
```

@lionel- does this usage of `try_fetch()` look right to you? In particular, I have used both `abort(parent = NA)` and `cnd_signal()` here, and I am not 100% confident of either one.