### PR TITLE
Add `error_call` to `build_*_spec()` and `pivot_*_spec()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidyr (development version)
 
+* `pivot_longer_spec()`, `pivot_wider_spec()`, `build_longer_spec()`, and
+  `build_wider_spec()` have all gained an `error_call` argument, resulting in
+  better error reporting in `pivot_longer()` and `pivot_wider()` (#1408).
+
 * `pivot_longer()` no longer supports interpreting `values_ptypes = list()`
   and `names_ptypes = list()` as `NULL`. An empty `list()` is now interpreted as
   a `<list>` prototype to apply to all columns, which is consistent with how any

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -325,7 +325,7 @@ pivot_wider_spec <- function(data,
     values_fill <- rep_named(values_from_cols, list(values_fill))
   } else if (!vec_is_list(values_fill)) {
     cli::cli_abort(
-      "{arg values_fill} must be NULL, a scalar, or a named list, not a {.obj_type_friendly {values_fill}",
+      "{.arg values_fill} must be {.code NULL}, a scalar, or a named list, not {.obj_type_friendly {values_fill}}.",
       call = error_call
     )
   }

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -204,7 +204,8 @@ pivot_wider.data.frame <- function(data,
     names_glue = names_glue,
     names_sort = names_sort,
     names_vary = names_vary,
-    names_expand = names_expand
+    names_expand = names_expand,
+    error_call = current_env()
   )
 
   id_cols <- compat_id_cols(
@@ -228,7 +229,8 @@ pivot_wider.data.frame <- function(data,
     names_repair = names_repair,
     values_fill = values_fill,
     values_fn = values_fn,
-    unused_fn = unused_fn
+    unused_fn = unused_fn,
+    error_call = current_env()
   )
 }
 
@@ -240,6 +242,7 @@ pivot_wider.data.frame <- function(data,
 #' @keywords internal
 #' @export
 #' @inheritParams rlang::args_dots_empty
+#' @inheritParams rlang::args_error_context
 #' @inheritParams pivot_wider
 #' @param spec A specification data frame. This is useful for more complex
 #'  pivots because it gives you greater control on how metadata stored in the
@@ -292,11 +295,12 @@ pivot_wider_spec <- function(data,
                              id_expand = FALSE,
                              values_fill = NULL,
                              values_fn = NULL,
-                             unused_fn = NULL) {
+                             unused_fn = NULL,
+                             error_call = current_env()) {
   check_dots_empty0(...)
 
-  spec <- check_pivot_spec(spec)
-  check_bool(id_expand)
+  spec <- check_pivot_spec(spec, call = error_call)
+  check_bool(id_expand, call = error_call)
 
   names_from_cols <- names(spec)[-(1:2)]
   values_from_cols <- vec_unique(spec$.value)
@@ -305,13 +309,14 @@ pivot_wider_spec <- function(data,
     data = data,
     id_cols = {{ id_cols }},
     names_from_cols = names_from_cols,
-    values_from_cols = values_from_cols
+    values_from_cols = values_from_cols,
+    error_call = error_call
   )
 
-  values_fn <- check_list_of_functions(values_fn, values_from_cols)
+  values_fn <- check_list_of_functions(values_fn, values_from_cols, call = error_call)
 
   unused_cols <- setdiff(names(data), c(id_cols, names_from_cols, values_from_cols))
-  unused_fn <- check_list_of_functions(unused_fn, unused_cols)
+  unused_fn <- check_list_of_functions(unused_fn, unused_cols, call = error_call)
   unused_cols <- names(unused_fn)
 
   if (is.null(values_fill)) {
@@ -319,7 +324,10 @@ pivot_wider_spec <- function(data,
   } else if (is_scalar(values_fill)) {
     values_fill <- rep_named(values_from_cols, list(values_fill))
   } else if (!vec_is_list(values_fill)) {
-    cli::cli_abort("{arg values_fill} must be NULL, a scalar, or a named list, not a {.obj_type_friendly {values_fill}")
+    cli::cli_abort(
+      "{arg values_fill} must be NULL, a scalar, or a named list, not a {.obj_type_friendly {values_fill}",
+      call = error_call
+    )
   }
   values_fill <- values_fill[intersect(names(values_fill), values_from_cols)]
 
@@ -361,7 +369,8 @@ pivot_wider_spec <- function(data,
       value_locs = unused_locs,
       value_name = unused_col,
       fn = unused_fn_i,
-      fn_name = "unused_fn"
+      fn_name = "unused_fn",
+      error_call = error_call
     )
   }
 
@@ -399,7 +408,8 @@ pivot_wider_spec <- function(data,
         value_locs = value_locs,
         value_name = value_name,
         fn = value_fn,
-        fn_name = "values_fn"
+        fn_name = "values_fn",
+        error_call = error_call
       )
     }
 
@@ -410,7 +420,7 @@ pivot_wider_spec <- function(data,
       out <- vec_init(value, nrow * ncol)
     } else {
       stopifnot(vec_size(fill) == 1)
-      fill <- vec_cast(fill, value)
+      fill <- vec_cast(fill, value, call = error_call)
       out <- vec_rep_each(fill, nrow * ncol)
     }
     out <- vec_assign(out, value_id$row + nrow * (value_id$col - 1L), value)
@@ -449,7 +459,7 @@ pivot_wider_spec <- function(data,
     values,
     unused,
     .name_repair = names_repair,
-    .error_call = current_env()
+    .error_call = error_call
   ))
 
   reconstruct_tibble(input, out)
@@ -467,28 +477,37 @@ build_wider_spec <- function(data,
                              names_glue = NULL,
                              names_sort = FALSE,
                              names_vary = "fastest",
-                             names_expand = FALSE) {
+                             names_expand = FALSE,
+                             error_call = current_env()) {
   check_dots_empty0(...)
 
   names_from <- tidyselect::eval_select(
     enquo(names_from),
     data,
     allow_rename = FALSE,
-    allow_empty = FALSE
+    allow_empty = FALSE,
+    error_call = error_call
   )
   values_from <- tidyselect::eval_select(
     enquo(values_from),
     data,
     allow_rename = FALSE,
-    allow_empty = FALSE
+    allow_empty = FALSE,
+    error_call = error_call
   )
 
-  check_string(names_prefix)
-  check_string(names_sep)
-  check_string(names_glue, allow_null = TRUE)
-  check_bool(names_sort)
-  names_vary <- arg_match0(names_vary, c("fastest", "slowest"), arg_nm = "names_vary")
-  check_bool(names_expand)
+  check_string(names_prefix, call = error_call)
+  check_string(names_sep, call = error_call)
+  check_string(names_glue, allow_null = TRUE, call = error_call)
+  check_bool(names_sort, call = error_call)
+  check_bool(names_expand, call = error_call)
+
+  names_vary <- arg_match0(
+    arg = names_vary,
+    values = c("fastest", "slowest"),
+    arg_nm = "names_vary",
+    error_call = error_call
+  )
 
   data <- as_tibble(data)
   data <- data[names_from]

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -13,7 +13,8 @@ pivot_longer_spec(
   names_repair = "check_unique",
   values_drop_na = FALSE,
   values_ptypes = NULL,
-  values_transform = NULL
+  values_transform = NULL,
+  error_call = current_env()
 )
 
 build_longer_spec(
@@ -26,7 +27,8 @@ build_longer_spec(
   names_sep = NULL,
   names_pattern = NULL,
   names_ptypes = NULL,
-  names_transform = NULL
+  names_transform = NULL,
+  error_call = current_env()
 )
 }
 \arguments{
@@ -67,6 +69,11 @@ for more options.}
 in the \code{value_to} column. This effectively converts explicit missing values
 to implicit missing values, and should generally be used only when missing
 values in \code{data} were created by its structure.}
+
+\item{error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pivot into
 longer format.}

--- a/man/pivot_wider_spec.Rd
+++ b/man/pivot_wider_spec.Rd
@@ -14,7 +14,8 @@ pivot_wider_spec(
   id_expand = FALSE,
   values_fill = NULL,
   values_fn = NULL,
-  unused_fn = NULL
+  unused_fn = NULL,
+  error_call = current_env()
 )
 
 build_wider_spec(
@@ -27,7 +28,8 @@ build_wider_spec(
   names_glue = NULL,
   names_sort = FALSE,
   names_vary = "fastest",
-  names_expand = FALSE
+  names_expand = FALSE,
+  error_call = current_env()
 )
 }
 \arguments{
@@ -94,6 +96,11 @@ all unspecified columns will be considered \code{id_cols}.
 
 This is similar to grouping by the \code{id_cols} then summarizing the
 unused columns using \code{unused_fn}.}
+
+\item{error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{names_from, values_from}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> A pair of
 arguments describing which column (or columns) to get the name of the

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -4,7 +4,7 @@
       (expect_error(pivot_longer(df, x, values_ptypes = character())))
     Output
       <error/vctrs_error_cast>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! Can't convert `x` <double> to <character>.
 
 # when `names_ptypes` is provided, the type error uses `names_to` names (#1364)
@@ -15,7 +15,7 @@
       }))
     Output
       <error/vctrs_error_cast>
-      Error in `build_longer_spec()`:
+      Error in `pivot_longer()`:
       ! Can't convert `name` <character> to <double>.
 
 # error when overwriting existing column
@@ -24,7 +24,7 @@
       (expect_error(pivot_longer(df, y, names_to = "x")))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1 and 2.
@@ -70,7 +70,7 @@
       (expect_error(pivot_longer(iris, matches("foo"))))
     Output
       <error/rlang_error>
-      Error in `build_longer_spec()`:
+      Error in `pivot_longer()`:
       ! `cols` must select at least one column.
 
 # named `cols` gives clear error (#1104)
@@ -78,7 +78,7 @@
     Code
       pivot_longer(df, c(z = y))
     Condition
-      Error in `build_longer_spec()`:
+      Error in `pivot_longer()`:
       ! Can't rename variables in this context.
 
 # `names_to` is validated
@@ -139,13 +139,13 @@
       (expect_error(pivot_longer(df, x, values_ptypes = 1)))
     Output
       <error/rlang_error>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! `values_ptypes` must be `NULL`, an empty ptype, or a named list of ptypes.
     Code
       (expect_error(pivot_longer(df, x, values_ptypes = list(integer()))))
     Output
       <error/rlang_error>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! All elements of `values_ptypes` must be named.
 
 # `values_transform` is validated
@@ -154,13 +154,13 @@
       (expect_error(pivot_longer(df, x, values_transform = 1)))
     Output
       <error/rlang_error>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! `values_transform` must be `NULL`, a function, or a named list of functions.
     Code
       (expect_error(pivot_longer(df, x, values_transform = list(~.x))))
     Output
       <error/rlang_error>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! All elements of `values_transform` must be named.
 
 # `cols_vary` is validated
@@ -169,14 +169,14 @@
       (expect_error(pivot_longer(df, x, cols_vary = "fast")))
     Output
       <error/rlang_error>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! `cols_vary` must be one of "fastest" or "slowest", not "fast".
       i Did you mean "fastest"?
     Code
       (expect_error(pivot_longer(df, x, cols_vary = 1)))
     Output
       <error/rlang_error>
-      Error in `pivot_longer_spec()`:
+      Error in `pivot_longer()`:
       ! `cols_vary` must be a string or character vector.
 
 # `pivot_longer()` catches unused input passed through the dots

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -4,7 +4,7 @@
       (expect_error(pivot_wider(df, names_from = key, values_from = val)))
     Output
       <error/vctrs_error_names_must_be_unique>
-      Error in `pivot_wider_spec()`:
+      Error in `pivot_wider()`:
       ! Names must be unique.
       x These names are duplicated:
         * "a" at locations 1 and 2.
@@ -25,7 +25,7 @@
       (expect_error(pivot_wider(df, values_from = val)))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `build_wider_spec()`:
+      Error in `pivot_wider()`:
       ! Can't subset columns that don't exist.
       x Column `name` doesn't exist.
 
@@ -35,7 +35,7 @@
       (expect_error(pivot_wider(df, names_from = key)))
     Output
       <error/vctrs_error_subscript_oob>
-      Error in `build_wider_spec()`:
+      Error in `pivot_wider()`:
       ! Can't subset columns that don't exist.
       x Column `value` doesn't exist.
 
@@ -46,7 +46,7 @@
       )
     Output
       <error/rlang_error>
-      Error in `build_wider_spec()`:
+      Error in `pivot_wider()`:
       ! Must select at least one item.
 
 # `values_from` must identify at least 1 column (#1240)
@@ -56,7 +56,7 @@
       )
     Output
       <error/rlang_error>
-      Error in `build_wider_spec()`:
+      Error in `pivot_wider()`:
       ! Must select at least one item.
 
 # `values_fn` emits an informative error when it doesn't result in unique values (#1238)
@@ -65,7 +65,7 @@
       (expect_error(pivot_wider(df, values_fn = list(value = ~.x))))
     Output
       <error/rlang_error>
-      Error in `pivot_wider_spec()`:
+      Error in `pivot_wider()`:
       ! Applying `values_fn` to `value` must result in a single summary value per key.
       i Applying `values_fn` resulted in a vector of length 2.
 
@@ -182,13 +182,13 @@
       (expect_error(pivot_wider(df, id_expand = 1)))
     Output
       <error/rlang_error>
-      Error in `pivot_wider_spec()`:
+      Error in `pivot_wider()`:
       ! `id_expand` must be `TRUE` or `FALSE`, not the number 1.
     Code
       (expect_error(pivot_wider(df, id_expand = "x")))
     Output
       <error/rlang_error>
-      Error in `pivot_wider_spec()`:
+      Error in `pivot_wider()`:
       ! `id_expand` must be `TRUE` or `FALSE`, not the string "x".
 
 # duplicated keys produce list column with warning
@@ -267,7 +267,7 @@
       (expect_error(pivot_wider(df, values_fn = 1)))
     Output
       <error/rlang_error>
-      Error in `pivot_wider_spec()`:
+      Error in `pivot_wider()`:
       ! `values_fn` must be `NULL`, a function, or a named list of functions.
 
 # `unused_fn` must result in single summary values
@@ -276,7 +276,7 @@
       (expect_error(pivot_wider(df, id_cols = id, unused_fn = identity)))
     Output
       <error/rlang_error>
-      Error in `pivot_wider_spec()`:
+      Error in `pivot_wider()`:
       ! Applying `unused_fn` to `unused` must result in a single summary value per key.
       i Applying `unused_fn` resulted in a vector of length 2.
 
@@ -286,7 +286,7 @@
       (expect_error(pivot_wider(df, id_cols = id, unused_fn = 1)))
     Output
       <error/rlang_error>
-      Error in `pivot_wider_spec()`:
+      Error in `pivot_wider()`:
       ! `unused_fn` must be `NULL`, a function, or a named list of functions.
 
 # `id_cols` has noisy compat behavior (#1353)

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -280,6 +280,15 @@
       ! Applying `unused_fn` to `unused` must result in a single summary value per key.
       i Applying `unused_fn` resulted in a vector of length 2.
 
+# `values_fill` is validated
+
+    Code
+      (expect_error(pivot_wider(df, values_fill = 1:2)))
+    Output
+      <error/rlang_error>
+      Error in `pivot_wider()`:
+      ! `values_fill` must be `NULL`, a scalar, or a named list, not an integer vector.
+
 # `unused_fn` is validated
 
     Code

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -733,6 +733,14 @@ test_that("can't fill implicit missings in unused column with `values_fill`", {
   expect_identical(res$unused, list(c(1, 2), c(4, 3), NA_real_))
 })
 
+test_that("`values_fill` is validated", {
+  df <- tibble(name = "a", value = 1)
+
+  expect_snapshot(
+    (expect_error(pivot_wider(df, values_fill = 1:2)))
+  )
+})
+
 test_that("`unused_fn` is validated", {
   df <- tibble(id = 1, unused = 1, name = "a", value = 1)
 


### PR DESCRIPTION
Closes #1408

Much nicer error call reporting!

Defaulted `error_call` to `current_env()` since it is reasonable to call these functions at the top level for advanced users.