### PR TITLE
Update roxygen2 to 7.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,5 +49,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 SystemRequirements: C++11

--- a/man/deprecated-se.Rd
+++ b/man/deprecated-se.Rd
@@ -156,10 +156,8 @@ happens when there are too many pieces. There are three valid options:
 \item "merge": only splits at most \code{length(into)} times
 }}
 
-\item{drop}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}:
-all list-columns are now preserved; If there are any that you
-don't want in the output use \code{select()} to remove them prior to
-unnesting.}
+\item{drop}{If \code{FALSE}, will keep factor levels that don't appear in the
+data, filling in missing combinations with \code{fill}.}
 
 \item{from}{Names of existing columns as character vector}
 

--- a/man/nest.Rd
+++ b/man/nest.Rd
@@ -111,10 +111,12 @@ tidyr 1.0.0 introduced a new syntax for \code{nest()} and \code{unnest()} that's
 designed to be more similar to other functions. Converting to the new syntax
 should be straightforward (guided by the message you'll recieve) but if
 you just need to run an old analysis, you can easily revert to the previous
-behaviour using \code{\link[=nest_legacy]{nest_legacy()}} and \code{\link[=unnest_legacy]{unnest_legacy()}} as follows:\preformatted{library(tidyr)
+behaviour using \code{\link[=nest_legacy]{nest_legacy()}} and \code{\link[=unnest_legacy]{unnest_legacy()}} as follows:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{library(tidyr)
 nest <- nest_legacy
 unnest <- unnest_legacy
-}
+}\if{html}{\out{</div>}}
 }
 
 \section{Grouped data frames}{

--- a/man/nest_legacy.Rd
+++ b/man/nest_legacy.Rd
@@ -47,10 +47,12 @@ tidyr 1.0.0 introduced a new syntax for \code{\link[=nest]{nest()}} and \code{\l
 of existing usage should be automatically translated to the new syntax with a
 warning. However, if you need to quickly roll back to the previous behaviour,
 these functions provide the previous interface. To make old code work as is,
-add the following code to the top of your script:\preformatted{library(tidyr)
+add the following code to the top of your script:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{library(tidyr)
 nest <- nest_legacy
 unnest <- unnest_legacy
-}
+}\if{html}{\out{</div>}}
 }
 \examples{
 # Nest and unnest are inverses

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -64,29 +64,6 @@ in the \code{value_to} column. This effectively converts explicit missing values
 to implicit missing values, and should generally be used only when missing
 values in \code{data} were created by its structure.}
 
-\item{values_ptypes}{Optionally, a list of column name-prototype
-pairs. Alternatively, a single empty prototype can be supplied, which will
-be applied to all columns. A prototype (or ptype for short) is a
-zero-length vector (like \code{integer()} or \code{numeric()}) that defines the type,
-class, and attributes of a vector. Use these arguments if you want to
-confirm that the created columns are the types that you expect. Note that
-if you want to change (instead of confirm) the types of specific columns,
-you should use \code{names_transform} or \code{values_transform} instead.
-
-For backwards compatibility reasons, supplying \code{list()} is interpreted as
-being identical to \code{NULL} rather than as using a list prototype on all
-columns. Expect this to change in the future.}
-
-\item{values_transform}{Optionally, a list of column
-name-function pairs. Alternatively, a single function can be supplied,
-which will be applied to all columns. Use these arguments if you need to
-change the types of specific columns. For example, \code{names_transform = list(week = as.integer)} would convert a character variable called \code{week}
-to an integer.
-
-If not specified, the type of the columns generated from \code{names_to} will
-be character, and the type of the variables generated from \code{values_to}
-will be the common type of the input columns used to generate them.}
-
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pivot into
 longer format.}
 
@@ -118,7 +95,7 @@ existing column names.}
 \item{names_prefix}{A regular expression used to remove matching text
 from the start of each variable name.}
 
-\item{names_sep}{If \code{names_to} contains multiple values,
+\item{names_sep, names_pattern}{If \code{names_to} contains multiple values,
 these arguments control how the column name is broken up.
 
 \code{names_sep} takes the same specification as \code{\link[=separate]{separate()}}, and can either
@@ -132,21 +109,7 @@ If these arguments do not give you enough control, use
 \code{pivot_longer_spec()} to create a spec object and process manually as
 needed.}
 
-\item{names_pattern}{If \code{names_to} contains multiple values,
-these arguments control how the column name is broken up.
-
-\code{names_sep} takes the same specification as \code{\link[=separate]{separate()}}, and can either
-be a numeric vector (specifying positions to break on), or a single string
-(specifying a regular expression to split on).
-
-\code{names_pattern} takes the same specification as \code{\link[=extract]{extract()}}, a regular
-expression containing matching groups (\verb{()}).
-
-If these arguments do not give you enough control, use
-\code{pivot_longer_spec()} to create a spec object and process manually as
-needed.}
-
-\item{names_ptypes}{Optionally, a list of column name-prototype
+\item{names_ptypes, values_ptypes}{Optionally, a list of column name-prototype
 pairs. Alternatively, a single empty prototype can be supplied, which will
 be applied to all columns. A prototype (or ptype for short) is a
 zero-length vector (like \code{integer()} or \code{numeric()}) that defines the type,
@@ -159,7 +122,7 @@ For backwards compatibility reasons, supplying \code{list()} is interpreted as
 being identical to \code{NULL} rather than as using a list prototype on all
 columns. Expect this to change in the future.}
 
-\item{names_transform}{Optionally, a list of column
+\item{names_transform, values_transform}{Optionally, a list of column
 name-function pairs. Alternatively, a single function can be supplied,
 which will be applied to all columns. Use these arguments if you need to
 change the types of specific columns. For example, \code{names_transform = list(week = as.integer)} would convert a character variable called \code{week}

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -91,15 +91,7 @@ all unspecified columns will be considered \code{id_cols}.
 This is similar to grouping by the \code{id_cols} then summarizing the
 unused columns using \code{unused_fn}.}
 
-\item{names_from}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A pair of
-arguments describing which column (or columns) to get the name of the
-output column (\code{names_from}), and which column (or columns) to get the
-cell values from (\code{values_from}).
-
-If \code{values_from} contains multiple values, the value will be added to the
-front of the output column.}
-
-\item{values_from}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A pair of
+\item{names_from, values_from}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A pair of
 arguments describing which column (or columns) to get the name of the
 output column (\code{names_from}), and which column (or columns) to get the
 cell values from (\code{values_from}).

--- a/man/tidyr-package.Rd
+++ b/man/tidyr-package.Rd
@@ -6,7 +6,7 @@
 \alias{tidyr-package}
 \title{tidyr: Tidy Messy Data}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
 Tools to help to create tidy data, where each column is a variable, each row is an observation, and each cell contains a single value. 'tidyr' contains tools for changing the shape (pivoting) and hierarchy (nesting and 'unnesting') of a dataset, turning deeply nested lists into rectangular data frames ('rectangling'), and extracting values out of string columns. It also includes tools for working with missing values (both implicit and explicit).
 }


### PR DESCRIPTION
- Fixed an incorrectly linked `drop` argument in the `spread_()` docs (it previously linked to the deprecated `.drop` of `unnest()`)
- Greatly improved the `pivot_longer_spec()` and `pivot_wider_spec()` docs through directly inheriting pairs of arguments like `names_sep, names_pattern`