### PR TITLE
Remove backwards compatible support for treating `list()` as `NULL`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tidyr (development version)
 
+* `pivot_longer()` no longer supports interpreting `values_ptypes = list()`
+  and `names_ptypes = list()` as `NULL`. An empty `list()` is now interpreted as
+  a `<list>` prototype to apply to all columns, which is consistent with how any
+  other 0-length value is interpreted (#1296).
+
 * All functions deprecated in tidyr 1.0 and 1.2 (the old lazyeval functions 
   ending in `_` and various arguments to `unnest()`) now warn on every use.
   They will be made defunct in 2024 (#1406).

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -93,10 +93,6 @@
 #'   confirm that the created columns are the types that you expect. Note that
 #'   if you want to change (instead of confirm) the types of specific columns,
 #'   you should use `names_transform` or `values_transform` instead.
-#'
-#'   For backwards compatibility reasons, supplying `list()` is interpreted as
-#'   being identical to `NULL` rather than as using a list prototype on all
-#'   columns. Expect this to change in the future.
 #' @param ... Additional arguments passed on to methods.
 #' @export
 #' @examples
@@ -262,10 +258,6 @@ pivot_longer_spec <- function(data,
   value_keys <- split(spec[-(1:2)], v_fct)
   keys <- vec_unique(spec[-(1:2)])
 
-  if (identical(values_ptypes, list())) {
-    # TODO: Remove me after https://github.com/tidyverse/tidyr/issues/1296
-    values_ptypes <- NULL
-  }
   values_ptypes <- check_list_of_ptypes(values_ptypes, value_names)
   values_transform <- check_list_of_functions(values_transform, value_names)
 
@@ -407,10 +399,6 @@ build_longer_spec <- function(data,
     vec_assert(values_to, ptype = character(), size = 1)
   }
 
-  if (identical(names_ptypes, list())) {
-    # TODO: Remove me after https://github.com/tidyverse/tidyr/issues/1296
-    names_ptypes <- NULL
-  }
   names_ptypes <- check_list_of_ptypes(names_ptypes, names(names), "names_ptypes")
   names_transform <- check_list_of_functions(names_transform, names(names), "names_transform")
 

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -85,11 +85,7 @@ zero-length vector (like \code{integer()} or \code{numeric()}) that defines the 
 class, and attributes of a vector. Use these arguments if you want to
 confirm that the created columns are the types that you expect. Note that
 if you want to change (instead of confirm) the types of specific columns,
-you should use \code{names_transform} or \code{values_transform} instead.
-
-For backwards compatibility reasons, supplying \code{list()} is interpreted as
-being identical to \code{NULL} rather than as using a list prototype on all
-columns. Expect this to change in the future.}
+you should use \code{names_transform} or \code{values_transform} instead.}
 
 \item{names_transform, values_transform}{Optionally, a list of column
 name-function pairs. Alternatively, a single function can be supplied,

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -120,11 +120,7 @@ zero-length vector (like \code{integer()} or \code{numeric()}) that defines the 
 class, and attributes of a vector. Use these arguments if you want to
 confirm that the created columns are the types that you expect. Note that
 if you want to change (instead of confirm) the types of specific columns,
-you should use \code{names_transform} or \code{values_transform} instead.
-
-For backwards compatibility reasons, supplying \code{list()} is interpreted as
-being identical to \code{NULL} rather than as using a list prototype on all
-columns. Expect this to change in the future.}
+you should use \code{names_transform} or \code{values_transform} instead.}
 
 \item{names_transform, values_transform}{Optionally, a list of column
 name-function pairs. Alternatively, a single function can be supplied,

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,46 +1,47 @@
 # Revdeps
 
-## Failed to check (26)
+## Failed to check (29)
 
-|package        |version |error |warning |note |
-|:--------------|:-------|:-----|:-------|:----|
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|FAMetA         |0.1.4   |1     |        |     |
-|NA             |?       |      |        |     |
-|ggPMX          |?       |      |        |     |
-|loon.ggplot    |?       |      |        |     |
-|NA             |?       |      |        |     |
-|NA             |?       |      |        |     |
-|MarketMatching |?       |      |        |     |
-|NA             |?       |      |        |     |
-|OlinkAnalyze   |?       |      |        |     |
-|Platypus       |?       |      |        |     |
-|RVA            |?       |      |        |     |
-|NA             |?       |      |        |     |
-|tinyarray      |?       |      |        |     |
-|vivid          |?       |      |        |     |
-|xpose.nlmixr2  |?       |      |        |     |
+|package       |version |error |warning |note |
+|:-------------|:-------|:-----|:-------|:----|
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|FAMetA        |0.1.4   |1     |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|genekitr      |?       |      |        |     |
+|ggPMX         |?       |      |        |     |
+|loon.ggplot   |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|NA            |?       |      |        |     |
+|numbat        |?       |      |        |     |
+|OlinkAnalyze  |?       |      |        |     |
+|Platypus      |?       |      |        |     |
+|NA            |?       |      |        |     |
+|RVA           |?       |      |        |     |
+|NA            |?       |      |        |     |
+|tinyarray     |?       |      |        |     |
+|vivid         |?       |      |        |     |
+|xpose.nlmixr2 |?       |      |        |     |
 
-## New problems (8)
+## New problems (6)
 
 |package       |version |error  |warning |note |
 |:-------------|:-------|:------|:-------|:----|
-|[cmcR](problems.md#cmcr)|0.1.9   |__+1__ |        |     |
 |[faux](problems.md#faux)|1.1.0   |       |__+1__  |     |
+|[GauPro](problems.md#gaupro)|0.2.6   |__+1__ |        |1    |
 |[ggpubr](problems.md#ggpubr)|0.5.0   |__+1__ |        |     |
 |[metaconfoundr](problems.md#metaconfoundr)|0.1.1   |__+2__ |__+1__  |     |
-|[mpwR](problems.md#mpwr)|0.1.0   |__+2__ |__+1__  |     |
 |[openalexR](problems.md#openalexr)|1.0.0   |       |__+1__  |     |
 |[recipes](problems.md#recipes)|1.0.3   |__+2__ |        |1    |
-|[tidyfst](problems.md#tidyfst)|1.7.5   |__+1__ |        |1    |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,30 +1,25 @@
 ## revdepcheck results
 
-We checked 1711 reverse dependencies (1695 from CRAN + 16 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 1733 reverse dependencies (1715 from CRAN + 18 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 8 new problems
- * We failed to check 10 packages
+ * We saw 6 new problems
+ * We failed to check 11 packages
 
 Issues with CRAN packages are summarised below.
 
 ### New problems
 (This reports the first line of each new failure)
 
-* cmcR
-  checking tests ... ERROR
-
 * faux
   checking re-building of vignette outputs ... WARNING
+
+* GauPro
+  checking tests ... ERROR
 
 * ggpubr
   checking examples ... ERROR
 
 * metaconfoundr
-  checking examples ... ERROR
-  checking tests ... ERROR
-  checking re-building of vignette outputs ... WARNING
-
-* mpwR
   checking examples ... ERROR
   checking tests ... ERROR
   checking re-building of vignette outputs ... WARNING
@@ -36,18 +31,16 @@ Issues with CRAN packages are summarised below.
   checking examples ... ERROR
   checking tests ... ERROR
 
-* tidyfst
-  checking examples ... ERROR
-
 ### Failed to check
 
-* FAMetA         (NA)
-* ggPMX          (NA)
-* loon.ggplot    (NA)
-* MarketMatching (NA)
-* OlinkAnalyze   (NA)
-* Platypus       (NA)
-* RVA            (NA)
-* tinyarray      (NA)
-* vivid          (NA)
-* xpose.nlmixr2  (NA)
+* FAMetA        (NA)
+* genekitr      (NA)
+* ggPMX         (NA)
+* loon.ggplot   (NA)
+* numbat        (NA)
+* OlinkAnalyze  (NA)
+* Platypus      (NA)
+* RVA           (NA)
+* tinyarray     (NA)
+* vivid         (NA)
+* xpose.nlmixr2 (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -480,6 +480,109 @@ Run `cloud_details(, "NA")` for more info
 
 
 ```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# genekitr
+
+<details>
+
+* Version: 1.0.8
+* GitHub: https://github.com/GangLiLab/genekitr
+* Source code: https://github.com/cran/genekitr
+* Date/Publication: 2022-11-23 11:30:02 UTC
+* Number of recursive dependencies: 200
+
+Run `cloud_details(, "genekitr")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/genekitr/new/genekitr.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘genekitr/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘genekitr’ version ‘1.0.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/genekitr/old/genekitr.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘genekitr/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘genekitr’ version ‘1.0.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
 # ggPMX
 
 <details>
@@ -510,7 +613,7 @@ Run `cloud_details(, "ggPMX")` for more info
 * checking package namespace information ... OK
 * checking package dependencies ... NOTE
 ...
-  [ FAIL 1 | WARN 13 | SKIP 8 | PASS 327 ]
+  [ FAIL 1 | WARN 14 | SKIP 8 | PASS 327 ]
   Error: Test failures
   Execution halted
 * checking for unstated dependencies in vignettes ... OK
@@ -540,7 +643,7 @@ Status: 1 ERROR, 2 NOTEs
 * checking package namespace information ... OK
 * checking package dependencies ... NOTE
 ...
-  [ FAIL 1 | WARN 13 | SKIP 8 | PASS 327 ]
+  [ FAIL 1 | WARN 14 | SKIP 8 | PASS 327 ]
   Error: Test failures
   Execution halted
 * checking for unstated dependencies in vignettes ... OK
@@ -698,72 +801,6 @@ Run `cloud_details(, "NA")` for more info
 
 
 ```
-# MarketMatching
-
-<details>
-
-* Version: 1.2.0
-* GitHub: NA
-* Source code: https://github.com/cran/MarketMatching
-* Date/Publication: 2021-01-08 20:10:02 UTC
-* Number of recursive dependencies: 72
-
-Run `cloud_details(, "MarketMatching")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/MarketMatching/new/MarketMatching.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MarketMatching/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘MarketMatching’ version ‘1.2.0’
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'CausalImpact', 'bsts', 'Boom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/MarketMatching/old/MarketMatching.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MarketMatching/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘MarketMatching’ version ‘1.2.0’
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'CausalImpact', 'bsts', 'Boom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
 # NA
 
 <details>
@@ -799,6 +836,72 @@ Run `cloud_details(, "NA")` for more info
 
 
 ```
+# numbat
+
+<details>
+
+* Version: 1.1.0
+* GitHub: https://github.com/kharchenkolab/numbat
+* Source code: https://github.com/cran/numbat
+* Date/Publication: 2022-11-29 18:30:02 UTC
+* Number of recursive dependencies: 183
+
+Run `cloud_details(, "numbat")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/numbat/new/numbat.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘numbat/DESCRIPTION’ ... OK
+* this is package ‘numbat’ version ‘1.1.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'ggtree', 'scistreer'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/numbat/old/numbat.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘numbat/DESCRIPTION’ ... OK
+* this is package ‘numbat’ version ‘1.1.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'ggtree', 'scistreer'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
 # OlinkAnalyze
 
 <details>
@@ -807,7 +910,7 @@ Run `cloud_details(, "NA")` for more info
 * GitHub: NA
 * Source code: https://github.com/cran/OlinkAnalyze
 * Date/Publication: 2022-11-16 00:30:05 UTC
-* Number of recursive dependencies: 203
+* Number of recursive dependencies: 202
 
 Run `cloud_details(, "OlinkAnalyze")` for more info
 
@@ -883,7 +986,7 @@ Status: 1 NOTE
 * GitHub: NA
 * Source code: https://github.com/cran/Platypus
 * Date/Publication: 2022-08-15 07:20:20 UTC
-* Number of recursive dependencies: 354
+* Number of recursive dependencies: 356
 
 Run `cloud_details(, "Platypus")` for more info
 
@@ -945,6 +1048,41 @@ See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
 * DONE
 Status: 1 ERROR
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
 
 
 
@@ -1204,7 +1342,7 @@ Status: 2 NOTEs
 * GitHub: NA
 * Source code: https://github.com/cran/xpose.nlmixr2
 * Date/Publication: 2022-06-08 09:10:02 UTC
-* Number of recursive dependencies: 154
+* Number of recursive dependencies: 161
 
 Run `cloud_details(, "xpose.nlmixr2")` for more info
 

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,41 +1,3 @@
-# cmcR
-
-<details>
-
-* Version: 0.1.9
-* GitHub: NA
-* Source code: https://github.com/cran/cmcR
-* Date/Publication: 2022-02-22 14:00:02 UTC
-* Number of recursive dependencies: 117
-
-Run `cloud_details(, "cmcR")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      ℹ Please use `"highCMCClassif"` instead of `.data$highCMCClassif`
-      
-      ══ Failed ══════════════════════════════════════════════════════════════════════
-      ── 1. Error ('test-diagnosticTools.R:55'): (code run outside of `test_that()`) ─
-      Error in `stringr::str_extract_all(., string = ..2$cmcR.info$cellRange, 
-          pattern = "[0-9]{1,}")`: `simplify` must be `TRUE` or `FALSE`, not the string "rows: 1 - 69, cols: 1 - 69".
-      Backtrace:
-       1. cmcR::cmcPlot(...)
-            at test-diagnosticTools.R:55:0
-       8. stringr::str_extract_all(simplify = .)
-      
-      ══ DONE ════════════════════════════════════════════════════════════════════════
-      Don't worry, you'll get it.
-      Error: Test failures
-      Execution halted
-    ```
-
 # faux
 
 <details>
@@ -56,18 +18,18 @@ Run `cloud_details(, "faux")` for more info
     ```
     Error(s) in re-building vignettes:
     --- re-building ‘codebook.Rmd’ using rmarkdown
-    
-    ************
-    Welcome to faux. For support and examples visit:
-    https://debruine.github.io/faux/
-    - Get and set global package options with: faux_options()
-    ************
     --- finished re-building ‘codebook.Rmd’
     
+    --- re-building ‘continuous.Rmd’ using rmarkdown
+    Quitting from lines 95-99 (continuous.Rmd) 
+    Error: processing vignette 'continuous.Rmd' failed with diagnostics:
+    Arguments in `...` must be used.
+    ✖ Problematic arguments:
+    • ..1 = "var"
     ...
-    https://debruine.github.io/faux/
-    - Get and set global package options with: faux_options()
-    ************
+    --- finished re-building ‘sim_design.Rmd’
+    
+    --- re-building ‘sim_df.Rmd’ using rmarkdown
     --- finished re-building ‘sim_df.Rmd’
     
     SUMMARY: processing the following file failed:
@@ -75,6 +37,54 @@ Run `cloud_details(, "faux")` for more info
     
     Error: Vignette re-building failed.
     Execution halted
+    ```
+
+# GauPro
+
+<details>
+
+* Version: 0.2.6
+* GitHub: https://github.com/CollinErickson/GauPro
+* Source code: https://github.com/cran/GauPro
+* Date/Publication: 2022-11-24 08:40:02 UTC
+* Number of recursive dependencies: 79
+
+Run `cloud_details(, "GauPro")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      > library(GauPro)
+      > 
+      > test_check("GauPro")
+      [ FAIL 1 | WARN 0 | SKIP 0 | PASS 1337 ]
+      
+      ══ Failed tests ════════════════════════════════════════════════════════════════
+      ── Failure ('test_kernel_model_and_kernels.R:204'): kernels work and have correct grads ──
+      White numgrad matches symbolic grad (failed on all 10 attempts) is not TRUE
+      
+      `actual` is a character vector ('Mean relative difference: 0.0003611384')
+      `expected` is a logical vector (TRUE)
+      
+      [ FAIL 1 | WARN 0 | SKIP 0 | PASS 1337 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+## In both
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 15.0Mb
+      sub-directories of 1Mb or more:
+        R      1.1Mb
+        libs  13.3Mb
     ```
 
 # ggpubr
@@ -199,94 +209,6 @@ Run `cloud_details(, "metaconfoundr")` for more info
     Execution halted
     ```
 
-# mpwR
-
-<details>
-
-* Version: 0.1.0
-* GitHub: NA
-* Source code: https://github.com/cran/mpwR
-* Date/Publication: 2022-06-22 07:30:02 UTC
-* Number of recursive dependencies: 96
-
-Run `cloud_details(, "mpwR")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘mpwR-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: get_Upset_list
-    > ### Title: Generate Upset list
-    > ### Aliases: get_Upset_list
-    > 
-    > ### ** Examples
-    > 
-    > # Load libraries
-    ...
-    ! `pattern` can't be the empty string (`""`).
-    Backtrace:
-        ▆
-     1. └─mpwR::get_Upset_list(input_list = data, level = "Precursor.IDs")
-     2.   ├─base::which(...)
-     3.   └─stringr::str_detect(string = names(output_list), pattern = "")
-     4.     └─stringr:::no_empty()
-     5.       └─cli::cli_abort(...)
-     6.         └─rlang::abort(...)
-    Execution halted
-    ```
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      ══ Failed tests ════════════════════════════════════════════════════════════════
-      ── Error ('test_Upset.R:72'): get_Upset_list works ─────────────────────────────
-      Error in `stringr::str_detect(string = names(output_list), pattern = "")`: `pattern` can't be the empty string (`""`).
-      Backtrace:
-          ▆
-       1. └─mpwR::get_Upset_list(input_list = data, level = "Precursor.IDs") at test_Upset.R:72:3
-       2.   ├─base::which(...)
-       3.   └─stringr::str_detect(string = names(output_list), pattern = "")
-       4.     └─stringr:::no_empty()
-       5.       └─cli::cli_abort(...)
-       6.         └─rlang::abort(...)
-      
-      [ FAIL 1 | WARN 553 | SKIP 0 | PASS 598 ]
-      Error: Test failures
-      Execution halted
-    ```
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-    --- re-building ‘Import.Rmd’ using rmarkdown
-    --- finished re-building ‘Import.Rmd’
-    
-    --- re-building ‘Requirements.Rmd’ using rmarkdown
-    --- finished re-building ‘Requirements.Rmd’
-    
-    --- re-building ‘Workflow.Rmd’ using rmarkdown
-    
-    Attaching package: 'dplyr'
-    ...
-    Quitting from lines 225-226 (Workflow.Rmd) 
-    Error: processing vignette 'Workflow.Rmd' failed with diagnostics:
-    `pattern` can't be the empty string (`""`).
-    --- failed re-building ‘Workflow.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘Workflow.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
-    ```
-
 # openalexR
 
 <details>
@@ -308,17 +230,9 @@ Run `cloud_details(, "openalexR")` for more info
     Error(s) in re-building vignettes:
       ...
     --- re-building ‘A_Brief_Introduction_to_openalexR.Rmd’ using rmarkdown
-    
-    Attaching package: 'dplyr'
-    
-    The following objects are masked from 'package:stats':
-    
-        filter, lag
-    
-    ...
-    Quitting from lines 207-213 (A_Brief_Introduction_to_openalexR.Rmd) 
+    Quitting from lines 342-354 (A_Brief_Introduction_to_openalexR.Rmd) 
     Error: processing vignette 'A_Brief_Introduction_to_openalexR.Rmd' failed with diagnostics:
-    $ operator is invalid for atomic vectors
+    missing value where TRUE/FALSE needed
     --- failed re-building ‘A_Brief_Introduction_to_openalexR.Rmd’
     
     SUMMARY: processing the following file failed:
@@ -396,53 +310,5 @@ Run `cloud_details(, "recipes")` for more info
 *   checking Rd cross-references ... NOTE
     ```
     Packages unavailable to check Rd xrefs: ‘fastICA’, ‘dimRed’
-    ```
-
-# tidyfst
-
-<details>
-
-* Version: 1.7.5
-* GitHub: https://github.com/hope-data-science/tidyfst
-* Source code: https://github.com/cran/tidyfst
-* Date/Publication: 2022-10-27 07:00:02 UTC
-* Number of recursive dependencies: 80
-
-Run `cloud_details(, "tidyfst")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘tidyfst-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: unite_dt
-    > ### Title: Unite multiple columns into one by pasting strings together
-    > ### Aliases: unite_dt
-    > 
-    > ### ** Examples
-    > 
-    > df <- expand.grid(x = c("a", NA), y = c("b", NA))
-    ...
-      2. ├─tidyfst::unite_dt(., "merged_name", "")
-      3. │ └─dt %>% select_dt(...)
-      4. ├─tidyfst::select_dt(., ...)
-      5. │ └─... %>% str_c(collapse = ",")
-      6. ├─stringr::str_c(., collapse = ",")
-      7. └─stringr::str_subset(names(dt), ., negate = negate)
-      8.   └─stringr:::no_empty()
-      9.     └─cli::cli_abort(...)
-     10.       └─rlang::abort(...)
-    Execution halted
-    ```
-
-## In both
-
-*   checking Rd cross-references ... NOTE
-    ```
-    Packages unavailable to check Rd xrefs: ‘fastDummies’, ‘widyr’, ‘pacman’, ‘sjmisc’
     ```
 

--- a/tests/testthat/test-pivot-long.R
+++ b/tests/testthat/test-pivot-long.R
@@ -373,6 +373,22 @@ test_that("`names_ptypes` and `names_transform` work with single values (#1284)"
   expect_identical(res$two, 2L)
 })
 
+test_that("`names_ptypes = list()` is interpreted as recycling <list> for all name columns (#1296)", {
+  df <- tibble(`1x2` = 1)
+
+  res <- build_longer_spec(
+    data = df,
+    cols = `1x2`,
+    names_to = c("one", "two"),
+    names_sep = "x",
+    names_transform = as.list,
+    names_ptypes = list()
+  )
+
+  expect_identical(res$one, list("1"))
+  expect_identical(res$two, list("2"))
+})
+
 test_that("`values_ptypes` works with single empty ptypes (#1284)", {
   df <- tibble(x_1 = 1, y_1 = 2)
 
@@ -388,6 +404,21 @@ test_that("`values_ptypes` works with single empty ptypes (#1284)", {
   expect_identical(res$y, 2L)
 })
 
+test_that("`values_ptypes = list()` is interpreted as recycling <list> for all value columns (#1296)", {
+  df <- tibble(x_1 = list_of(1L, 2:3, 4L), y_1 = list_of(2:3, 4L, 5:6))
+
+  res <- pivot_longer(
+    data = df,
+    cols = everything(),
+    names_to = c(".value", "set"),
+    names_sep = "_",
+    values_ptypes = list()
+  )
+
+  expect_identical(res$x, vec_cast(df$x_1, list()))
+  expect_identical(res$y, vec_cast(df$y_1, list()))
+})
+
 test_that("`values_transform` works with single functions (#1284)", {
   df <- tibble(x_1 = 1, y_1 = 2)
 
@@ -401,21 +432,6 @@ test_that("`values_transform` works with single functions (#1284)", {
 
   expect_identical(res$x, "1")
   expect_identical(res$y, "2")
-})
-
-test_that("`names/values_ptypes = list()` is currently the same as `NULL` (#1296)", {
-  # Because of some backwards compatibility support
-
-  df <- tibble(x = 1)
-
-  expect_identical(
-    pivot_longer(df, x, names_ptypes = list()),
-    pivot_longer(df, x, names_ptypes = NULL)
-  )
-  expect_identical(
-    pivot_longer(df, x, values_ptypes = list()),
-    pivot_longer(df, x, values_ptypes = NULL)
-  )
 })
 
 test_that("Error if the `col` can't be selected.", {


### PR DESCRIPTION
Closes #1296 
Reverts https://github.com/tidyverse/tidyr/pull/1297

Since those 4 revdeps that relied on this have been updated on CRAN for some time now.

Using `names_ptypes = list()` really isn't particularly useful, but it is at least slightly more consistent and removes a special case in the code.

`"170484b6-4f5d-46fd-9787-1ab5f83861d1"` - 6 total broken revdeps but none of them look related to this so i think we can continue. Most look related to new usage of `allow_rename = FALSE` in `eval_select()`