### PR TITLE
NEWS: mention breaking change related to #1332

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,13 @@
   grouped data frame happens "within" each group and otherwise has the
   potential to produce erroneous results (#1299).
 
+* `replace_na()` no longer allows the type of `data` to change when the
+  replacement is applied. `replace` will now always be cast to the type of
+  `data` before the replacement is made. For example, this means that using a
+  replacement value of `1.5` on an integer column is no longer allowed.
+  Similarly, replacing missing values in a list-column must now be done with
+  `list("foo")` rather than just `"foo"`.
+
 ## Pivoting
 
 * `pivot_wider()` gains new `names_expand` and `id_expand` arguments for turning
@@ -95,13 +102,6 @@
   This means that you can use these functions on a wider variety of column
   types, including lubridate's Period types (#1094), data frame columns, and
   the [rcrd](https://vctrs.r-lib.org/reference/new_rcrd.html) type from vctrs.
-
-* `replace_na()` no longer allows the type of `data` to change when the
-  replacement is applied. `replace` will now always be cast to the type of
-  `data` before the replacement is made. For example, this means that using a
-  replacement value of `1.5` on an integer column is no longer allowed.
-  Similarly, replacing missing values in a list-column must now be done with
-  `list("foo")` rather than just `"foo"`.
 
 * `replace_na()` no longer replaces empty atomic elements in list-columns
   (like `integer(0)`). The only value that is replaced in a list-column is

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,13 @@
 
 # tidyr 1.2.0
 
+## Breaking changes
+
+* `complete()` and `expand()` no longer allow you to complete or expand on a
+  grouping column. This was never well-defined since completion/expansion on a
+  grouped data frame happens "within" each group and otherwise has the
+  potential to produce erroneous results (#1299).
+
 ## Pivoting
 
 * `pivot_wider()` gains new `names_expand` and `id_expand` arguments for turning
@@ -81,11 +88,6 @@
 
 * `complete()` gains a grouped data frame method. This generates a more correct
   completed data frame when groups are involved (#396, #966).
-  
-* `complete()` and `expand()` no longer allow you to complete or expand on a
-  grouping column. This was never well-defined since completion/expansion on a
-  grouped data frame happens "within" each group and otherwise has the
-  potential to produce erroneous results (#1299).
 
 ## Missing values
 


### PR DESCRIPTION
#1332 
I understand you won't realistically bump the version after-the-fact, but I think it's a good idea to modify the NEWS file. Previously [there was no mention of the inability to complete on a grouping](https://github.com/tidyverse/tidyr/blob/49753836537547511e331b1d55a44b3471b8f422/R/complete.R) so it's very possible others have done it and usually when code breaks you search for breaking changes to try to debug.