### PR TITLE
Document grouped data frame support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* `nest()`, `complete()`, `expand()`, and `fill()` now document their support
+  for grouped data frames created by `dplyr::group_by()` (#952).
+
 * `pivot_longer_spec()`, `pivot_wider_spec()`, `build_longer_spec()`, and
   `build_wider_spec()` have all gained an `error_call` argument, resulting in
   better error reporting in `pivot_longer()` and `pivot_wider()` (#1408).

--- a/R/complete.R
+++ b/R/complete.R
@@ -4,9 +4,10 @@
 #' around [expand()], [dplyr::full_join()] and [replace_na()] that's useful for
 #' completing missing combinations of data.
 #'
-#' @details
-#' With grouped data frames, `complete()` operates _within_ each group. Because
-#' of this, you cannot complete a grouping column.
+#' @section Grouped data frames:
+#' With grouped data frames created by [dplyr::group_by()], `complete()`
+#' operates _within_ each group. Because of this, you cannot complete a grouping
+#' column.
 #'
 #' @inheritParams expand
 #' @param fill A named list that for each variable supplies a single value to

--- a/R/expand.R
+++ b/R/expand.R
@@ -14,9 +14,9 @@
 #'  * use it with `anti_join()` to figure out which combinations are missing
 #'    (e.g., identify gaps in your data frame).
 #'
-#' @details
-#' With grouped data frames, `expand()` operates _within_ each group. Because of
-#' this, you cannot expand on a grouping column.
+#' @section Grouped data frames:
+#' With grouped data frames created by [dplyr::group_by()], `expand()` operates
+#' _within_ each group. Because of this, you cannot expand on a grouping column.
 #'
 #' @inheritParams expand_grid
 #' @param data A data frame.

--- a/R/fill.R
+++ b/R/fill.R
@@ -6,7 +6,12 @@
 #'
 #' Missing values are replaced in atomic vectors; `NULL`s are replaced in lists.
 #'
-#' @inheritParams gather
+#' @section Grouped data frames:
+#' With grouped data frames created by [dplyr::group_by()], `fill()` will be
+#' applied _within_ each group, meaning that it won't fill across group
+#' boundaries.
+#'
+#' @param data A data frame.
 #' @param ... <[`tidy-select`][tidyr_tidy_select]> Columns to fill.
 #' @param .direction Direction in which to fill missing values. Currently
 #'   either "down" (the default), "up", "downup" (i.e. first down and then up)

--- a/man/complete.Rd
+++ b/man/complete.Rd
@@ -44,10 +44,13 @@ Turns implicit missing values into explicit missing values. This is a wrapper
 around \code{\link[=expand]{expand()}}, \code{\link[dplyr:mutate-joins]{dplyr::full_join()}} and \code{\link[=replace_na]{replace_na()}} that's useful for
 completing missing combinations of data.
 }
-\details{
-With grouped data frames, \code{complete()} operates \emph{within} each group. Because
-of this, you cannot complete a grouping column.
+\section{Grouped data frames}{
+
+With grouped data frames created by \code{\link[dplyr:group_by]{dplyr::group_by()}}, \code{complete()}
+operates \emph{within} each group. Because of this, you cannot complete a grouping
+column.
 }
+
 \examples{
 df <- tibble(
   group = c(1:2, 1, 2),

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -68,10 +68,12 @@ explicit missing values (e.g., fill in gaps in your data frame).
 (e.g., identify gaps in your data frame).
 }
 }
-\details{
-With grouped data frames, \code{expand()} operates \emph{within} each group. Because of
-this, you cannot expand on a grouping column.
+\section{Grouped data frames}{
+
+With grouped data frames created by \code{\link[dplyr:group_by]{dplyr::group_by()}}, \code{expand()} operates
+\emph{within} each group. Because of this, you cannot expand on a grouping column.
 }
+
 \examples{
 # Finding combinations ------------------------------------------------------
 fruits <- tibble(

--- a/man/fill.Rd
+++ b/man/fill.Rd
@@ -23,6 +23,13 @@ and are only recorded when they change.
 \details{
 Missing values are replaced in atomic vectors; \code{NULL}s are replaced in lists.
 }
+\section{Grouped data frames}{
+
+With grouped data frames created by \code{\link[dplyr:group_by]{dplyr::group_by()}}, \code{fill()} will be
+applied \emph{within} each group, meaning that it won't fill across group
+boundaries.
+}
+
 \examples{
 # direction = "down" --------------------------------------------------------
 # Value (year) is recorded only when it changes


### PR DESCRIPTION
Closes #952

There are 4 functions that support grouped data frames in a special way (beyond just reconstruction on the way out)
- `nest()` (method)
- `expand()` (method)
- `complete()` (method)
- `fill()` (`mutate_at()`)

`nest()`, `expand()`, and `complete()` all already documented their grouped df support, having both examples and a section specifically about grouped data frames.

I've standardized all of the functions to have a `Grouped data frames:` section, repurposing existing bits as appropriate (`nest()` already had one and has no changes)