### PR TITLE
Bump rlang version and update snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     lifecycle,
     magrittr,
     purrr,
-    rlang (>= 1.0.2),
+    rlang (>= 1.0.4),
     tibble (>= 2.1.1),
     tidyselect (>= 1.1.0),
     utils,

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -168,6 +168,6 @@
       (expect_error(pivot_longer(df, x, cols_vary = 1)))
     Output
       <error/rlang_error>
-      Error in `arg_match0()`:
+      Error in `pivot_longer_spec()`:
       ! `cols_vary` must be a string or character vector.
 

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -75,7 +75,7 @@
       (expect_error(build_wider_spec(df, names_vary = 1)))
     Output
       <error/rlang_error>
-      Error in `arg_match0()`:
+      Error in `build_wider_spec()`:
       ! `names_vary` must be a string or character vector.
     Code
       (expect_error(build_wider_spec(df, names_vary = "x")))


### PR DESCRIPTION
rlang 1.0.3 fixed the `arg_match0()` call bug