### PR TITLE
POC Rethrow purrr errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     glue,
     lifecycle (>= 1.0.3),
     magrittr,
-    purrr (>= 1.0.0),
+    purrr (>= 1.0.0.9000),
     rlang (>= 1.0.4),
     stringr (>= 1.5.0),
     tibble (>= 2.1.1),
@@ -52,3 +52,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 SystemRequirements: C++11
+Remotes:
+    tidyverse/purrr#1034

--- a/R/utils.R
+++ b/R/utils.R
@@ -245,13 +245,14 @@ check_list_of_functions <- function(x, names, arg = caller_arg(x), call = caller
   }
 
   check_unique_names(x, arg = arg, call = call)
+  x_names <- names(x)
 
-  x <- lapply(set_names(seq_along(x), names(x)), function(i) {
-    as_function(x[[i]], arg = glue("{arg}[[{i}]]"), call = call)
-  })
+  for (i in seq_along(x)) {
+    x[[i]] <- as_function(x[[i]], arg = glue("{arg}${x_names[[i]]}"), call = call)
+  }
 
   # Silently drop user supplied names not found in the data
-  x <- x[intersect(names(x), names)]
+  x <- x[intersect(x_names, names)]
 
   x
 }

--- a/tests/testthat/_snaps/unnest-helper.md
+++ b/tests/testthat/_snaps/unnest-helper.md
@@ -71,7 +71,7 @@
     Output
       <error/rlang_error>
       Error:
-      ! Can't convert `transform[[1]]`, a number, to a function.
+      ! Can't convert `transform$x`, a number, to a function.
     Code
       (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))
     Output

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -5,7 +5,10 @@
     Output
       <error/rlang_error>
       Error in `unnest_wider()`:
-      ! List-column `y` must contain only vectors.
+      i In column: `y`.
+      i In row: 1.
+      Caused by error:
+      ! List-column must only contain vectors.
 
 # can unnest a vector with a mix of named/unnamed elements (#1200 comment)
 


### PR DESCRIPTION
Mainly important for `unnest_wider()`. A few notes:
- Set `error_call = NULL` for `elt_to_wide()` to it doesn't try to report `unnest_wider()` in the parent error too
- Tweaked an `elt_to_wide()` error to no longer mention the column name, since that is now done in the wrapper error

I switched to a for-loop approach in `check_list_of_functions()`. I tried converting it over to purrr, but it didn't seem worth it. Since we already report the `arg` in a pretty way through `as_function()`, really we just wanted to turn off the purrr error wrapping support. I had this ready to go, but it ended up being more code for little benefit vs just a loop:

```r
without_purrr_indexed_errors <- function(expr) {
  try_fetch(
    expr,
    purrr_error_indexed = function(cnd) {
      cnd_signal(cnd$parent)
    }
  )
}
``` 