### PR TITLE
Make import of data from classroom.csv and classroom2.csv consistent in tidy-data.Rmd vignette

### DIFF
--- a/vignettes/tidy-data.Rmd
+++ b/vignettes/tidy-data.Rmd
@@ -37,14 +37,26 @@ Like families, tidy datasets are all alike but every messy dataset is messy in i
 Most statistical datasets are data frames made up of **rows** and **columns**. The columns are almost always labeled and the rows are sometimes labeled. The following code provides some data about an imaginary classroom in a format commonly seen in the wild. The table has three columns and four rows, and both rows and columns are labeled.
 
 ```{r}
-classroom <- read.csv("classroom.csv", stringsAsFactors = FALSE, colClasses = "character")
+library(tibble)
+classroom <- tribble(
+  ~name, ~quiz1, ~quiz2, ~test1,
+  "Billy", NA, "D", "C",
+  "Suzy", "F", NA, NA,
+  "Lionel", "B", "C", "B",
+  "Jenny", "A", "A", "B"
+  )
 classroom
 ```
 
 There are many ways to structure the same underlying data. The following table shows the same data as above, but the rows and columns have been transposed.
 
 ```{r}
-read.csv("classroom2.csv", stringsAsFactors = FALSE, colClasses = "character")
+tribble(
+  ~assessment, ~Billy, ~Suzy, ~Lionel, ~Jenny,
+  "quiz1", NA, "F", "B", "A",
+  "quiz2", "D", NA, "C", "A",
+  "test1", "C", NA, "B", "B"
+  )
 ```
 
 The data is the same, but the layout is different. Our vocabulary of rows and columns is simply not rich enough to describe why the two tables represent the same data. In addition to appearance, we need a way to describe the underlying semantics, or meaning, of the values displayed in the table.

--- a/vignettes/tidy-data.Rmd
+++ b/vignettes/tidy-data.Rmd
@@ -37,14 +37,14 @@ Like families, tidy datasets are all alike but every messy dataset is messy in i
 Most statistical datasets are data frames made up of **rows** and **columns**. The columns are almost always labeled and the rows are sometimes labeled. The following code provides some data about an imaginary classroom in a format commonly seen in the wild. The table has three columns and four rows, and both rows and columns are labeled.
 
 ```{r}
-classroom <- read.csv("classroom.csv", stringsAsFactors = FALSE)
+classroom <- read.csv("classroom.csv", stringsAsFactors = FALSE, colClasses = "character")
 classroom
 ```
 
 There are many ways to structure the same underlying data. The following table shows the same data as above, but the rows and columns have been transposed.
 
 ```{r}
-read.csv("classroom2.csv", stringsAsFactors = FALSE)
+read.csv("classroom2.csv", stringsAsFactors = FALSE, colClasses = "character")
 ```
 
 The data is the same, but the layout is different. Our vocabulary of rows and columns is simply not rich enough to describe why the two tables represent the same data. In addition to appearance, we need a way to describe the underlying semantics, or meaning, of the values displayed in the table.

--- a/vignettes/tidy-data.Rmd
+++ b/vignettes/tidy-data.Rmd
@@ -39,11 +39,11 @@ Most statistical datasets are data frames made up of **rows** and **columns**. T
 ```{r}
 library(tibble)
 classroom <- tribble(
-  ~name, ~quiz1, ~quiz2, ~test1,
-  "Billy", NA, "D", "C",
-  "Suzy", "F", NA, NA,
-  "Lionel", "B", "C", "B",
-  "Jenny", "A", "A", "B"
+  ~name,    ~quiz1, ~quiz2, ~test1,
+  "Billy",  NA,     "D",    "C",
+  "Suzy",   "F",    NA,     NA,
+  "Lionel", "B",    "C",    "B",
+  "Jenny",  "A",    "A",    "B"
   )
 classroom
 ```
@@ -53,9 +53,9 @@ There are many ways to structure the same underlying data. The following table s
 ```{r}
 tribble(
   ~assessment, ~Billy, ~Suzy, ~Lionel, ~Jenny,
-  "quiz1", NA, "F", "B", "A",
-  "quiz2", "D", NA, "C", "A",
-  "test1", "C", NA, "B", "B"
+  "quiz1",     NA,     "F",   "B",     "A",
+  "quiz2",     "D",    NA,    "C",     "A",
+  "test1",     "C",    NA,    "B",     "B"
   )
 ```
 


### PR DESCRIPTION
In the vignette tidy-data.Rmd, when you read the example data from classroom2.csv:

```R
read.csv("classroom2.csv", stringsAsFactors = FALSE)
```

Suzy's grade on quiz1 should be `"F"` but it's read as `FALSE`. That's because of `read.csv()` defaults. This fix is needed for consistency with the previous example:

```R
classroom <- read.csv("classroom.csv", stringsAsFactors = FALSE)
```