### PR TITLE
Speed up `pivot_wider(names_sep = ...)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr (development version)
 
+* `pivot_wider()` is now faster when `names_sep` is provided (@mgirlich, #1426).
+
 * The `...` argument of both `pivot_longer()` and `pivot_wider()` has been
   moved to the front of the function signature, after the required arguments
   but before the optional ones. Additionally, `pivot_longer_spec()`,

--- a/R/utils.R
+++ b/R/utils.R
@@ -182,7 +182,11 @@ list_of_ptype <- function(x) {
 }
 
 apply_names_sep <- function(outer, inner, names_sep) {
-  as.character(glue("{outer}{names_sep}{inner}"))
+  if (length(inner) == 0 || length(outer) == 0) {
+    character()
+  } else {
+    paste0(outer, names_sep, inner)
+  }
 }
 
 vec_paste0 <- function(...) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -182,7 +182,11 @@ list_of_ptype <- function(x) {
 }
 
 apply_names_sep <- function(outer, inner, names_sep) {
-  if (length(inner) == 0 || length(outer) == 0) {
+  # Need to avoid `paste0()` recycling issue. Not using `vec_paste0()`
+  # because that is too slow to be applied to each element (#1427).
+  # `outer` and `names_sep` are required to be length 1,
+  # so we only need to check `inner`.
+  if (length(inner) == 0L) {
     character()
   } else {
     paste0(outer, names_sep, inner)


### PR DESCRIPTION
Closes https://github.com/tidyverse/tidyr/issues/1426

I think the only reason to use `glue()` was the handling in the case of empty input. This is already covered in tests (`names_sep` works with empty elements (#1185)`).

``` r
library(tidyr)

df <- tibble(
  id = 1:10e3,
  x = list(1:3)
)

bench::mark(
  unnest_wider = unnest_wider(df, x, names_sep = "_")
)

# Before
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest_wider    1.79s    1.79s     0.558    3.66MB     22.3

# After
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unnest_wider    207ms    227ms      4.45    3.66MB     20.8
```

<sup>Created on 2022-11-23 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>