### PR TITLE
Updates for purrr/stringr/dplyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     magrittr,
     purrr (>= 1.0.0),
     rlang (>= 1.0.4),
-    stringr (>= 1.4.0.9000),
+    stringr (>= 1.5.0),
     tibble (>= 2.1.1),
     tidyselect (>= 1.2.0),
     utils,
@@ -53,5 +53,3 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 SystemRequirements: C++11
-Remotes: 
-    tidyverse/stringr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     glue,
     lifecycle (>= 1.0.3),
     magrittr,
-    purrr,
+    purrr (>= 1.0.0),
     rlang (>= 1.0.4),
     stringr (>= 1.4.0.9000),
     tibble (>= 2.1.1),

--- a/R/complete.R
+++ b/R/complete.R
@@ -113,15 +113,19 @@ complete.grouped_df <- function(data,
                                 explicit = TRUE) {
 
   if (the$has_dplyr_1_1) {
-    out <- dplyr::reframe(
+    reframe <- utils::getFromNamespace("reframe", ns = "dplyr")
+    pick <- utils::getFromNamespace("pick", ns = "dplyr")
+
+    out <- reframe(
       data,
       complete(
-        data = dplyr::pick(everything()),
+        data = pick(everything()),
         ...,
         fill = fill,
         explicit = explicit
       )
     )
+
     drop <- dplyr::group_by_drop_default(data)
     dplyr::group_by(out, !!!dplyr::groups(data), .drop = drop)
   } else {

--- a/R/complete.R
+++ b/R/complete.R
@@ -69,7 +69,7 @@ complete <- function(data,
 }
 
 on_load({
-  the$dplyr_needs_multiple <- packageVersion("dplyr") >= "1.0.99"
+  the$has_dplyr_1_1 <- packageVersion("dplyr") >= "1.0.99"
 })
 
 #' @export
@@ -83,7 +83,7 @@ complete.data.frame <- function(data,
   names <- names(out)
 
   if (length(names) > 0L) {
-    if (the$dplyr_needs_multiple) {
+    if (the$has_dplyr_1_1) {
       out <- dplyr::full_join(out, data, by = names, multiple = "all")
     } else {
       out <- dplyr::full_join(out, data, by = names)
@@ -111,14 +111,30 @@ complete.grouped_df <- function(data,
                                 ...,
                                 fill = list(),
                                 explicit = TRUE) {
-  dplyr::summarise(
-    data,
-    complete(
-      data = dplyr::cur_data(),
-      ...,
-      fill = fill,
-      explicit = explicit
-    ),
-    .groups = "keep"
-  )
+
+  if (the$has_dplyr_1_1) {
+    out <- dplyr::reframe(
+      data,
+      complete(
+        data = dplyr::pick(everything()),
+        ...,
+        fill = fill,
+        explicit = explicit
+      )
+    )
+    .drop <- attr(attr(data, "groups"), ".drop")
+    dplyr::group_by(out, !!!syms(dplyr::group_vars(data)), .drop = .drop)
+  } else {
+    dplyr::summarise(
+      data,
+      complete(
+        data = dplyr::cur_data(),
+        ...,
+        fill = fill,
+        explicit = explicit
+      ),
+      .groups = "keep"
+    )
+
+  }
 }

--- a/R/complete.R
+++ b/R/complete.R
@@ -122,8 +122,8 @@ complete.grouped_df <- function(data,
         explicit = explicit
       )
     )
-    .drop <- attr(attr(data, "groups"), ".drop")
-    dplyr::group_by(out, !!!syms(dplyr::group_vars(data)), .drop = .drop)
+    drop <- dplyr::group_by_drop_default(data)
+    dplyr::group_by(out, !!!dplyr::groups(data), .drop = drop)
   } else {
     dplyr::summarise(
       data,

--- a/R/expand.R
+++ b/R/expand.R
@@ -103,14 +103,18 @@ expand.data.frame <- function(data, ..., .name_repair = "check_unique") {
 expand.grouped_df <- function(data, ..., .name_repair = "check_unique") {
 
   if (the$has_dplyr_1_1) {
-    out <- dplyr::reframe(
+    reframe <- utils::getFromNamespace("reframe", ns = "dplyr")
+    pick <- utils::getFromNamespace("pick", ns = "dplyr")
+
+    out <- reframe(
       data,
       expand(
-        data = dplyr::pick(everything()),
+        data = pick(everything()),
         ...,
         .name_repair = .name_repair
       )
     )
+
     drop <- dplyr::group_by_drop_default(data)
     dplyr::group_by(out, !!!dplyr::groups(data), .drop = drop)
   } else {

--- a/R/expand.R
+++ b/R/expand.R
@@ -111,8 +111,8 @@ expand.grouped_df <- function(data, ..., .name_repair = "check_unique") {
         .name_repair = .name_repair
       )
     )
-    .drop <- attr(attr(data, "groups"), ".drop")
-    dplyr::group_by(out, !!!syms(dplyr::group_vars(data)), .drop = .drop)
+    drop <- dplyr::group_by_drop_default(data)
+    dplyr::group_by(out, !!!dplyr::groups(data), .drop = drop)
   } else {
     dplyr::summarise(
       data,

--- a/R/expand.R
+++ b/R/expand.R
@@ -101,15 +101,31 @@ expand.data.frame <- function(data, ..., .name_repair = "check_unique") {
 
 #' @export
 expand.grouped_df <- function(data, ..., .name_repair = "check_unique") {
-  dplyr::summarise(
-    data,
-    expand(
-      data = dplyr::cur_data(),
-      ...,
-      .name_repair = .name_repair
-    ),
-    .groups = "keep"
-  )
+
+  if (the$has_dplyr_1_1) {
+    out <- dplyr::reframe(
+      data,
+      expand(
+        data = dplyr::pick(everything()),
+        ...,
+        .name_repair = .name_repair
+      )
+    )
+    .drop <- attr(attr(data, "groups"), ".drop")
+    dplyr::group_by(out, !!!syms(dplyr::group_vars(data)), .drop = .drop)
+  } else {
+    dplyr::summarise(
+      data,
+      expand(
+        data = dplyr::cur_data(),
+        ...,
+        .name_repair = .name_repair
+      ),
+      .groups = "keep"
+    )
+
+  }
+
 }
 
 # Nesting & crossing ------------------------------------------------------

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -140,11 +140,13 @@ col_to_wide <- function(col, name, strict, names_sep, error_call = caller_env())
 
   out <- lapply(
     out,
-    elt_to_wide,
-    name = name,
-    strict = strict,
-    names_sep = names_sep,
-    error_call = error_call
+    function(x) elt_to_wide(
+      x = x,
+      name = name,
+      strict = strict,
+      names_sep = names_sep,
+      error_call = error_call
+    )
   )
 
   # In the sole case of a list_of<data_frame>, we can be sure that the

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -137,7 +137,15 @@ col_to_wide <- function(col, name, strict, names_sep, error_call = caller_env())
 
   # Avoid expensive dispatch from `[[.list_of`
   out <- tidyr_new_list(col)
-  out <- map(out, elt_to_wide, name = name, strict = strict, names_sep = names_sep, error_call = error_call)
+
+  out <- lapply(
+    out,
+    elt_to_wide,
+    name = name,
+    strict = strict,
+    names_sep = names_sep,
+    error_call = error_call
+  )
 
   # In the sole case of a list_of<data_frame>, we can be sure that the
   # elements of `out` will all be of the same type. Otherwise,

--- a/R/utils.R
+++ b/R/utils.R
@@ -238,7 +238,10 @@ check_list_of_functions <- function(x, names, arg = caller_arg(x), call = caller
 
   check_unique_names(x, arg = arg, call = call)
 
-  x <- map(x, as_function, arg = arg, call = call)
+  x <- lapply(set_names(seq_along(x), names(x)), function(i) {
+    as_function(x[[i]], arg = glue("{arg}[[{i}]]"), call = call)
+  })
+
   # Silently drop user supplied names not found in the data
   x <- x[intersect(names(x), names)]
 

--- a/tests/testthat/_snaps/unnest-helper.md
+++ b/tests/testthat/_snaps/unnest-helper.md
@@ -70,7 +70,9 @@
       (expect_error(df_simplify(data.frame(), transform = list(x = 1))))
     Output
       <error/rlang_error>
-      Error:
+      Error in `map()`:
+      i In index: 1.
+      Caused by error:
       ! Can't convert `transform`, a number, to a function.
     Code
       (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))

--- a/tests/testthat/_snaps/unnest-helper.md
+++ b/tests/testthat/_snaps/unnest-helper.md
@@ -70,10 +70,8 @@
       (expect_error(df_simplify(data.frame(), transform = list(x = 1))))
     Output
       <error/rlang_error>
-      Error in `map()`:
-      i In index: 1.
-      Caused by error:
-      ! Can't convert `transform`, a number, to a function.
+      Error:
+      ! Can't convert `transform[[1]]`, a number, to a function.
     Code
       (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))
     Output

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -4,7 +4,9 @@
       (expect_error(unnest_wider(df, y)))
     Output
       <error/rlang_error>
-      Error in `unnest_wider()`:
+      Error in `map()`:
+      i In index: 1.
+      Caused by error in `unnest_wider()`:
       ! List-column `y` must contain only vectors.
 
 # can unnest a vector with a mix of named/unnamed elements (#1200 comment)

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -4,9 +4,7 @@
       (expect_error(unnest_wider(df, y)))
     Output
       <error/rlang_error>
-      Error in `map()`:
-      i In index: 1.
-      Caused by error in `unnest_wider()`:
+      Error in `unnest_wider()`:
       ! List-column `y` must contain only vectors.
 
 # can unnest a vector with a mix of named/unnamed elements (#1200 comment)

--- a/tests/testthat/test-hoist.R
+++ b/tests/testthat/test-hoist.R
@@ -136,10 +136,7 @@ test_that("can use a numeric vector for deep hoisting", {
   expect_identical(out$bb, 2)
 })
 
-test_that("can't maintain type stability with empty elements due to `purrr::pluck()` (#1203)", {
-  # We want to be notified if this changes in purrr, but not error on CRAN
-  skip_on_cran()
-
+test_that("can maintain type stability with empty elements (#1203)", {
   df <- tibble(
     col = list(
       list(a = integer()),
@@ -149,9 +146,7 @@ test_that("can't maintain type stability with empty elements due to `purrr::pluc
 
   out <- hoist(df, col, "a")
 
-  # Ideally:
-  # expect_identical(out$a, c(NA_integer_, NA_integer_))
-  expect_identical(out$a, c(NA, NA))
+  expect_identical(out$a, c(NA_integer_, NA_integer_))
 })
 
 test_that("can hoist out a rcrd style column (#999)", {


### PR DESCRIPTION
Closes https://github.com/tidyverse/tidyr/issues/1422

Updated and activated a test related to https://github.com/tidyverse/tidyr/issues/1203 now that `pluck()` retains empty elements correctly.

Updated snapshots, but these seem to be a little backwards. Really `unnest_wider()` calls `map()`, but the `.f` we call `map()` with accepts an `error_call` argument and that `error_call` points to `unnest_wider()` as the function to use in the errors. So it ends up looking like `map()` calls `unnest_wider()`.