### PR TITLE
Adjust dots in pivoting functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,16 @@
   `pivot_wider_spec()`, `build_longer_spec()`, and `build_wider_spec()` have
   all gained `...` arguments in a similar location. This change allows us to
   more easily add new features to the pivoting functions without breaking
-  existing CRAN packages and user scripts. To read more about this pattern,
-  see [Data, dots, details](https://design.tidyverse.org/dots-position.html) in
-  the tidyverse design guide (#1350).
+  existing CRAN packages and user scripts.
+  
+  `pivot_wider()` provides temporary backwards compatible support for the case
+  of a single unnamed argument that previously was being positionally matched to
+  `id_cols`. This one special case still works, but will throw a warning
+  encouraging you to explicitly name the `id_cols` argument.
+  
+  To read more about this pattern, see
+  [Data, dots, details](https://design.tidyverse.org/dots-position.html) in the
+  tidyverse design guide (#1350).
 
 * New family of consistent string separating functions:
   `separate_wider_delim()`, `separate_wider_position()`, `separate_wider_regex()`, 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # tidyr (development version)
 
+* The `...` argument of both `pivot_longer()` and `pivot_wider()` has been
+  moved to the front of the function signature, after the required arguments
+  but before the optional ones. Additionally, `pivot_longer_spec()`,
+  `pivot_wider_spec()`, `build_longer_spec()`, and `build_wider_spec()` have
+  all gained `...` arguments in a similar location. This change allows us to
+  more easily add new features to the pivoting functions without breaking
+  existing CRAN packages and user scripts. To read more about this pattern,
+  see [Data, dots, details](https://design.tidyverse.org/dots-position.html) in
+  the tidyverse design guide (#1350).
+
 * New family of consistent string separating functions:
   `separate_wider_delim()`, `separate_wider_position()`, `separate_wider_regex()`, 
   `separate_longer_delim()`, and `separate_longer_position()`. These functions

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -140,6 +140,7 @@
 #'   )
 pivot_longer <- function(data,
                          cols,
+                         ...,
                          cols_vary = "fastest",
                          names_to = "name",
                          names_prefix = NULL,
@@ -151,8 +152,7 @@ pivot_longer <- function(data,
                          values_to = "value",
                          values_drop_na = FALSE,
                          values_ptypes = NULL,
-                         values_transform = NULL,
-                         ...) {
+                         values_transform = NULL) {
   check_dots_used()
   UseMethod("pivot_longer")
 }
@@ -160,6 +160,7 @@ pivot_longer <- function(data,
 #' @export
 pivot_longer.data.frame <- function(data,
                                     cols,
+                                    ...,
                                     cols_vary = "fastest",
                                     names_to = "name",
                                     names_prefix = NULL,
@@ -171,8 +172,7 @@ pivot_longer.data.frame <- function(data,
                                     values_to = "value",
                                     values_drop_na = FALSE,
                                     values_ptypes = NULL,
-                                    values_transform = NULL,
-                                    ...) {
+                                    values_transform = NULL) {
   spec <- build_longer_spec(
     data = data,
     cols = {{ cols }},
@@ -204,6 +204,7 @@ pivot_longer.data.frame <- function(data,
 #'
 #' @keywords internal
 #' @export
+#' @inheritParams rlang::args_dots_empty
 #' @inheritParams pivot_longer
 #' @param spec A specification data frame. This is useful for more complex
 #'  pivots because it gives you greater control on how metadata stored in the
@@ -238,11 +239,14 @@ pivot_longer.data.frame <- function(data,
 #' )
 pivot_longer_spec <- function(data,
                               spec,
+                              ...,
                               cols_vary = "fastest",
                               names_repair = "check_unique",
                               values_drop_na = FALSE,
                               values_ptypes = NULL,
                               values_transform = NULL) {
+  check_dots_empty0(...)
+
   spec <- check_pivot_spec(spec)
   spec <- deduplicate_spec(spec, data)
 
@@ -337,6 +341,7 @@ pivot_longer_spec <- function(data,
 #' @export
 build_longer_spec <- function(data,
                               cols,
+                              ...,
                               names_to = "name",
                               values_to = "value",
                               names_prefix = NULL,
@@ -344,7 +349,7 @@ build_longer_spec <- function(data,
                               names_pattern = NULL,
                               names_ptypes = NULL,
                               names_transform = NULL) {
-
+  check_dots_empty0(...)
   check_data_frame(data)
   check_required(cols)
   check_character(names_to, allow_null = TRUE)

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -156,6 +156,7 @@
 #'     values_fn = ~ mean(.x, na.rm = TRUE)
 #'   )
 pivot_wider <- function(data,
+                        ...,
                         id_cols = NULL,
                         id_expand = FALSE,
                         names_from = name,
@@ -169,14 +170,14 @@ pivot_wider <- function(data,
                         values_from = value,
                         values_fill = NULL,
                         values_fn = NULL,
-                        unused_fn = NULL,
-                        ...) {
+                        unused_fn = NULL) {
   check_dots_used()
   UseMethod("pivot_wider")
 }
 
 #' @export
 pivot_wider.data.frame <- function(data,
+                                   ...,
                                    id_cols = NULL,
                                    id_expand = FALSE,
                                    names_from = name,
@@ -190,8 +191,7 @@ pivot_wider.data.frame <- function(data,
                                    values_from = value,
                                    values_fill = NULL,
                                    values_fn = NULL,
-                                   unused_fn = NULL,
-                                   ...) {
+                                   unused_fn = NULL) {
   names_from <- enquo(names_from)
   values_from <- enquo(values_from)
 
@@ -233,6 +233,7 @@ pivot_wider.data.frame <- function(data,
 #'
 #' @keywords internal
 #' @export
+#' @inheritParams rlang::args_dots_empty
 #' @inheritParams pivot_wider
 #' @param spec A specification data frame. This is useful for more complex
 #'  pivots because it gives you greater control on how metadata stored in the
@@ -279,12 +280,14 @@ pivot_wider.data.frame <- function(data,
 #'   pivot_wider_spec(spec2)
 pivot_wider_spec <- function(data,
                              spec,
+                             ...,
                              names_repair = "check_unique",
                              id_cols = NULL,
                              id_expand = FALSE,
                              values_fill = NULL,
                              values_fn = NULL,
                              unused_fn = NULL) {
+  check_dots_empty0(...)
 
   spec <- check_pivot_spec(spec)
   check_bool(id_expand)
@@ -450,6 +453,7 @@ pivot_wider_spec <- function(data,
 #' @rdname pivot_wider_spec
 #' @inheritParams pivot_wider
 build_wider_spec <- function(data,
+                             ...,
                              names_from = name,
                              values_from = value,
                              names_prefix = "",
@@ -458,6 +462,8 @@ build_wider_spec <- function(data,
                              names_sort = FALSE,
                              names_vary = "fastest",
                              names_expand = FALSE) {
+  check_dots_empty0(...)
+
   names_from <- tidyselect::eval_select(
     enquo(names_from),
     data,

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -654,7 +654,7 @@ warn_deprecated_unnamed_id_cols <- function(id_cols, user_env = caller_env(2)) {
   id_cols <- as_label(id_cols)
 
   lifecycle::deprecate_warn(
-    when = "1.2.2",
+    when = "1.3.0",
     what = I(cli::format_inline(
       "Specifying the {.arg id_cols} argument by position"
     )),

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -7,6 +7,7 @@
 pivot_longer(
   data,
   cols,
+  ...,
   cols_vary = "fastest",
   names_to = "name",
   names_prefix = NULL,
@@ -18,8 +19,7 @@ pivot_longer(
   values_to = "value",
   values_drop_na = FALSE,
   values_ptypes = NULL,
-  values_transform = NULL,
-  ...
+  values_transform = NULL
 )
 }
 \arguments{
@@ -27,6 +27,8 @@ pivot_longer(
 
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pivot into
 longer format.}
+
+\item{...}{Additional arguments passed on to methods.}
 
 \item{cols_vary}{When pivoting \code{cols} into longer format, how should the
 output rows be arranged relative to their original row number?
@@ -115,8 +117,6 @@ existing column names.}
 in the \code{value_to} column. This effectively converts explicit missing values
 to implicit missing values, and should generally be used only when missing
 values in \code{data} were created by its structure.}
-
-\item{...}{Additional arguments passed on to methods.}
 }
 \description{
 \code{pivot_longer()} "lengthens" data, increasing the number of rows and

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -8,6 +8,7 @@
 pivot_longer_spec(
   data,
   spec,
+  ...,
   cols_vary = "fastest",
   names_repair = "check_unique",
   values_drop_na = FALSE,
@@ -18,6 +19,7 @@ pivot_longer_spec(
 build_longer_spec(
   data,
   cols,
+  ...,
   names_to = "name",
   values_to = "value",
   names_prefix = NULL,
@@ -40,6 +42,8 @@ long format of the dataset and contain values corresponding to columns
 pivoted from the wide format.
 The special \code{.seq} variable is used to disambiguate rows internally;
 it is automatically removed after pivotting.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{cols_vary}{When pivoting \code{cols} into longer format, how should the
 output rows be arranged relative to their original row number?

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -6,6 +6,7 @@
 \usage{
 pivot_wider(
   data,
+  ...,
   id_cols = NULL,
   id_expand = FALSE,
   names_from = name,
@@ -19,12 +20,13 @@ pivot_wider(
   values_from = value,
   values_fill = NULL,
   values_fn = NULL,
-  unused_fn = NULL,
-  ...
+  unused_fn = NULL
 )
 }
 \arguments{
 \item{data}{A data frame to pivot.}
+
+\item{...}{Additional arguments passed on to methods.}
 
 \item{id_cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A set of columns that
 uniquely identify each observation. Typically used when you have
@@ -117,8 +119,6 @@ all unspecified columns will be considered \code{id_cols}.
 
 This is similar to grouping by the \code{id_cols} then summarizing the
 unused columns using \code{unused_fn}.}
-
-\item{...}{Additional arguments passed on to methods.}
 }
 \description{
 \code{pivot_wider()} "widens" data, increasing the number of columns and

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -8,6 +8,7 @@
 pivot_wider_spec(
   data,
   spec,
+  ...,
   names_repair = "check_unique",
   id_cols = NULL,
   id_expand = FALSE,
@@ -18,6 +19,7 @@ pivot_wider_spec(
 
 build_wider_spec(
   data,
+  ...,
   names_from = name,
   values_from = value,
   names_prefix = "",
@@ -41,6 +43,8 @@ long format of the dataset and contain values corresponding to columns
 pivoted from the wide format.
 The special \code{.seq} variable is used to disambiguate rows internally;
 it is automatically removed after pivotting.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{names_repair}{What happens if the output has invalid column names?
 The default, \code{"check_unique"} is to error if the columns are duplicated.

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -20,14 +20,19 @@
 |NA             |?       |      |        |     |
 |vivid          |?       |      |        |     |
 
-## New problems (6)
+## New problems (11)
 
-|package                              |version |error  |warning |note |
-|:------------------------------------|:-------|:------|:-------|:----|
-|[batchtma](problems.md#batchtma)     |0.1.6   |__+1__ |__+1__  |     |
-|[dartR](problems.md#dartr)           |2.0.3   |__+1__ |1       |1    |
-|[faux](problems.md#faux)             |1.1.0   |       |__+1__  |     |
-|[simpr](problems.md#simpr)           |0.2.2   |       |__+1__  |     |
-|[sparklyr](problems.md#sparklyr)     |1.7.5   |       |__+1__  |2    |
-|[tidyseurat](problems.md#tidyseurat) |0.5.1   |       |__+1__  |     |
+|package                        |version |error  |warning |note |
+|:------------------------------|:-------|:------|:-------|:----|
+|[broom](problems.md#broom)     |0.8.0   |__+1__ |        |1    |
+|[dartR](problems.md#dartr)     |2.0.3   |__+1__ |1       |1    |
+|[egor](problems.md#egor)       |1.22.1  |__+2__ |__+1__  |     |
+|[faux](problems.md#faux)       |1.1.0   |       |__+1__  |     |
+|[ftExtra](problems.md#ftextra) |0.3.0   |__+2__ |__+1__  |     |
+|[hacksig](problems.md#hacksig) |0.1.2   |__+1__ |__+1__  |     |
+|[psfmi](problems.md#psfmi)     |1.0.0   |       |__+1__  |1    |
+|[rmdcev](problems.md#rmdcev)   |1.2.4   |__+1__ |        |3    |
+|[simITS](problems.md#simits)   |0.1.1   |__+2__ |        |     |
+|[surveil](problems.md#surveil) |0.2.0   |__+1__ |__+1__  |3    |
+|[tsibble](problems.md#tsibble) |1.1.1   |__+1__ |        |     |
 

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,6 +1,6 @@
 # Revdeps
 
-## Failed to check (15)
+## Failed to check (26)
 
 |package        |version |error |warning |note |
 |:--------------|:-------|:-----|:-------|:----|
@@ -14,25 +14,33 @@
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|FAMetA         |0.1.4   |1     |        |     |
+|NA             |?       |      |        |     |
+|ggPMX          |?       |      |        |     |
 |loon.ggplot    |?       |      |        |     |
+|NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
 |MarketMatching |?       |      |        |     |
 |NA             |?       |      |        |     |
+|OlinkAnalyze   |?       |      |        |     |
+|Platypus       |?       |      |        |     |
+|RVA            |?       |      |        |     |
+|NA             |?       |      |        |     |
+|tinyarray      |?       |      |        |     |
 |vivid          |?       |      |        |     |
+|xpose.nlmixr2  |?       |      |        |     |
 
-## New problems (11)
+## New problems (8)
 
-|package                        |version |error  |warning |note |
-|:------------------------------|:-------|:------|:-------|:----|
-|[broom](problems.md#broom)     |0.8.0   |__+1__ |        |1    |
-|[dartR](problems.md#dartr)     |2.0.3   |__+1__ |1       |1    |
-|[egor](problems.md#egor)       |1.22.1  |__+2__ |__+1__  |     |
-|[faux](problems.md#faux)       |1.1.0   |       |__+1__  |     |
-|[ftExtra](problems.md#ftextra) |0.3.0   |__+2__ |__+1__  |     |
-|[hacksig](problems.md#hacksig) |0.1.2   |__+1__ |__+1__  |     |
-|[psfmi](problems.md#psfmi)     |1.0.0   |       |__+1__  |1    |
-|[rmdcev](problems.md#rmdcev)   |1.2.4   |__+1__ |        |3    |
-|[simITS](problems.md#simits)   |0.1.1   |__+2__ |        |     |
-|[surveil](problems.md#surveil) |0.2.0   |__+1__ |__+1__  |3    |
-|[tsibble](problems.md#tsibble) |1.1.1   |__+1__ |        |     |
+|package       |version |error  |warning |note |
+|:-------------|:-------|:------|:-------|:----|
+|[cmcR](problems.md#cmcr)|0.1.9   |__+1__ |        |     |
+|[faux](problems.md#faux)|1.1.0   |       |__+1__  |     |
+|[ggpubr](problems.md#ggpubr)|0.5.0   |__+1__ |        |     |
+|[metaconfoundr](problems.md#metaconfoundr)|0.1.1   |__+2__ |__+1__  |     |
+|[mpwR](problems.md#mpwr)|0.1.0   |__+2__ |__+1__  |     |
+|[openalexR](problems.md#openalexr)|1.0.0   |       |__+1__  |     |
+|[recipes](problems.md#recipes)|1.0.3   |__+2__ |        |1    |
+|[tidyfst](problems.md#tidyfst)|1.7.5   |__+1__ |        |1    |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,57 +1,53 @@
 ## revdepcheck results
 
-We checked 1515 reverse dependencies (1503 from CRAN + 12 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 1711 reverse dependencies (1695 from CRAN + 16 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 11 new problems
- * We failed to check 3 packages
+ * We saw 8 new problems
+ * We failed to check 10 packages
 
 Issues with CRAN packages are summarised below.
 
 ### New problems
 (This reports the first line of each new failure)
 
-* broom
-  checking examples ... ERROR
-
-* dartR
-  checking examples ... ERROR
-
-* egor
-  checking examples ... ERROR
+* cmcR
   checking tests ... ERROR
-  checking re-building of vignette outputs ... WARNING
 
 * faux
   checking re-building of vignette outputs ... WARNING
 
-* ftExtra
+* ggpubr
+  checking examples ... ERROR
+
+* metaconfoundr
   checking examples ... ERROR
   checking tests ... ERROR
   checking re-building of vignette outputs ... WARNING
 
-* hacksig
+* mpwR
   checking examples ... ERROR
-  checking re-building of vignette outputs ... WARNING
-
-* psfmi
-  checking re-building of vignette outputs ... WARNING
-
-* rmdcev
   checking tests ... ERROR
+  checking re-building of vignette outputs ... WARNING
 
-* simITS
+* openalexR
+  checking re-building of vignette outputs ... WARNING
+
+* recipes
   checking examples ... ERROR
   checking tests ... ERROR
 
-* surveil
-  checking tests ... ERROR
-  checking re-building of vignette outputs ... WARNING
-
-* tsibble
-  checking tests ... ERROR
+* tidyfst
+  checking examples ... ERROR
 
 ### Failed to check
 
+* FAMetA         (NA)
+* ggPMX          (NA)
 * loon.ggplot    (NA)
 * MarketMatching (NA)
+* OlinkAnalyze   (NA)
+* Platypus       (NA)
+* RVA            (NA)
+* tinyarray      (NA)
 * vivid          (NA)
+* xpose.nlmixr2  (NA)

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,8 +1,8 @@
 ## revdepcheck results
 
-We checked 1509 reverse dependencies (1497 from CRAN + 12 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 1515 reverse dependencies (1503 from CRAN + 12 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 6 new problems
+ * We saw 11 new problems
  * We failed to check 3 packages
 
 Issues with CRAN packages are summarised below.
@@ -10,24 +10,45 @@ Issues with CRAN packages are summarised below.
 ### New problems
 (This reports the first line of each new failure)
 
-* batchtma
+* broom
   checking examples ... ERROR
-  checking re-building of vignette outputs ... WARNING
 
 * dartR
   checking examples ... ERROR
 
+* egor
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... WARNING
+
 * faux
   checking re-building of vignette outputs ... WARNING
 
-* simpr
-  checking S3 generic/method consistency ... WARNING
+* ftExtra
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... WARNING
 
-* sparklyr
-  checking S3 generic/method consistency ... WARNING
+* hacksig
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... WARNING
 
-* tidyseurat
-  checking S3 generic/method consistency ... WARNING
+* psfmi
+  checking re-building of vignette outputs ... WARNING
+
+* rmdcev
+  checking tests ... ERROR
+
+* simITS
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* surveil
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... WARNING
+
+* tsibble
+  checking tests ... ERROR
 
 ### Failed to check
 

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -348,15 +348,223 @@ Run `cloud_details(, "NA")` for more info
 
 
 ```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# FAMetA
+
+<details>
+
+* Version: 0.1.4
+* GitHub: NA
+* Source code: https://github.com/cran/FAMetA
+* Date/Publication: 2022-03-01 15:40:23 UTC
+* Number of recursive dependencies: 90
+
+Run `cloud_details(, "FAMetA")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘FAMetA’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/FAMetA/new/FAMetA.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘FAMetA’ ...
+** package ‘FAMetA’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘LipidMS’ in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]):
+ there is no package called ‘readMzXmlData’
+Execution halted
+ERROR: lazy loading failed for package ‘FAMetA’
+* removing ‘/tmp/workdir/FAMetA/new/FAMetA.Rcheck/FAMetA’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘FAMetA’ ...
+** package ‘FAMetA’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘LipidMS’ in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]):
+ there is no package called ‘readMzXmlData’
+Execution halted
+ERROR: lazy loading failed for package ‘FAMetA’
+* removing ‘/tmp/workdir/FAMetA/old/FAMetA.Rcheck/FAMetA’
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# ggPMX
+
+<details>
+
+* Version: 1.2.8
+* GitHub: https://github.com/ggPMXdevelopment/ggPMX
+* Source code: https://github.com/cran/ggPMX
+* Date/Publication: 2022-06-17 23:10:02 UTC
+* Number of recursive dependencies: 177
+
+Run `cloud_details(, "ggPMX")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ggPMX/new/ggPMX.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ggPMX/DESCRIPTION’ ... OK
+* this is package ‘ggPMX’ version ‘1.2.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... NOTE
+...
+  [ FAIL 1 | WARN 13 | SKIP 8 | PASS 327 ]
+  Error: Test failures
+  Execution halted
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘ggPMX-guide.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 ERROR, 2 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ggPMX/old/ggPMX.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ggPMX/DESCRIPTION’ ... OK
+* this is package ‘ggPMX’ version ‘1.2.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... NOTE
+...
+  [ FAIL 1 | WARN 13 | SKIP 8 | PASS 327 ]
+  Error: Test failures
+  Execution halted
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘ggPMX-guide.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 ERROR, 2 NOTEs
+
+
+
+
+
+```
 # loon.ggplot
 
 <details>
 
-* Version: 1.3.1
+* Version: 1.3.3
 * GitHub: https://github.com/great-northern-diver/loon.ggplot
 * Source code: https://github.com/cran/loon.ggplot
-* Date/Publication: 2022-02-07 21:50:06 UTC
-* Number of recursive dependencies: 103
+* Date/Publication: 2022-11-12 22:30:02 UTC
+* Number of recursive dependencies: 104
 
 Run `cloud_details(, "loon.ggplot")` for more info
 
@@ -374,7 +582,7 @@ Run `cloud_details(, "loon.ggplot")` for more info
 * using option ‘--no-manual’
 * checking for file ‘loon.ggplot/DESCRIPTION’ ... OK
 * checking extension type ... Package
-* this is package ‘loon.ggplot’ version ‘1.3.1’
+* this is package ‘loon.ggplot’ version ‘1.3.3’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
@@ -402,7 +610,7 @@ Status: 1 ERROR
 * using option ‘--no-manual’
 * checking for file ‘loon.ggplot/DESCRIPTION’ ... OK
 * checking extension type ... Package
-* this is package ‘loon.ggplot’ version ‘1.3.1’
+* this is package ‘loon.ggplot’ version ‘1.3.3’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
@@ -455,6 +663,41 @@ Run `cloud_details(, "NA")` for more info
 
 
 ```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
 # MarketMatching
 
 <details>
@@ -463,7 +706,7 @@ Run `cloud_details(, "NA")` for more info
 * GitHub: NA
 * Source code: https://github.com/cran/MarketMatching
 * Date/Publication: 2021-01-08 20:10:02 UTC
-* Number of recursive dependencies: 71
+* Number of recursive dependencies: 72
 
 Run `cloud_details(, "MarketMatching")` for more info
 
@@ -556,6 +799,327 @@ Run `cloud_details(, "NA")` for more info
 
 
 ```
+# OlinkAnalyze
+
+<details>
+
+* Version: 3.2.2
+* GitHub: NA
+* Source code: https://github.com/cran/OlinkAnalyze
+* Date/Publication: 2022-11-16 00:30:05 UTC
+* Number of recursive dependencies: 203
+
+Run `cloud_details(, "OlinkAnalyze")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/OlinkAnalyze/new/OlinkAnalyze.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘OlinkAnalyze/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘OlinkAnalyze’ version ‘3.2.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘Vignett.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/OlinkAnalyze/old/OlinkAnalyze.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘OlinkAnalyze/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘OlinkAnalyze’ version ‘3.2.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘Vignett.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# Platypus
+
+<details>
+
+* Version: 3.4.1
+* GitHub: NA
+* Source code: https://github.com/cran/Platypus
+* Date/Publication: 2022-08-15 07:20:20 UTC
+* Number of recursive dependencies: 354
+
+Run `cloud_details(, "Platypus")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/Platypus/new/Platypus.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘Platypus/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘Platypus’ version ‘3.4.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+* checking package dependencies ... ERROR
+Package required but not available: ‘ggtree’
+
+Packages suggested but not available for checking:
+  'Matrix.utils', 'monocle3', 'ProjecTILs', 'SeuratWrappers'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/Platypus/old/Platypus.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘Platypus/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘Platypus’ version ‘3.4.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+* checking package dependencies ... ERROR
+Package required but not available: ‘ggtree’
+
+Packages suggested but not available for checking:
+  'Matrix.utils', 'monocle3', 'ProjecTILs', 'SeuratWrappers'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# RVA
+
+<details>
+
+* Version: 0.0.5
+* GitHub: https://github.com/THERMOSTATS/RVA
+* Source code: https://github.com/cran/RVA
+* Date/Publication: 2021-11-01 21:40:02 UTC
+* Number of recursive dependencies: 208
+
+Run `cloud_details(, "RVA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/RVA/new/RVA.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘RVA/DESCRIPTION’ ... OK
+* this is package ‘RVA’ version ‘0.0.5’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/RVA/old/RVA.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘RVA/DESCRIPTION’ ... OK
+* this is package ‘RVA’ version ‘0.0.5’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# tinyarray
+
+<details>
+
+* Version: 2.2.7
+* GitHub: https://github.com/xjsun1221/tinyarray
+* Source code: https://github.com/cran/tinyarray
+* Date/Publication: 2021-11-08 10:00:02 UTC
+* Number of recursive dependencies: 228
+
+Run `cloud_details(, "tinyarray")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/tinyarray/new/tinyarray.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tinyarray/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘tinyarray’ version ‘2.2.7’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/tinyarray/old/tinyarray.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tinyarray/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘tinyarray’ version ‘2.2.7’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
 # vivid
 
 <details>
@@ -564,7 +1128,7 @@ Run `cloud_details(, "NA")` for more info
 * GitHub: NA
 * Source code: https://github.com/cran/vivid
 * Date/Publication: 2021-11-20 01:30:02 UTC
-* Number of recursive dependencies: 202
+* Number of recursive dependencies: 206
 
 Run `cloud_details(, "vivid")` for more info
 
@@ -626,6 +1190,78 @@ Status: 2 NOTEs
 * checking re-building of vignette outputs ... OK
 * DONE
 Status: 2 NOTEs
+
+
+
+
+
+```
+# xpose.nlmixr2
+
+<details>
+
+* Version: 0.4.0
+* GitHub: NA
+* Source code: https://github.com/cran/xpose.nlmixr2
+* Date/Publication: 2022-06-08 09:10:02 UTC
+* Number of recursive dependencies: 154
+
+Run `cloud_details(, "xpose.nlmixr2")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/xpose.nlmixr2/new/xpose.nlmixr2.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘xpose.nlmixr2/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘xpose.nlmixr2’ version ‘0.4.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘nlmixr2est’
+
+Package suggested but not available for checking: ‘nlmixr2’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/xpose.nlmixr2/old/xpose.nlmixr2.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘xpose.nlmixr2/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘xpose.nlmixr2’ version ‘0.4.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘nlmixr2est’
+
+Package suggested but not available for checking: ‘nlmixr2’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
 
 
 

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,14 +1,14 @@
-# batchtma
+# broom
 
 <details>
 
-* Version: 0.1.6
-* GitHub: https://github.com/stopsack/batchtma
-* Source code: https://github.com/cran/batchtma
-* Date/Publication: 2021-12-06 08:10:02 UTC
-* Number of recursive dependencies: 106
+* Version: 0.8.0
+* GitHub: https://github.com/tidymodels/broom
+* Source code: https://github.com/cran/broom
+* Date/Publication: 2022-04-13 15:02:34 UTC
+* Number of recursive dependencies: 294
 
-Run `cloud_details(, "batchtma")` for more info
+Run `cloud_details(, "broom")` for more info
 
 </details>
 
@@ -16,52 +16,35 @@ Run `cloud_details(, "batchtma")` for more info
 
 *   checking examples ... ERROR
     ```
-    Running examples in ‘batchtma-Ex.R’ failed
+    Running examples in ‘broom-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: adjust_batch
-    > ### Title: Adjust for batch effects
-    > ### Aliases: adjust_batch
+    > ### Name: glance.lmodel2
+    > ### Title: Glance at a(n) lmodel2 object
+    > ### Aliases: glance.lmodel2
     > 
     > ### ** Examples
     > 
-    > # Data frame with two batches
+    > 
     ...
-    > adjust_batch(
-    +   data = df,
-    +   markers = biomarker,
-    +   batch = tma,
-    +   method = simple
-    + )
-    Error in tidyr::pivot_longer(., col = c(-.data$.batchvar), names_to = "marker",  : 
-      argument 2 matches multiple formal arguments
-    Calls: adjust_batch -> batchmean_simple -> %>%
+      4. ├─dplyr::select(., method = Method, term, conf.low, conf.high)
+      5. ├─base::as.data.frame(.)
+      6. ├─dplyr::arrange(., Method)
+      7. └─tidyr::pivot_wider(., c(Method, term), names_from = level, values_from = value)
+      8.   └─rlang `<fn>`()
+      9.     └─rlang:::check_dots(env, error, action, call)
+     10.       └─rlang:::action_dots(...)
+     11.         ├─base try_dots(...)
+     12.         └─rlang action(...)
     Execution halted
     ```
 
-*   checking re-building of vignette outputs ... WARNING
+## In both
+
+*   checking dependencies in R code ... NOTE
     ```
-    Error(s) in re-building vignettes:
-      ...
-    --- re-building ‘batchtma.Rmd’ using rmarkdown
-    ── Attaching packages ─────────────────────────────────────── tidyverse 1.3.1 ──
-    ✔ ggplot2 3.3.5          ✔ purrr   0.3.4     
-    ✔ tibble  3.1.6          ✔ dplyr   1.0.8     
-    ✔ tidyr   1.2.0.9000     ✔ stringr 1.4.0     
-    ✔ readr   2.1.2          ✔ forcats 0.5.1     
-    ── Conflicts ────────────────────────────────────────── tidyverse_conflicts() ──
-    ✖ dplyr::filter() masks stats::filter()
-    ...
-    Quitting from lines 92-96 (batchtma.Rmd) 
-    Error: processing vignette 'batchtma.Rmd' failed with diagnostics:
-    argument 2 matches multiple formal arguments
-    --- failed re-building ‘batchtma.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘batchtma.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
+    Namespace in Imports field not imported from: ‘ggplot2’
+      All declared Imports should be used.
     ```
 
 # dartR
@@ -93,15 +76,15 @@ Run `cloud_details(, "dartR")` for more info
     > ### ** Examples
     > 
     ...
-    Backtrace:
-        ▆
-     1. ├─dartR::gl.report.pa(testset.gl[1:20, ])
-     2. │ ├─tidyr::pivot_longer(data_long, -source, "target")
-     3. │ └─tidyr:::pivot_longer.data.frame(data_long, -source, "target")
-     4. │   └─tidyr::pivot_longer_spec(...)
-     5. │     └─rlang::arg_match0(...)
-     6. └─rlang:::stop_arg_match(w, x, y, z)
-     7.   └─rlang::abort(msg, call = error_call)
+      6. │       ├─base::withCallingHandlers(...)
+      7. │       └─vctrs::vec_recycle(value[[j]], nrow)
+      8. ├─vctrs:::stop_recycle_incompatible_size(...)
+      9. │ └─vctrs:::stop_vctrs(...)
+     10. │   └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = vctrs_error_call(call))
+     11. │     └─rlang:::signal_abort(cnd, .file)
+     12. │       └─base::signalCondition(cnd)
+     13. └─tibble `<fn>`(`<vctrs___>`)
+     14.   └─rlang::cnd_signal(...)
     Execution halted
     ```
 
@@ -138,6 +121,94 @@ Run `cloud_details(, "dartR")` for more info
       sub-directories of 1Mb or more:
         R      1.1Mb
         data   1.5Mb
+    ```
+
+# egor
+
+<details>
+
+* Version: 1.22.1
+* GitHub: https://github.com/tilltnet/egor
+* Source code: https://github.com/cran/egor
+* Date/Publication: 2022-01-14 20:52:41 UTC
+* Number of recursive dependencies: 89
+
+Run `cloud_details(, "egor")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘egor-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: count_dyads
+    > ### Title: Count attribute combinations of dyads in ego-centered networks
+    > ### Aliases: count_dyads
+    > 
+    > ### ** Examples
+    > 
+    > data(egor32)
+    ...
+    Backtrace:
+        ▆
+     1. └─egor::count_dyads(object = egor32, alter_var_name = "country")
+     2.   └─tidyr::pivot_wider(...)
+     3.     └─rlang `<fn>`()
+     4.       └─rlang:::check_dots(env, error, action, call)
+     5.         └─rlang:::action_dots(...)
+     6.           ├─base try_dots(...)
+     7.           └─rlang action(...)
+    Execution halted
+    ```
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      ✖ Problematic argument:
+      • ..1 = .egoID
+      Backtrace:
+          ▆
+       1. └─egor::count_dyads(object = x, "sex") at test-count_dyads.R:42:2
+       2.   └─tidyr::pivot_wider(...)
+       3.     └─rlang `<fn>`()
+       4.       └─rlang:::check_dots(env, error, action, call)
+       5.         └─rlang:::action_dots(...)
+       6.           ├─base try_dots(...)
+       7.           └─rlang action(...)
+      
+      [ FAIL 3 | WARN 0 | SKIP 0 | PASS 228 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+*   checking re-building of vignette outputs ... WARNING
+    ```
+    Error(s) in re-building vignettes:
+    --- re-building ‘egor_allbus.Rmd’ using rmarkdown
+    Loading required package: dplyr
+    
+    Attaching package: 'dplyr'
+    
+    The following objects are masked from 'package:stats':
+    
+        filter, lag
+    
+    ...
+    Arguments in `...` must be used.
+    ✖ Problematic argument:
+    • ..1 = .egoID
+    --- failed re-building ‘using_egor.Rmd’
+    
+    SUMMARY: processing the following file failed:
+      ‘using_egor.Rmd’
+    
+    Error: Vignette re-building failed.
+    Execution halted
     ```
 
 # faux
@@ -181,126 +252,450 @@ Run `cloud_details(, "faux")` for more info
     Execution halted
     ```
 
-# simpr
+# ftExtra
 
 <details>
 
-* Version: 0.2.2
-* GitHub: https://github.com/statisfactions/simpr
-* Source code: https://github.com/cran/simpr
-* Date/Publication: 2022-02-13 00:40:02 UTC
-* Number of recursive dependencies: 76
+* Version: 0.3.0
+* GitHub: https://github.com/atusy/ftExtra
+* Source code: https://github.com/cran/ftExtra
+* Date/Publication: 2022-01-04 17:00:02 UTC
+* Number of recursive dependencies: 66
 
-Run `cloud_details(, "simpr")` for more info
+Run `cloud_details(, "ftExtra")` for more info
 
 </details>
 
 ## Newly broken
 
-*   checking S3 generic/method consistency ... WARNING
+*   checking examples ... ERROR
     ```
-    pivot_longer:
-      function(data, cols, cols_vary, names_to, names_prefix, names_sep,
-               names_pattern, names_ptypes, names_transform, names_repair,
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
-    pivot_longer.simpr_sims:
-      function(data, cols, names_to, names_prefix, names_sep,
-               names_pattern, names_ptypes, names_transform, names_repair,
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
+    Running examples in ‘ftExtra-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: span_header
+    > ### Title: Span the header based on delimiters
+    > ### Aliases: span_header
+    > 
+    > ### ** Examples
+    > 
+    > iris %>%
     ...
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
-    pivot_longer.simpr_spec:
-      function(data, cols, names_to, names_prefix, names_sep,
-               names_pattern, names_ptypes, names_transform, names_repair,
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
-    
-    See section ‘Generic functions and methods’ in the ‘Writing R
-    Extensions’ manual.
+      4. │   └─... %>% fill_header(.fill)
+      5. ├─ftExtra:::fill_header(., .fill)
+      6. │ └─... %>% ...
+      7. └─tidyr::pivot_wider(...)
+      8.   └─rlang `<fn>`()
+      9.     └─rlang:::check_dots(env, error, action, call)
+     10.       └─rlang:::action_dots(...)
+     11.         ├─base try_dots(...)
+     12.         └─rlang action(...)
+    Execution halted
     ```
 
-# sparklyr
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+        5. ├─ftExtra::span_header(.)
+        6. │ └─ftExtra:::transform_header(...)
+        7. │   └─... %>% fill_header(.fill)
+        8. ├─ftExtra:::fill_header(., .fill)
+        9. │ └─... %>% ...
+       10. └─tidyr::pivot_wider(...)
+       11.   └─rlang `<fn>`()
+       12.     └─rlang:::check_dots(env, error, action, call)
+       13.       └─rlang:::action_dots(...)
+       14.         ├─base try_dots(...)
+       15.         └─rlang action(...)
+      
+      [ FAIL 2 | WARN 0 | SKIP 0 | PASS 40 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+*   checking re-building of vignette outputs ... WARNING
+    ```
+    Error(s) in re-building vignettes:
+      ...
+    --- re-building ‘format_columns.Rmd’ using rmarkdown
+    --- finished re-building ‘format_columns.Rmd’
+    
+    --- re-building ‘group-rows.Rmd’ using rmarkdown
+    --- finished re-building ‘group-rows.Rmd’
+    
+    --- re-building ‘transform-headers.Rmd’ using rmarkdown
+    Quitting from lines 53-54 (transform-headers.Rmd) 
+    ...
+    Arguments in `...` must be used.
+    ✖ Problematic argument:
+    • ..1 = "original"
+    --- failed re-building ‘transform-headers.Rmd’
+    
+    SUMMARY: processing the following file failed:
+      ‘transform-headers.Rmd’
+    
+    Error: Vignette re-building failed.
+    Execution halted
+    ```
+
+# hacksig
 
 <details>
 
-* Version: 1.7.5
-* GitHub: https://github.com/sparklyr/sparklyr
-* Source code: https://github.com/cran/sparklyr
-* Date/Publication: 2022-02-02 14:30:02 UTC
-* Number of recursive dependencies: 107
+* Version: 0.1.2
+* GitHub: https://github.com/Acare/hacksig
+* Source code: https://github.com/cran/hacksig
+* Date/Publication: 2022-02-17 14:22:02 UTC
+* Number of recursive dependencies: 72
 
-Run `cloud_details(, "sparklyr")` for more info
+Run `cloud_details(, "hacksig")` for more info
 
 </details>
 
 ## Newly broken
 
-*   checking S3 generic/method consistency ... WARNING
+*   checking examples ... ERROR
     ```
-    pivot_longer:
-      function(data, cols, cols_vary, names_to, names_prefix, names_sep,
-               names_pattern, names_ptypes, names_transform, names_repair,
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
-    pivot_longer.tbl_spark:
-      function(data, cols, names_to, names_prefix, names_sep,
-               names_pattern, names_ptypes, names_transform, names_repair,
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
+    Running examples in ‘hacksig-Ex.R’ failed
+    The error most likely occurred in:
     
-    See section ‘Generic functions and methods’ in the ‘Writing R
-    Extensions’ manual.
+    > ### Name: hack_immunophenoscore
+    > ### Title: Hack the Immunophenoscore
+    > ### Aliases: hack_immunophenoscore
+    > 
+    > ### ** Examples
+    > 
+    > hack_immunophenoscore(test_expr)
+    ...
+        ▆
+     1. └─hacksig::hack_immunophenoscore(test_expr)
+     2.   ├─dplyr::ungroup(...)
+     3.   └─tidyr::pivot_wider(...)
+     4.     └─rlang `<fn>`()
+     5.       └─rlang:::check_dots(env, error, action, call)
+     6.         └─rlang:::action_dots(...)
+     7.           ├─base try_dots(...)
+     8.           └─rlang action(...)
+    Execution halted
+    ```
+
+*   checking re-building of vignette outputs ... WARNING
+    ```
+    Error(s) in re-building vignettes:
+      ...
+    --- re-building ‘hacksig.Rmd’ using rmarkdown
+    
+    Attaching package: 'dplyr'
+    
+    The following objects are masked from 'package:stats':
+    
+        filter, lag
+    
+    ...
+    Arguments in `...` must be used.
+    ✖ Problematic argument:
+    • ..1 = c("sample_id", "raw", "ips")
+    --- failed re-building ‘hacksig.Rmd’
+    
+    SUMMARY: processing the following file failed:
+      ‘hacksig.Rmd’
+    
+    Error: Vignette re-building failed.
+    Execution halted
+    ```
+
+# psfmi
+
+<details>
+
+* Version: 1.0.0
+* GitHub: https://github.com/mwheymans/psfmi
+* Source code: https://github.com/cran/psfmi
+* Date/Publication: 2021-09-23 10:10:05 UTC
+* Number of recursive dependencies: 152
+
+Run `cloud_details(, "psfmi")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... WARNING
+    ```
+    Error(s) in re-building vignettes:
+    --- re-building ‘MI_boot.Rmd’ using rmarkdown
+    --- finished re-building ‘MI_boot.Rmd’
+    
+    --- re-building ‘MI_cv_naive.Rmd’ using rmarkdown
+    --- finished re-building ‘MI_cv_naive.Rmd’
+    
+    --- re-building ‘Pool_Model_Performance.Rmd’ using rmarkdown
+    --- finished re-building ‘Pool_Model_Performance.Rmd’
+    
+    ...
+    --- failed re-building ‘psfmi_StabilityAnalysis.Rmd’
+    
+    --- re-building ‘psfmi_mice.Rmd’ using rmarkdown
+    --- finished re-building ‘psfmi_mice.Rmd’
+    
+    SUMMARY: processing the following file failed:
+      ‘psfmi_StabilityAnalysis.Rmd’
+    
+    Error: Vignette re-building failed.
+    Execution halted
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespace in Imports field not imported from: ‘miceadds’
+      All declared Imports should be used.
+    ```
+
+# rmdcev
+
+<details>
+
+* Version: 1.2.4
+* GitHub: https://github.com/plloydsmith/rmdcev
+* Source code: https://github.com/cran/rmdcev
+* Date/Publication: 2020-09-30 18:40:02 UTC
+* Number of recursive dependencies: 84
+
+Run `cloud_details(, "rmdcev")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+        3. │   ├─base::t(GrabParms(est_sim, "scale"))
+        4. │   └─rmdcev:::GrabParms(est_sim, "scale")
+        5. │     └─... %>% as.matrix(.)
+        6. ├─base::as.matrix(.)
+        7. ├─dplyr::select(., -sim_id)
+        8. └─tidyr::pivot_wider(., sim_id, names_from = "parms", values_from = "value")
+        9.   └─rlang `<fn>`()
+       10.     └─rlang:::check_dots(env, error, action, call)
+       11.       └─rlang:::action_dots(...)
+       12.         ├─base try_dots(...)
+       13.         └─rlang action(...)
+      
+      [ FAIL 15 | WARN 0 | SKIP 1 | PASS 54 ]
+      Error: Test failures
+      Execution halted
     ```
 
 ## In both
 
 *   checking installed package size ... NOTE
     ```
-      installed size is  6.3Mb
+      installed size is 114.5Mb
       sub-directories of 1Mb or more:
-        R      1.5Mb
-        java   3.4Mb
+        libs  113.7Mb
     ```
 
 *   checking dependencies in R code ... NOTE
     ```
-    Namespace in Imports field not imported from: ‘lifecycle’
+    Namespace in Imports field not imported from: ‘RcppParallel’
       All declared Imports should be used.
     ```
 
-# tidyseurat
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
+
+# simITS
 
 <details>
 
-* Version: 0.5.1
-* GitHub: https://github.com/stemangiola/tidyseurat
-* Source code: https://github.com/cran/tidyseurat
-* Date/Publication: 2022-02-03 13:20:02 UTC
-* Number of recursive dependencies: 186
+* Version: 0.1.1
+* GitHub: NA
+* Source code: https://github.com/cran/simITS
+* Date/Publication: 2020-05-20 13:50:02 UTC
+* Number of recursive dependencies: 78
 
-Run `cloud_details(, "tidyseurat")` for more info
+Run `cloud_details(, "simITS")` for more info
 
 </details>
 
 ## Newly broken
 
-*   checking S3 generic/method consistency ... WARNING
+*   checking examples ... ERROR
     ```
-    pivot_longer:
-      function(data, cols, cols_vary, names_to, names_prefix, names_sep,
-               names_pattern, names_ptypes, names_transform, names_repair,
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
-    pivot_longer.Seurat:
-      function(data, cols, names_to, names_prefix, names_sep,
-               names_pattern, names_ptypes, names_transform, names_repair,
-               values_to, values_drop_na, values_ptypes, values_transform,
-               ...)
+    Running examples in ‘simITS-Ex.R’ failed
+    The error most likely occurred in:
     
-    See section ‘Generic functions and methods’ in the ‘Writing R
-    Extensions’ manual.
+    > ### Name: adjust_data
+    > ### Title: Adjust an outcome time series based on the group weights.
+    > ### Aliases: adjust_data
+    > 
+    > ### ** Examples
+    > 
+    > data( "meck_subgroup" )
+    ...
+        ▆
+     1. ├─simITS::aggregate_data(...)
+     2. │ └─... %>% ...
+     3. └─tidyr::pivot_wider(...)
+     4.   └─rlang `<fn>`()
+     5.     └─rlang:::check_dots(env, error, action, call)
+     6.       └─rlang:::action_dots(...)
+     7.         ├─base try_dots(...)
+     8.         └─rlang action(...)
+    Execution halted
+    ```
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      • ..1 = month
+      Backtrace:
+          ▆
+       1. ├─simITS::aggregate_data(meck, "pbail", "category", Nname = "N") at test-post_stratified_ITS.R:45:2
+       2. │ └─... %>% ...
+       3. └─tidyr::pivot_wider(...)
+       4.   └─rlang `<fn>`()
+       5.     └─rlang:::check_dots(env, error, action, call)
+       6.       └─rlang:::action_dots(...)
+       7.         ├─base try_dots(...)
+       8.         └─rlang action(...)
+      
+      [ FAIL 2 | WARN 0 | SKIP 0 | PASS 78 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+# surveil
+
+<details>
+
+* Version: 0.2.0
+* GitHub: https://github.com/ConnorDonegan/surveil
+* Source code: https://github.com/cran/surveil
+* Date/Publication: 2022-04-03 18:40:02 UTC
+* Number of recursive dependencies: 94
+
+Run `cloud_details(, "surveil")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      Backtrace:
+          ▆
+       1. ├─surveil::stan_rw(...) at test_rw.R:141:4
+       2. │ └─... %>% dplyr::select(-c(.data$id))
+       3. ├─dplyr::select(., -c(.data$id))
+       4. └─tidyr::pivot_wider(...)
+       5.   └─rlang `<fn>`()
+       6.     └─rlang:::check_dots(env, error, action, call)
+       7.       └─rlang:::action_dots(...)
+       8.         ├─base try_dots(...)
+       9.         └─rlang action(...)
+      
+      [ FAIL 8 | WARN 11 | SKIP 0 | PASS 3 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+*   checking re-building of vignette outputs ... WARNING
+    ```
+    Error(s) in re-building vignettes:
+    --- re-building ‘age-standardization.Rmd’ using rmarkdown
+    Quitting from lines 115-122 (age-standardization.Rmd) 
+    Error: processing vignette 'age-standardization.Rmd' failed with diagnostics:
+    Arguments in `...` must be used.
+    ✖ Problematic argument:
+    • ..1 = id
+    --- failed re-building ‘age-standardization.Rmd’
+    
+    --- re-building ‘demonstration.Rmd’ using rmarkdown
+    ...
+    Arguments in `...` must be used.
+    ✖ Problematic argument:
+    • ..1 = id
+    --- failed re-building ‘demonstration.Rmd’
+    
+    SUMMARY: processing the following files failed:
+      ‘age-standardization.Rmd’ ‘demonstration.Rmd’
+    
+    Error: Vignette re-building failed.
+    Execution halted
+    ```
+
+## In both
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 75.9Mb
+      sub-directories of 1Mb or more:
+        libs  74.7Mb
+    ```
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘RcppParallel’ ‘rstantools’
+      All declared Imports should be used.
+    ```
+
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
+
+# tsibble
+
+<details>
+
+* Version: 1.1.1
+* GitHub: https://github.com/tidyverts/tsibble
+* Source code: https://github.com/cran/tsibble
+* Date/Publication: 2021-12-03 21:30:02 UTC
+* Number of recursive dependencies: 94
+
+Run `cloud_details(, "tsibble")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ... ERROR
+    ```
+      Running ‘spelling.R’
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+        3. │   └─testthat:::quasi_capture(...)
+        4. │     ├─testthat .capture(...)
+        5. │     │ └─base::withCallingHandlers(...)
+        6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
+        7. ├─tsbl %>% pivot_wider(qtr, names_from = qtr, values_from = value)
+        8. ├─tidyr::pivot_wider(., qtr, names_from = qtr, values_from = value)
+        9. └─rlang `<fn>`()
+       10.   └─rlang:::check_dots(env, error, action, call)
+       11.     └─rlang:::action_dots(...)
+       12.       ├─base try_dots(...)
+       13.       └─rlang action(...)
+      
+      [ FAIL 1 | WARN 1 | SKIP 5 | PASS 743 ]
+      Error: Test failures
+      Execution halted
     ```
 

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,214 +1,39 @@
-# broom
+# cmcR
 
 <details>
 
-* Version: 0.8.0
-* GitHub: https://github.com/tidymodels/broom
-* Source code: https://github.com/cran/broom
-* Date/Publication: 2022-04-13 15:02:34 UTC
-* Number of recursive dependencies: 294
-
-Run `cloud_details(, "broom")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘broom-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: glance.lmodel2
-    > ### Title: Glance at a(n) lmodel2 object
-    > ### Aliases: glance.lmodel2
-    > 
-    > ### ** Examples
-    > 
-    > 
-    ...
-      4. ├─dplyr::select(., method = Method, term, conf.low, conf.high)
-      5. ├─base::as.data.frame(.)
-      6. ├─dplyr::arrange(., Method)
-      7. └─tidyr::pivot_wider(., c(Method, term), names_from = level, values_from = value)
-      8.   └─rlang `<fn>`()
-      9.     └─rlang:::check_dots(env, error, action, call)
-     10.       └─rlang:::action_dots(...)
-     11.         ├─base try_dots(...)
-     12.         └─rlang action(...)
-    Execution halted
-    ```
-
-## In both
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespace in Imports field not imported from: ‘ggplot2’
-      All declared Imports should be used.
-    ```
-
-# dartR
-
-<details>
-
-* Version: 2.0.3
+* Version: 0.1.9
 * GitHub: NA
-* Source code: https://github.com/cran/dartR
-* Date/Publication: 2022-03-28 14:50:02 UTC
-* Number of recursive dependencies: 274
+* Source code: https://github.com/cran/cmcR
+* Date/Publication: 2022-02-22 14:00:02 UTC
+* Number of recursive dependencies: 117
 
-Run `cloud_details(, "dartR")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘dartR-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: gl.report.pa
-    > ### Title: Reports private alleles (and fixed alleles) per pair of
-    > ###   populations
-    > ### Aliases: gl.report.pa
-    > 
-    > ### ** Examples
-    > 
-    ...
-      6. │       ├─base::withCallingHandlers(...)
-      7. │       └─vctrs::vec_recycle(value[[j]], nrow)
-      8. ├─vctrs:::stop_recycle_incompatible_size(...)
-      9. │ └─vctrs:::stop_vctrs(...)
-     10. │   └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = vctrs_error_call(call))
-     11. │     └─rlang:::signal_abort(cnd, .file)
-     12. │       └─base::signalCondition(cnd)
-     13. └─tibble `<fn>`(`<vctrs___>`)
-     14.   └─rlang::cnd_signal(...)
-    Execution halted
-    ```
-
-## In both
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-    --- re-building ‘IntroTutorial_dartR.Rmd’ using rmarkdown
-    A new version of TeX Live has been released. If you need to install or update any LaTeX packages, you have to upgrade TinyTeX with tinytex::reinstall_tinytex(). If it fails to upgrade, you might be using a default random CTAN mirror that has not been fully synced to the main CTAN repository, and you need to wait for a few more days or use a CTAN mirror that is known to be up-to-date (see the "repository" argument on the help page ?tinytex::install_tinytex).
-    
-    tlmgr: Local TeX Live (2021) is older than remote repository (2022).
-    Cross release updates are only supported with
-      update-tlmgr-latest(.sh/.exe) --update
-    See https://tug.org/texlive/upgrade.html for details.
-    Warning in system2("tlmgr", args, ...) :
-      running command ''tlmgr' search --file --global '/tcolorbox.sty'' had status 1
-    ...
-    --- failed re-building ‘IntroTutorial_dartR.Rmd’
-    
-    --- re-building ‘dartRTutorials.Rmd’ using rmarkdown
-    --- finished re-building ‘dartRTutorials.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘IntroTutorial_dartR.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
-    ```
-
-*   checking installed package size ... NOTE
-    ```
-      installed size is  5.0Mb
-      sub-directories of 1Mb or more:
-        R      1.1Mb
-        data   1.5Mb
-    ```
-
-# egor
-
-<details>
-
-* Version: 1.22.1
-* GitHub: https://github.com/tilltnet/egor
-* Source code: https://github.com/cran/egor
-* Date/Publication: 2022-01-14 20:52:41 UTC
-* Number of recursive dependencies: 89
-
-Run `cloud_details(, "egor")` for more info
+Run `cloud_details(, "cmcR")` for more info
 
 </details>
 
 ## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘egor-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: count_dyads
-    > ### Title: Count attribute combinations of dyads in ego-centered networks
-    > ### Aliases: count_dyads
-    > 
-    > ### ** Examples
-    > 
-    > data(egor32)
-    ...
-    Backtrace:
-        ▆
-     1. └─egor::count_dyads(object = egor32, alter_var_name = "country")
-     2.   └─tidyr::pivot_wider(...)
-     3.     └─rlang `<fn>`()
-     4.       └─rlang:::check_dots(env, error, action, call)
-     5.         └─rlang:::action_dots(...)
-     6.           ├─base try_dots(...)
-     7.           └─rlang action(...)
-    Execution halted
-    ```
 
 *   checking tests ... ERROR
     ```
       Running ‘testthat.R’
     Running the tests in ‘tests/testthat.R’ failed.
     Last 13 lines of output:
-      ✖ Problematic argument:
-      • ..1 = .egoID
-      Backtrace:
-          ▆
-       1. └─egor::count_dyads(object = x, "sex") at test-count_dyads.R:42:2
-       2.   └─tidyr::pivot_wider(...)
-       3.     └─rlang `<fn>`()
-       4.       └─rlang:::check_dots(env, error, action, call)
-       5.         └─rlang:::action_dots(...)
-       6.           ├─base try_dots(...)
-       7.           └─rlang action(...)
+      ℹ Please use `"highCMCClassif"` instead of `.data$highCMCClassif`
       
-      [ FAIL 3 | WARN 0 | SKIP 0 | PASS 228 ]
+      ══ Failed ══════════════════════════════════════════════════════════════════════
+      ── 1. Error ('test-diagnosticTools.R:55'): (code run outside of `test_that()`) ─
+      Error in `stringr::str_extract_all(., string = ..2$cmcR.info$cellRange, 
+          pattern = "[0-9]{1,}")`: `simplify` must be `TRUE` or `FALSE`, not the string "rows: 1 - 69, cols: 1 - 69".
+      Backtrace:
+       1. cmcR::cmcPlot(...)
+            at test-diagnosticTools.R:55:0
+       8. stringr::str_extract_all(simplify = .)
+      
+      ══ DONE ════════════════════════════════════════════════════════════════════════
+      Don't worry, you'll get it.
       Error: Test failures
       Execution halted
-    ```
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-    --- re-building ‘egor_allbus.Rmd’ using rmarkdown
-    Loading required package: dplyr
-    
-    Attaching package: 'dplyr'
-    
-    The following objects are masked from 'package:stats':
-    
-        filter, lag
-    
-    ...
-    Arguments in `...` must be used.
-    ✖ Problematic argument:
-    • ..1 = .egoID
-    --- failed re-building ‘using_egor.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘using_egor.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
     ```
 
 # faux
@@ -252,17 +77,17 @@ Run `cloud_details(, "faux")` for more info
     Execution halted
     ```
 
-# ftExtra
+# ggpubr
 
 <details>
 
-* Version: 0.3.0
-* GitHub: https://github.com/atusy/ftExtra
-* Source code: https://github.com/cran/ftExtra
-* Date/Publication: 2022-01-04 17:00:02 UTC
-* Number of recursive dependencies: 66
+* Version: 0.5.0
+* GitHub: https://github.com/kassambara/ggpubr
+* Source code: https://github.com/cran/ggpubr
+* Date/Publication: 2022-11-16 12:10:54 UTC
+* Number of recursive dependencies: 84
 
-Run `cloud_details(, "ftExtra")` for more info
+Run `cloud_details(, "ggpubr")` for more info
 
 </details>
 
@@ -270,47 +95,89 @@ Run `cloud_details(, "ftExtra")` for more info
 
 *   checking examples ... ERROR
     ```
-    Running examples in ‘ftExtra-Ex.R’ failed
+    Running examples in ‘ggpubr-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: span_header
-    > ### Title: Span the header based on delimiters
-    > ### Aliases: span_header
+    > ### Name: ggsummarytable
+    > ### Title: GGPLOT with Summary Stats Table Under the Plot
+    > ### Aliases: ggsummarytable ggsummarystats print.ggsummarystats
+    > ###   print.ggsummarystats_list
     > 
     > ### ** Examples
     > 
-    > iris %>%
     ...
-      4. │   └─... %>% fill_header(.fill)
-      5. ├─ftExtra:::fill_header(., .fill)
-      6. │ └─... %>% ...
-      7. └─tidyr::pivot_wider(...)
-      8.   └─rlang `<fn>`()
-      9.     └─rlang:::check_dots(env, error, action, call)
-     10.       └─rlang:::action_dots(...)
-     11.         ├─base try_dots(...)
-     12.         └─rlang action(...)
+      6.   └─tidyselect::eval_select(expr(c(...)), data, allow_rename = FALSE)
+      7.     └─tidyselect:::eval_select_impl(...)
+      8.       ├─tidyselect:::with_subscript_errors(...)
+      9.       │ └─rlang::try_fetch(...)
+     10.       │   └─base::withCallingHandlers(...)
+     11.       └─tidyselect:::vars_select_eval(...)
+     12.         └─tidyselect:::ensure_named(...)
+     13.           └─cli::cli_abort(...)
+     14.             └─rlang::abort(...)
+    Execution halted
+    ```
+
+# metaconfoundr
+
+<details>
+
+* Version: 0.1.1
+* GitHub: https://github.com/malcolmbarrett/metaconfoundr
+* Source code: https://github.com/cran/metaconfoundr
+* Date/Publication: 2022-08-06 14:00:10 UTC
+* Number of recursive dependencies: 117
+
+Run `cloud_details(, "metaconfoundr")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘metaconfoundr-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: metaconfoundr()
+    > ### Title: Prepare a meta-analysis data set for metaconfoundr
+    > ### Aliases: metaconfoundr() metaconfoundr
+    > 
+    > ### ** Examples
+    > 
+    > 
+    ...
+      7.           └─tidyselect::eval_select(...)
+      8.             └─tidyselect:::eval_select_impl(...)
+      9.               ├─tidyselect:::with_subscript_errors(...)
+     10.               │ └─rlang::try_fetch(...)
+     11.               │   └─base::withCallingHandlers(...)
+     12.               └─tidyselect:::vars_select_eval(...)
+     13.                 └─tidyselect:::ensure_named(...)
+     14.                   └─cli::cli_abort(...)
+     15.                     └─rlang::abort(...)
     Execution halted
     ```
 
 *   checking tests ... ERROR
     ```
+      Running ‘spelling.R’
       Running ‘testthat.R’
     Running the tests in ‘tests/testthat.R’ failed.
     Last 13 lines of output:
-        5. ├─ftExtra::span_header(.)
-        6. │ └─ftExtra:::transform_header(...)
-        7. │   └─... %>% fill_header(.fill)
-        8. ├─ftExtra:::fill_header(., .fill)
-        9. │ └─... %>% ...
-       10. └─tidyr::pivot_wider(...)
-       11.   └─rlang `<fn>`()
-       12.     └─rlang:::check_dots(env, error, action, call)
-       13.       └─rlang:::action_dots(...)
-       14.         ├─base try_dots(...)
-       15.         └─rlang action(...)
       
-      [ FAIL 2 | WARN 0 | SKIP 0 | PASS 40 ]
+      [ FAIL 2 | WARN 6 | SKIP 4 | PASS 32 ]
+      Deleting unused snapshots:
+      • non-confounders/non-confounder-count-point.svg
+      • plots/cochrane-heatmap.svg
+      • plots/cochrane-traffic-light-plot.svg
+      • plots/heatmap-with-robins-labels-cochrane-colors.svg
+      • plots/sorted-heatmap-by-domain.svg
+      • plots/sorted-heatmap.svg
+      • plots/sorted-traffic-light-plot-by-domain.svg
+      • plots/sorted-traffic-light-plot.svg
+      • plots/themed-heatmap.svg
+      • plots/themed-traffic-light-plot.svg
       Error: Test failures
       Execution halted
     ```
@@ -319,38 +186,30 @@ Run `cloud_details(, "ftExtra")` for more info
     ```
     Error(s) in re-building vignettes:
       ...
-    --- re-building ‘format_columns.Rmd’ using rmarkdown
-    --- finished re-building ‘format_columns.Rmd’
-    
-    --- re-building ‘group-rows.Rmd’ using rmarkdown
-    --- finished re-building ‘group-rows.Rmd’
-    
-    --- re-building ‘transform-headers.Rmd’ using rmarkdown
-    Quitting from lines 53-54 (transform-headers.Rmd) 
-    ...
-    Arguments in `...` must be used.
-    ✖ Problematic argument:
-    • ..1 = "original"
-    --- failed re-building ‘transform-headers.Rmd’
+    --- re-building ‘intro-to-metaconfoundr.Rmd’ using rmarkdown
+    Quitting from lines 39-42 (intro-to-metaconfoundr.Rmd) 
+    Error: processing vignette 'intro-to-metaconfoundr.Rmd' failed with diagnostics:
+    Can't rename variables in this context.
+    --- failed re-building ‘intro-to-metaconfoundr.Rmd’
     
     SUMMARY: processing the following file failed:
-      ‘transform-headers.Rmd’
+      ‘intro-to-metaconfoundr.Rmd’
     
     Error: Vignette re-building failed.
     Execution halted
     ```
 
-# hacksig
+# mpwR
 
 <details>
 
-* Version: 0.1.2
-* GitHub: https://github.com/Acare/hacksig
-* Source code: https://github.com/cran/hacksig
-* Date/Publication: 2022-02-17 14:22:02 UTC
-* Number of recursive dependencies: 72
+* Version: 0.1.0
+* GitHub: NA
+* Source code: https://github.com/cran/mpwR
+* Date/Publication: 2022-06-22 07:30:02 UTC
+* Number of recursive dependencies: 96
 
-Run `cloud_details(, "hacksig")` for more info
+Run `cloud_details(, "mpwR")` for more info
 
 </details>
 
@@ -358,34 +217,97 @@ Run `cloud_details(, "hacksig")` for more info
 
 *   checking examples ... ERROR
     ```
-    Running examples in ‘hacksig-Ex.R’ failed
+    Running examples in ‘mpwR-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: hack_immunophenoscore
-    > ### Title: Hack the Immunophenoscore
-    > ### Aliases: hack_immunophenoscore
+    > ### Name: get_Upset_list
+    > ### Title: Generate Upset list
+    > ### Aliases: get_Upset_list
     > 
     > ### ** Examples
     > 
-    > hack_immunophenoscore(test_expr)
+    > # Load libraries
     ...
+    ! `pattern` can't be the empty string (`""`).
+    Backtrace:
         ▆
-     1. └─hacksig::hack_immunophenoscore(test_expr)
-     2.   ├─dplyr::ungroup(...)
-     3.   └─tidyr::pivot_wider(...)
-     4.     └─rlang `<fn>`()
-     5.       └─rlang:::check_dots(env, error, action, call)
-     6.         └─rlang:::action_dots(...)
-     7.           ├─base try_dots(...)
-     8.           └─rlang action(...)
+     1. └─mpwR::get_Upset_list(input_list = data, level = "Precursor.IDs")
+     2.   ├─base::which(...)
+     3.   └─stringr::str_detect(string = names(output_list), pattern = "")
+     4.     └─stringr:::no_empty()
+     5.       └─cli::cli_abort(...)
+     6.         └─rlang::abort(...)
     Execution halted
+    ```
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      ══ Failed tests ════════════════════════════════════════════════════════════════
+      ── Error ('test_Upset.R:72'): get_Upset_list works ─────────────────────────────
+      Error in `stringr::str_detect(string = names(output_list), pattern = "")`: `pattern` can't be the empty string (`""`).
+      Backtrace:
+          ▆
+       1. └─mpwR::get_Upset_list(input_list = data, level = "Precursor.IDs") at test_Upset.R:72:3
+       2.   ├─base::which(...)
+       3.   └─stringr::str_detect(string = names(output_list), pattern = "")
+       4.     └─stringr:::no_empty()
+       5.       └─cli::cli_abort(...)
+       6.         └─rlang::abort(...)
+      
+      [ FAIL 1 | WARN 553 | SKIP 0 | PASS 598 ]
+      Error: Test failures
+      Execution halted
     ```
 
 *   checking re-building of vignette outputs ... WARNING
     ```
     Error(s) in re-building vignettes:
+    --- re-building ‘Import.Rmd’ using rmarkdown
+    --- finished re-building ‘Import.Rmd’
+    
+    --- re-building ‘Requirements.Rmd’ using rmarkdown
+    --- finished re-building ‘Requirements.Rmd’
+    
+    --- re-building ‘Workflow.Rmd’ using rmarkdown
+    
+    Attaching package: 'dplyr'
+    ...
+    Quitting from lines 225-226 (Workflow.Rmd) 
+    Error: processing vignette 'Workflow.Rmd' failed with diagnostics:
+    `pattern` can't be the empty string (`""`).
+    --- failed re-building ‘Workflow.Rmd’
+    
+    SUMMARY: processing the following file failed:
+      ‘Workflow.Rmd’
+    
+    Error: Vignette re-building failed.
+    Execution halted
+    ```
+
+# openalexR
+
+<details>
+
+* Version: 1.0.0
+* GitHub: https://github.com/massimoaria/openalexR
+* Source code: https://github.com/cran/openalexR
+* Date/Publication: 2022-10-06 10:40:02 UTC
+* Number of recursive dependencies: 78
+
+Run `cloud_details(, "openalexR")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... WARNING
+    ```
+    Error(s) in re-building vignettes:
       ...
-    --- re-building ‘hacksig.Rmd’ using rmarkdown
+    --- re-building ‘A_Brief_Introduction_to_openalexR.Rmd’ using rmarkdown
     
     Attaching package: 'dplyr'
     
@@ -394,136 +316,29 @@ Run `cloud_details(, "hacksig")` for more info
         filter, lag
     
     ...
-    Arguments in `...` must be used.
-    ✖ Problematic argument:
-    • ..1 = c("sample_id", "raw", "ips")
-    --- failed re-building ‘hacksig.Rmd’
+    Quitting from lines 207-213 (A_Brief_Introduction_to_openalexR.Rmd) 
+    Error: processing vignette 'A_Brief_Introduction_to_openalexR.Rmd' failed with diagnostics:
+    $ operator is invalid for atomic vectors
+    --- failed re-building ‘A_Brief_Introduction_to_openalexR.Rmd’
     
     SUMMARY: processing the following file failed:
-      ‘hacksig.Rmd’
+      ‘A_Brief_Introduction_to_openalexR.Rmd’
     
     Error: Vignette re-building failed.
     Execution halted
     ```
 
-# psfmi
+# recipes
 
 <details>
 
-* Version: 1.0.0
-* GitHub: https://github.com/mwheymans/psfmi
-* Source code: https://github.com/cran/psfmi
-* Date/Publication: 2021-09-23 10:10:05 UTC
-* Number of recursive dependencies: 152
+* Version: 1.0.3
+* GitHub: https://github.com/tidymodels/recipes
+* Source code: https://github.com/cran/recipes
+* Date/Publication: 2022-11-09 16:50:02 UTC
+* Number of recursive dependencies: 134
 
-Run `cloud_details(, "psfmi")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-    --- re-building ‘MI_boot.Rmd’ using rmarkdown
-    --- finished re-building ‘MI_boot.Rmd’
-    
-    --- re-building ‘MI_cv_naive.Rmd’ using rmarkdown
-    --- finished re-building ‘MI_cv_naive.Rmd’
-    
-    --- re-building ‘Pool_Model_Performance.Rmd’ using rmarkdown
-    --- finished re-building ‘Pool_Model_Performance.Rmd’
-    
-    ...
-    --- failed re-building ‘psfmi_StabilityAnalysis.Rmd’
-    
-    --- re-building ‘psfmi_mice.Rmd’ using rmarkdown
-    --- finished re-building ‘psfmi_mice.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘psfmi_StabilityAnalysis.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
-    ```
-
-## In both
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespace in Imports field not imported from: ‘miceadds’
-      All declared Imports should be used.
-    ```
-
-# rmdcev
-
-<details>
-
-* Version: 1.2.4
-* GitHub: https://github.com/plloydsmith/rmdcev
-* Source code: https://github.com/cran/rmdcev
-* Date/Publication: 2020-09-30 18:40:02 UTC
-* Number of recursive dependencies: 84
-
-Run `cloud_details(, "rmdcev")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-        3. │   ├─base::t(GrabParms(est_sim, "scale"))
-        4. │   └─rmdcev:::GrabParms(est_sim, "scale")
-        5. │     └─... %>% as.matrix(.)
-        6. ├─base::as.matrix(.)
-        7. ├─dplyr::select(., -sim_id)
-        8. └─tidyr::pivot_wider(., sim_id, names_from = "parms", values_from = "value")
-        9.   └─rlang `<fn>`()
-       10.     └─rlang:::check_dots(env, error, action, call)
-       11.       └─rlang:::action_dots(...)
-       12.         ├─base try_dots(...)
-       13.         └─rlang action(...)
-      
-      [ FAIL 15 | WARN 0 | SKIP 1 | PASS 54 ]
-      Error: Test failures
-      Execution halted
-    ```
-
-## In both
-
-*   checking installed package size ... NOTE
-    ```
-      installed size is 114.5Mb
-      sub-directories of 1Mb or more:
-        libs  113.7Mb
-    ```
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespace in Imports field not imported from: ‘RcppParallel’
-      All declared Imports should be used.
-    ```
-
-*   checking for GNU extensions in Makefiles ... NOTE
-    ```
-    GNU make is a SystemRequirements.
-    ```
-
-# simITS
-
-<details>
-
-* Version: 0.1.1
-* GitHub: NA
-* Source code: https://github.com/cran/simITS
-* Date/Publication: 2020-05-20 13:50:02 UTC
-* Number of recursive dependencies: 78
-
-Run `cloud_details(, "simITS")` for more info
+Run `cloud_details(, "recipes")` for more info
 
 </details>
 
@@ -531,26 +346,26 @@ Run `cloud_details(, "simITS")` for more info
 
 *   checking examples ... ERROR
     ```
-    Running examples in ‘simITS-Ex.R’ failed
+    Running examples in ‘recipes-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: adjust_data
-    > ### Title: Adjust an outcome time series based on the group weights.
-    > ### Aliases: adjust_data
+    > ### Name: step_naomit
+    > ### Title: Remove observations with missing values
+    > ### Aliases: step_naomit
     > 
     > ### ** Examples
     > 
-    > data( "meck_subgroup" )
+    > 
     ...
-        ▆
-     1. ├─simITS::aggregate_data(...)
-     2. │ └─... %>% ...
-     3. └─tidyr::pivot_wider(...)
-     4.   └─rlang `<fn>`()
-     5.     └─rlang:::check_dots(env, error, action, call)
-     6.       └─rlang:::action_dots(...)
-     7.         ├─base try_dots(...)
-     8.         └─rlang action(...)
+     10.       └─tidyselect::eval_select(expr(c(!!!dots)), data, allow_rename = FALSE)
+     11.         └─tidyselect:::eval_select_impl(...)
+     12.           ├─tidyselect:::with_subscript_errors(...)
+     13.           │ └─rlang::try_fetch(...)
+     14.           │   └─base::withCallingHandlers(...)
+     15.           └─tidyselect:::vars_select_eval(...)
+     16.             └─tidyselect:::ensure_named(...)
+     17.               └─cli::cli_abort(...)
+     18.                 └─rlang::abort(...)
     Execution halted
     ```
 
@@ -559,143 +374,75 @@ Run `cloud_details(, "simITS")` for more info
       Running ‘testthat.R’
     Running the tests in ‘tests/testthat.R’ failed.
     Last 13 lines of output:
-      • ..1 = month
-      Backtrace:
-          ▆
-       1. ├─simITS::aggregate_data(meck, "pbail", "category", Nname = "N") at test-post_stratified_ITS.R:45:2
-       2. │ └─... %>% ...
-       3. └─tidyr::pivot_wider(...)
-       4.   └─rlang `<fn>`()
-       5.     └─rlang:::check_dots(env, error, action, call)
-       6.       └─rlang:::action_dots(...)
-       7.         ├─base try_dots(...)
-       8.         └─rlang action(...)
+        9.     ├─tidyr::drop_na(new_data, object$columns)
+       10.     └─tidyr:::drop_na.data.frame(new_data, object$columns)
+       11.       └─tidyselect::eval_select(expr(c(!!!dots)), data, allow_rename = FALSE)
+       12.         └─tidyselect:::eval_select_impl(...)
+       13.           ├─tidyselect:::with_subscript_errors(...)
+       14.           │ └─rlang::try_fetch(...)
+       15.           │   └─base::withCallingHandlers(...)
+       16.           └─tidyselect:::vars_select_eval(...)
+       17.             └─tidyselect:::ensure_named(...)
+       18.               └─cli::cli_abort(...)
+       19.                 └─rlang::abort(...)
       
-      [ FAIL 2 | WARN 0 | SKIP 0 | PASS 78 ]
+      [ FAIL 2 | WARN 2 | SKIP 401 | PASS 1889 ]
       Error: Test failures
       Execution halted
     ```
 
-# surveil
+## In both
+
+*   checking Rd cross-references ... NOTE
+    ```
+    Packages unavailable to check Rd xrefs: ‘fastICA’, ‘dimRed’
+    ```
+
+# tidyfst
 
 <details>
 
-* Version: 0.2.0
-* GitHub: https://github.com/ConnorDonegan/surveil
-* Source code: https://github.com/cran/surveil
-* Date/Publication: 2022-04-03 18:40:02 UTC
-* Number of recursive dependencies: 94
+* Version: 1.7.5
+* GitHub: https://github.com/hope-data-science/tidyfst
+* Source code: https://github.com/cran/tidyfst
+* Date/Publication: 2022-10-27 07:00:02 UTC
+* Number of recursive dependencies: 80
 
-Run `cloud_details(, "surveil")` for more info
+Run `cloud_details(, "tidyfst")` for more info
 
 </details>
 
 ## Newly broken
 
-*   checking tests ... ERROR
+*   checking examples ... ERROR
     ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      Backtrace:
-          ▆
-       1. ├─surveil::stan_rw(...) at test_rw.R:141:4
-       2. │ └─... %>% dplyr::select(-c(.data$id))
-       3. ├─dplyr::select(., -c(.data$id))
-       4. └─tidyr::pivot_wider(...)
-       5.   └─rlang `<fn>`()
-       6.     └─rlang:::check_dots(env, error, action, call)
-       7.       └─rlang:::action_dots(...)
-       8.         ├─base try_dots(...)
-       9.         └─rlang action(...)
-      
-      [ FAIL 8 | WARN 11 | SKIP 0 | PASS 3 ]
-      Error: Test failures
-      Execution halted
-    ```
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-    --- re-building ‘age-standardization.Rmd’ using rmarkdown
-    Quitting from lines 115-122 (age-standardization.Rmd) 
-    Error: processing vignette 'age-standardization.Rmd' failed with diagnostics:
-    Arguments in `...` must be used.
-    ✖ Problematic argument:
-    • ..1 = id
-    --- failed re-building ‘age-standardization.Rmd’
+    Running examples in ‘tidyfst-Ex.R’ failed
+    The error most likely occurred in:
     
-    --- re-building ‘demonstration.Rmd’ using rmarkdown
+    > ### Name: unite_dt
+    > ### Title: Unite multiple columns into one by pasting strings together
+    > ### Aliases: unite_dt
+    > 
+    > ### ** Examples
+    > 
+    > df <- expand.grid(x = c("a", NA), y = c("b", NA))
     ...
-    Arguments in `...` must be used.
-    ✖ Problematic argument:
-    • ..1 = id
-    --- failed re-building ‘demonstration.Rmd’
-    
-    SUMMARY: processing the following files failed:
-      ‘age-standardization.Rmd’ ‘demonstration.Rmd’
-    
-    Error: Vignette re-building failed.
+      2. ├─tidyfst::unite_dt(., "merged_name", "")
+      3. │ └─dt %>% select_dt(...)
+      4. ├─tidyfst::select_dt(., ...)
+      5. │ └─... %>% str_c(collapse = ",")
+      6. ├─stringr::str_c(., collapse = ",")
+      7. └─stringr::str_subset(names(dt), ., negate = negate)
+      8.   └─stringr:::no_empty()
+      9.     └─cli::cli_abort(...)
+     10.       └─rlang::abort(...)
     Execution halted
     ```
 
 ## In both
 
-*   checking installed package size ... NOTE
+*   checking Rd cross-references ... NOTE
     ```
-      installed size is 75.9Mb
-      sub-directories of 1Mb or more:
-        libs  74.7Mb
-    ```
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespaces in Imports field not imported from:
-      ‘RcppParallel’ ‘rstantools’
-      All declared Imports should be used.
-    ```
-
-*   checking for GNU extensions in Makefiles ... NOTE
-    ```
-    GNU make is a SystemRequirements.
-    ```
-
-# tsibble
-
-<details>
-
-* Version: 1.1.1
-* GitHub: https://github.com/tidyverts/tsibble
-* Source code: https://github.com/cran/tsibble
-* Date/Publication: 2021-12-03 21:30:02 UTC
-* Number of recursive dependencies: 94
-
-Run `cloud_details(, "tsibble")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘spelling.R’
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-        3. │   └─testthat:::quasi_capture(...)
-        4. │     ├─testthat .capture(...)
-        5. │     │ └─base::withCallingHandlers(...)
-        6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
-        7. ├─tsbl %>% pivot_wider(qtr, names_from = qtr, values_from = value)
-        8. ├─tidyr::pivot_wider(., qtr, names_from = qtr, values_from = value)
-        9. └─rlang `<fn>`()
-       10.   └─rlang:::check_dots(env, error, action, call)
-       11.     └─rlang:::action_dots(...)
-       12.       ├─base try_dots(...)
-       13.       └─rlang action(...)
-      
-      [ FAIL 1 | WARN 1 | SKIP 5 | PASS 743 ]
-      Error: Test failures
-      Execution halted
+    Packages unavailable to check Rd xrefs: ‘fastDummies’, ‘widyr’, ‘pacman’, ‘sjmisc’
     ```
 

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -185,7 +185,7 @@
       (expect_error(pivot_longer(df, c(x, y), 1)))
     Output
       <error/rlib_error_dots_unused>
-      Error:
+      Error in `pivot_longer()`:
       ! Arguments in `...` must be used.
       x Problematic argument:
       * ..1 = 1
@@ -193,7 +193,7 @@
       (expect_error(pivot_longer(df, c(x, y), col_vary = "slowest")))
     Output
       <error/rlib_error_dots_unused>
-      Error:
+      Error in `pivot_longer()`:
       ! Arguments in `...` must be used.
       x Problematic argument:
       * col_vary = "slowest"

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -179,3 +179,62 @@
       Error in `pivot_longer_spec()`:
       ! `cols_vary` must be a string or character vector.
 
+# `pivot_longer()` catches unused input passed through the dots
+
+    Code
+      (expect_error(pivot_longer(df, c(x, y), 1)))
+    Output
+      <error/rlib_error_dots_unused>
+      Error:
+      ! Arguments in `...` must be used.
+      x Problematic argument:
+      * ..1 = 1
+    Code
+      (expect_error(pivot_longer(df, c(x, y), col_vary = "slowest")))
+    Output
+      <error/rlib_error_dots_unused>
+      Error:
+      ! Arguments in `...` must be used.
+      x Problematic argument:
+      * col_vary = "slowest"
+
+# `build_longer_spec()` requires empty dots
+
+    Code
+      (expect_error(build_longer_spec(df, c(x, y), 1)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `build_longer_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 1
+      i Did you forget to name an argument?
+    Code
+      (expect_error(build_longer_spec(df, c(x, y), name_to = "name")))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `build_longer_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * name_to = "name"
+
+# `pivot_longer_spec()` requires empty dots
+
+    Code
+      (expect_error(pivot_longer_spec(df, spec, 1)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `pivot_longer_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 1
+      i Did you forget to name an argument?
+    Code
+      (expect_error(pivot_longer_spec(df, spec, col_vary = "slowest")))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `pivot_longer_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * col_vary = "slowest"
+

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -295,7 +295,7 @@
       out <- pivot_wider(df, id)
     Condition
       Warning:
-      Specifying the `id_cols` argument by position was deprecated in tidyr 1.2.2.
+      Specifying the `id_cols` argument by position was deprecated in tidyr 1.3.0.
       i Please explicitly name `id_cols`, like `id_cols = id`.
 
 ---

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -75,7 +75,7 @@
       (expect_error(pivot_wider(df, 1)))
     Output
       <error/rlib_error_dots_unused>
-      Error:
+      Error in `pivot_wider()`:
       ! Arguments in `...` must be used.
       x Problematic argument:
       * ..1 = 1
@@ -83,7 +83,7 @@
       (expect_error(pivot_wider(df, name_prefix = "")))
     Output
       <error/rlib_error_dots_unused>
-      Error:
+      Error in `pivot_wider()`:
       ! Arguments in `...` must be used.
       x Problematic argument:
       * name_prefix = ""

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -69,25 +69,6 @@
       ! Applying `values_fn` to `value` must result in a single summary value per key.
       i Applying `values_fn` resulted in a vector of length 2.
 
-# `pivot_wider()` catches unused input passed through the dots
-
-    Code
-      (expect_error(pivot_wider(df, 1)))
-    Output
-      <error/rlib_error_dots_unused>
-      Error in `pivot_wider()`:
-      ! Arguments in `...` must be used.
-      x Problematic argument:
-      * ..1 = 1
-    Code
-      (expect_error(pivot_wider(df, name_prefix = "")))
-    Output
-      <error/rlib_error_dots_unused>
-      Error in `pivot_wider()`:
-      ! Arguments in `...` must be used.
-      x Problematic argument:
-      * name_prefix = ""
-
 # `build_wider_spec()` requires empty dots
 
     Code
@@ -307,4 +288,51 @@
       <error/rlang_error>
       Error in `pivot_wider_spec()`:
       ! `unused_fn` must be `NULL`, a function, or a named list of functions.
+
+# `id_cols` has noisy compat behavior (#1353)
+
+    Code
+      out <- pivot_wider(df, id)
+    Condition
+      Warning:
+      Specifying the `id_cols` argument by position was deprecated in tidyr 1.2.2.
+      i Please explicitly name `id_cols`, like `id_cols = id`.
+
+---
+
+    Code
+      expect <- pivot_wider(df, id_cols = id)
+
+# `id_cols` compat behavior doesn't trigger if `id_cols` is specified too
+
+    Code
+      pivot_wider(df, id, id_cols = id2)
+    Condition
+      Error in `pivot_wider()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = id
+      i Did you forget to name an argument?
+
+# `id_cols` compat behavior doesn't trigger if multiple `...` are supplied
+
+    Code
+      pivot_wider(df, id, id2)
+    Condition
+      Error in `pivot_wider()`:
+      ! `...` must be empty.
+      x Problematic arguments:
+      * ..1 = id
+      * ..2 = id2
+      i Did you forget to name an argument?
+
+# `id_cols` compat behavior doesn't trigger if named `...` are supplied
+
+    Code
+      pivot_wider(df, ids = id)
+    Condition
+      Error in `pivot_wider()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ids = id
 

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -69,6 +69,65 @@
       ! Applying `values_fn` to `value` must result in a single summary value per key.
       i Applying `values_fn` resulted in a vector of length 2.
 
+# `pivot_wider()` catches unused input passed through the dots
+
+    Code
+      (expect_error(pivot_wider(df, 1)))
+    Output
+      <error/rlib_error_dots_unused>
+      Error:
+      ! Arguments in `...` must be used.
+      x Problematic argument:
+      * ..1 = 1
+    Code
+      (expect_error(pivot_wider(df, name_prefix = "")))
+    Output
+      <error/rlib_error_dots_unused>
+      Error:
+      ! Arguments in `...` must be used.
+      x Problematic argument:
+      * name_prefix = ""
+
+# `build_wider_spec()` requires empty dots
+
+    Code
+      (expect_error(build_wider_spec(df, 1)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `build_wider_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 1
+      i Did you forget to name an argument?
+    Code
+      (expect_error(build_wider_spec(df, name_prefix = "")))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `build_wider_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * name_prefix = ""
+
+# `pivot_wider_spec()` requires empty dots
+
+    Code
+      (expect_error(pivot_wider_spec(df, spec, 1)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `pivot_wider_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 1
+      i Did you forget to name an argument?
+    Code
+      (expect_error(pivot_wider_spec(df, spec, name_repair = "check_unique")))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `pivot_wider_spec()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * name_repair = "check_unique"
+
 # `names_vary` is validated
 
     Code

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -483,3 +483,31 @@ test_that("`cols_vary` is validated", {
     (expect_error(pivot_longer(df, x, cols_vary = 1)))
   })
 })
+
+test_that("`pivot_longer()` catches unused input passed through the dots", {
+  df <- tibble(id = c("a", "b"), x = c(1, 2), y = c(3, 4))
+
+  expect_snapshot({
+    (expect_error(pivot_longer(df, c(x, y), 1)))
+    (expect_error(pivot_longer(df, c(x, y), col_vary = "slowest")))
+  })
+})
+
+test_that("`build_longer_spec()` requires empty dots", {
+  df <- tibble(id = c("a", "b"), x = c(1, 2), y = c(3, 4))
+
+  expect_snapshot({
+    (expect_error(build_longer_spec(df, c(x, y), 1)))
+    (expect_error(build_longer_spec(df, c(x, y), name_to = "name")))
+  })
+})
+
+test_that("`pivot_longer_spec()` requires empty dots", {
+  df <- tibble(id = c("a", "b"), x = c(1, 2), y = c(3, 4))
+  spec <- build_longer_spec(df, c(x, y))
+
+  expect_snapshot({
+    (expect_error(pivot_longer_spec(df, spec, 1)))
+    (expect_error(pivot_longer_spec(df, spec, col_vary = "slowest")))
+  })
+})

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -205,15 +205,6 @@ test_that("expansion with `id_expand` and `names_expand` works with zero row dat
   expect_identical(res$b, c(NA_integer_, NA_integer_))
 })
 
-test_that("`pivot_wider()` catches unused input passed through the dots", {
-  df <- tibble(name = c("x", "y", "z"), value = 1:3)
-
-  expect_snapshot({
-    (expect_error(pivot_wider(df, 1)))
-    (expect_error(pivot_wider(df, name_prefix = "")))
-  })
-})
-
 test_that("`build_wider_spec()` requires empty dots", {
   df <- tibble(name = c("x", "y", "z"), value = 1:3)
 
@@ -749,3 +740,66 @@ test_that("`unused_fn` is validated", {
     (expect_error(pivot_wider(df, id_cols = id, unused_fn = 1)))
   )
 })
+
+# deprecated ---------------------------------------------------------------
+
+test_that("`id_cols` has noisy compat behavior (#1353)", {
+  df <- tibble(
+    id = c(1, 2),
+    id2 = c(3, 4),
+    name = c("a", "b"),
+    value = c(5, 6)
+  )
+
+  # Noisy
+  expect_snapshot({
+    out <- pivot_wider(df, id)
+  })
+
+  # Silent
+  expect_snapshot({
+    expect <- pivot_wider(df, id_cols = id)
+  })
+
+  expect_identical(out, expect)
+})
+
+test_that("`id_cols` compat behavior doesn't trigger if `id_cols` is specified too", {
+  df <- tibble(
+    id = c(1, 2),
+    id2 = c(3, 4),
+    name = c("a", "b"),
+    value = c(5, 6)
+  )
+
+  expect_snapshot(error = TRUE, {
+    pivot_wider(df, id, id_cols = id2)
+  })
+})
+
+test_that("`id_cols` compat behavior doesn't trigger if multiple `...` are supplied", {
+  df <- tibble(
+    id = c(1, 2),
+    id2 = c(3, 4),
+    name = c("a", "b"),
+    value = c(5, 6)
+  )
+
+  expect_snapshot(error = TRUE, {
+    pivot_wider(df, id, id2)
+  })
+})
+
+test_that("`id_cols` compat behavior doesn't trigger if named `...` are supplied", {
+  df <- tibble(
+    id = c(1, 2),
+    id2 = c(3, 4),
+    name = c("a", "b"),
+    value = c(5, 6)
+  )
+
+  expect_snapshot(error = TRUE, {
+    pivot_wider(df, ids = id)
+  })
+})
+

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -205,6 +205,34 @@ test_that("expansion with `id_expand` and `names_expand` works with zero row dat
   expect_identical(res$b, c(NA_integer_, NA_integer_))
 })
 
+test_that("`pivot_wider()` catches unused input passed through the dots", {
+  df <- tibble(name = c("x", "y", "z"), value = 1:3)
+
+  expect_snapshot({
+    (expect_error(pivot_wider(df, 1)))
+    (expect_error(pivot_wider(df, name_prefix = "")))
+  })
+})
+
+test_that("`build_wider_spec()` requires empty dots", {
+  df <- tibble(name = c("x", "y", "z"), value = 1:3)
+
+  expect_snapshot({
+    (expect_error(build_wider_spec(df, 1)))
+    (expect_error(build_wider_spec(df, name_prefix = "")))
+  })
+})
+
+test_that("`pivot_wider_spec()` requires empty dots", {
+  df <- tibble(name = c("x", "y", "z"), value = 1:3)
+  spec <- build_wider_spec(df)
+
+  expect_snapshot({
+    (expect_error(pivot_wider_spec(df, spec, 1)))
+    (expect_error(pivot_wider_spec(df, spec, name_repair = "check_unique")))
+  })
+})
+
 # column names -------------------------------------------------------------
 
 test_that("names_glue affects output names", {
@@ -215,7 +243,12 @@ test_that("names_glue affects output names", {
     b = 1:2
   )
 
-  spec <- build_wider_spec(df, x:y, a:b, names_glue = "{x}{y}_{.value}")
+  spec <- build_wider_spec(
+    df,
+    names_from = x:y,
+    values_from = a:b,
+    names_glue = "{x}{y}_{.value}"
+  )
   expect_equal(spec$.name, c("X1_a", "Y2_a", "X1_b", "Y2_b"))
 })
 


### PR DESCRIPTION
Closes #1350 

- `pivot_longer()` and `pivot_wider()` dots have been moved to the front, after the required args but before any optional ones. `check_dots_used()` ensures that typos are caught.
- `pivot_longer_spec()`, `pivot_wider_spec()`, `build_longer_spec()`, and `build_wider_spec()` have all gained dots that are also placed up front. `check_dots_empty()` ensures that typos are caught.

This should make it much easier to extend these functions going forward. I see two big benefits:
- For developers: it should mean we can add arguments to the generic after the `...` and not automatically break any packages that have added S3 methods for these functions
- For users: it forces them to specify arguments by name, creating more robust and readable code. We will be able to add new arguments in any order we prefer and not have to worry about positional argument issues.

I'll run revdeps, I'm hoping it clears up the S3 related issues from here https://github.com/tidyverse/tidyr/pull/1347#issuecomment-1095147941