### PR TITLE
Fix `pivotting` -> `pivoting` + misc typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -386,7 +386,7 @@
     ```
     
 * `pivot_wider()` gains a `names_sort` argument which allows you to sort
-  column names in order. The default, `FALSE`, orders columms by their 
+  column names in order. The default, `FALSE`, orders columns by their 
   first appearance (#839). In a future version, I'll consider changing the
   default to `TRUE`.
 
@@ -824,7 +824,7 @@ backend.
 
 - Following the switch to tidy evaluation, you might see warnings
   about the "variable context not set". This is most likely caused by
-  supplyng helpers like `everything()` to underscored versions of
+  supplying helpers like `everything()` to underscored versions of
   tidyr verbs. Helpers should be always be evaluated lazily. To fix
   this, just quote the helper with a formula: `drop_na(df,
   ~everything())`.
@@ -1006,7 +1006,7 @@ following changes:
 
 * Made compatible with both dplyr 0.4 and 0.5.
 
-* tidyr functions that create new columns are more aggresive about re-encoding
+* tidyr functions that create new columns are more aggressive about re-encoding
   the column names as UTF-8. 
 
 # tidyr 0.4.1
@@ -1147,7 +1147,7 @@ following changes:
 * `extract_numeric()` preserves negative signs (#20).
 
 * `gather()` has better defaults if `key` and `value` are not supplied.
-  If `...` is ommitted, `gather()` selects all columns (#28). Performance
+  If `...` is omitted, `gather()` selects all columns (#28). Performance
   is now comparable to `reshape2::melt()` (#18).
 
 * `separate()` gains `extra` argument which lets you control what happens

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -199,8 +199,8 @@ pivot_longer.data.frame <- function(data,
 
 #' Pivot data from wide to long using a spec
 #'
-#' This is a low level interface to pivotting, inspired by the cdata package,
-#' that allows you to describe pivotting with a data frame.
+#' This is a low level interface to pivoting, inspired by the cdata package,
+#' that allows you to describe pivoting with a data frame.
 #'
 #' @keywords internal
 #' @export
@@ -215,7 +215,7 @@ pivot_longer.data.frame <- function(data,
 #'   long format of the dataset and contain values corresponding to columns
 #'   pivoted from the wide format.
 #'   The special `.seq` variable is used to disambiguate rows internally;
-#'   it is automatically removed after pivotting.
+#'   it is automatically removed after pivoting.
 #'
 #' @examples
 #' # See vignette("pivot") for examples and explanation
@@ -443,7 +443,7 @@ drop_cols <- function(df, cols) {
 }
 
 # Ensure that there's a one-to-one match from spec to data by adding
-# a special .seq variable which is automatically removed after pivotting.
+# a special .seq variable which is automatically removed after pivoting.
 deduplicate_spec <- function(spec, df) {
 
   # Ensure each .name has a unique output identifier

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -14,7 +14,7 @@
 #' under active development.
 #'
 #' @seealso [pivot_wider_spec()] to pivot "by hand" with a data frame that
-#'   defines a pivotting specification.
+#'   defines a pivoting specification.
 #' @inheritParams pivot_longer
 #' @param id_cols <[`tidy-select`][tidyr_tidy_select]> A set of columns that
 #'   uniquely identify each observation. Typically used when you have
@@ -234,8 +234,8 @@ pivot_wider.data.frame <- function(data,
 
 #' Pivot data from long to wide using a spec
 #'
-#' This is a low level interface to pivotting, inspired by the cdata package,
-#' that allows you to describe pivotting with a data frame.
+#' This is a low level interface to pivoting, inspired by the cdata package,
+#' that allows you to describe pivoting with a data frame.
 #'
 #' @keywords internal
 #' @export
@@ -250,7 +250,7 @@ pivot_wider.data.frame <- function(data,
 #'   long format of the dataset and contain values corresponding to columns
 #'   pivoted from the wide format.
 #'   The special `.seq` variable is used to disambiguate rows internally;
-#'   it is automatically removed after pivotting.
+#'   it is automatically removed after pivoting.
 #' @param id_cols <[`tidy-select`][tidyr_tidy_select]> A set of columns that
 #'   uniquely identifies each observation. Defaults to all columns in `data`
 #'   except for the columns specified in `spec$.value` and the columns of the

--- a/README.Rmd
+++ b/README.Rmd
@@ -56,7 +56,7 @@ library(tidyr)
 
 tidyr functions fall into five main categories:
 
-* "Pivotting" which converts between long and wide forms. tidyr 1.0.0 
+* "Pivoting" which converts between long and wide forms. tidyr 1.0.0 
   introduces `pivot_longer()` and `pivot_wider()`, replacing the older 
   `spread()` and `gather()` functions. See `vignette("pivot")` for more 
   details.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ library(tidyr)
 
 tidyr functions fall into five main categories:
 
--   “Pivotting” which converts between long and wide forms. tidyr 1.0.0
+-   “Pivoting” which converts between long and wide forms. tidyr 1.0.0
     introduces `pivot_longer()` and `pivot_wider()`, replacing the older
     `spread()` and `gather()` functions. See `vignette("pivot")` for
     more details.

--- a/man/check_pivot_spec.Rd
+++ b/man/check_pivot_spec.Rd
@@ -16,7 +16,7 @@ Additional columns in \code{spec} should be named to match columns in the
 long format of the dataset and contain values corresponding to columns
 pivoted from the wide format.
 The special \code{.seq} variable is used to disambiguate rows internally;
-it is automatically removed after pivotting.}
+it is automatically removed after pivoting.}
 }
 \description{
 \code{check_pivot_spec()} is a developer facing helper function for validating

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -41,7 +41,7 @@ Additional columns in \code{spec} should be named to match columns in the
 long format of the dataset and contain values corresponding to columns
 pivoted from the wide format.
 The special \code{.seq} variable is used to disambiguate rows internally;
-it is automatically removed after pivotting.}
+it is automatically removed after pivoting.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
@@ -137,8 +137,8 @@ be character, and the type of the variables generated from \code{values_to}
 will be the common type of the input columns used to generate them.}
 }
 \description{
-This is a low level interface to pivotting, inspired by the cdata package,
-that allows you to describe pivotting with a data frame.
+This is a low level interface to pivoting, inspired by the cdata package,
+that allows you to describe pivoting with a data frame.
 }
 \examples{
 # See vignette("pivot") for examples and explanation

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -197,5 +197,5 @@ warpbreaks \%>\%
 }
 \seealso{
 \code{\link[=pivot_wider_spec]{pivot_wider_spec()}} to pivot "by hand" with a data frame that
-defines a pivotting specification.
+defines a pivoting specification.
 }

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -42,7 +42,7 @@ Additional columns in \code{spec} should be named to match columns in the
 long format of the dataset and contain values corresponding to columns
 pivoted from the wide format.
 The special \code{.seq} variable is used to disambiguate rows internally;
-it is automatically removed after pivotting.}
+it is automatically removed after pivoting.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
@@ -136,8 +136,8 @@ represented in the data will become explicit. Additionally, the column
 names will be sorted, identical to what \code{names_sort} would produce.}
 }
 \description{
-This is a low level interface to pivotting, inspired by the cdata package,
-that allows you to describe pivotting with a data frame.
+This is a low level interface to pivoting, inspired by the cdata package,
+that allows you to describe pivoting with a data frame.
 }
 \examples{
 # See vignette("pivot") for examples and explanation

--- a/vignettes/pivot.Rmd
+++ b/vignettes/pivot.Rmd
@@ -193,7 +193,7 @@ Doing it this way is a little more efficient than doing a mutate after the fact,
 
 ### Multiple observations per row
 
-So far, we have been working with data frames that have one observation per row, but many important pivotting problems involve multiple observations per row. You can usually recognise this case because name of the column that you want to appear in the output is part of the column name in the input. In this section, you'll learn how to pivot this sort of data. 
+So far, we have been working with data frames that have one observation per row, but many important pivoting problems involve multiple observations per row. You can usually recognise this case because name of the column that you want to appear in the output is part of the column name in the input. In this section, you'll learn how to pivot this sort of data. 
 
 The following example is adapted from the [data.table vignette](https://CRAN.R-project.org/package=data.table/vignettes/datatable-reshape.html), as inspiration for tidyr's solution to this problem.
 
@@ -569,7 +569,7 @@ contacts %>%
 
 ## Longer, then wider
 
-Some problems can't be solved by pivotting in a single direction. The examples in this section show how you might combine `pivot_longer()` and `pivot_wider()` to solve more complex problems.
+Some problems can't be solved by pivoting in a single direction. The examples in this section show how you might combine `pivot_longer()` and `pivot_wider()` to solve more complex problems.
 
 ### World bank
 
@@ -656,11 +656,11 @@ multi2 %>%
 
 ## Manual specs
 
-The arguments to `pivot_longer()` and `pivot_wider()` allow you to pivot a wide range of datasets. But the creativity that people apply to their data structures is seemingly endless, so it's quite possible that you will encounter a dataset that you can't immediately see how to reshape with `pivot_longer()` and `pivot_wider()`. To gain more control over pivotting, you can instead create a "spec" data frame that describes exactly how data stored in the column names becomes variables (and vice versa). This section introduces you to the spec data structure, and show you how to use it when `pivot_longer()` and `pivot_wider()` are insufficient.
+The arguments to `pivot_longer()` and `pivot_wider()` allow you to pivot a wide range of datasets. But the creativity that people apply to their data structures is seemingly endless, so it's quite possible that you will encounter a dataset that you can't immediately see how to reshape with `pivot_longer()` and `pivot_wider()`. To gain more control over pivoting, you can instead create a "spec" data frame that describes exactly how data stored in the column names becomes variables (and vice versa). This section introduces you to the spec data structure, and show you how to use it when `pivot_longer()` and `pivot_wider()` are insufficient.
 
 ### Longer
 
-To see how this works, lets return to the simplest case of pivotting applied to the `relig_income` dataset. Now pivotting happens in two steps: we first create a spec object (using `build_longer_spec()`) then use that to describe the pivotting operation:
+<!-- To see how this works, lets return to the simplest case of pivoting applied to the `relig_income` dataset. Now pivoting happens in two steps: we first create a spec object (using `build_longer_spec()`) then use that to describe the pivoting operation: -->
 
 ```{r}
 spec <- relig_income %>% 
@@ -767,7 +767,7 @@ construction %>%
   pivot_wider_spec(spec)
 ```
 
-The pivotting spec allows us to be more precise about exactly how `pivot_longer(df, spec = spec)` changes the shape of `df`: it will have `nrow(df) * nrow(spec)` rows, and `ncol(df) - nrow(spec) + ncol(spec) - 2` columns.
+The pivoting spec allows us to be more precise about exactly how `pivot_longer(df, spec = spec)` changes the shape of `df`: it will have `nrow(df) * nrow(spec)` rows, and `ncol(df) - nrow(spec) + ncol(spec) - 2` columns.
 
 [cdata]: https://winvector.github.io/cdata/
 [data.table]: https://github.com/Rdatatable/data.table/wiki

--- a/vignettes/pivot.Rmd
+++ b/vignettes/pivot.Rmd
@@ -660,7 +660,7 @@ The arguments to `pivot_longer()` and `pivot_wider()` allow you to pivot a wide 
 
 ### Longer
 
-- To see how this works, lets return to the simplest case of pivoting applied to the `relig_income` dataset. Now pivoting happens in two steps: we first create a spec object (using `build_longer_spec()`) then use that to describe the pivoting operation:
+To see how this works, lets return to the simplest case of pivoting applied to the `relig_income` dataset. Now pivoting happens in two steps: we first create a spec object (using `build_longer_spec()`) then use that to describe the pivoting operation:
 
 ```{r}
 spec <- relig_income %>% 

--- a/vignettes/pivot.Rmd
+++ b/vignettes/pivot.Rmd
@@ -660,7 +660,7 @@ The arguments to `pivot_longer()` and `pivot_wider()` allow you to pivot a wide 
 
 ### Longer
 
-<!-- To see how this works, lets return to the simplest case of pivoting applied to the `relig_income` dataset. Now pivoting happens in two steps: we first create a spec object (using `build_longer_spec()`) then use that to describe the pivoting operation: -->
+- To see how this works, lets return to the simplest case of pivoting applied to the `relig_income` dataset. Now pivoting happens in two steps: we first create a spec object (using `build_longer_spec()`) then use that to describe the pivoting operation:
 
 ```{r}
 spec <- relig_income %>% 

--- a/vignettes/tidy-data.Rmd
+++ b/vignettes/tidy-data.Rmd
@@ -139,7 +139,7 @@ relig_income
 
 This dataset has three variables, `religion`, `income` and `frequency`. To tidy it, we need to **pivot** the non-variable columns into a two-column key-value pair. This action is often described as making a wide dataset longer (or taller). 
 
-When pivoting variables, we need to provide the name of the new key-value columns to create. After defining the colums to pivot (every column except for religion), you will need the name of the key column, which is the name of the variable defined by the values of the column headings. In this case, it's `income`. The second argument is the name of the value column, `frequency`. 
+When pivoting variables, we need to provide the name of the new key-value columns to create. After defining the columns to pivot (every column except for religion), you will need the name of the key column, which is the name of the variable defined by the values of the column headings. In this case, it's `income`. The second argument is the name of the value column, `frequency`. 
 
 ```{r}
 relig_income %>% 


### PR DESCRIPTION
Just caught this while reading the docs. Thank you! 