### PR TITLE
Improve on `unpack()` column name duplication errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # tidyr (development version)
 
 * `unpack()` does a better job of reporting column name duplication issues and
-  gives better advise about how to resolve them using `names_sep`. This also
+  gives better advice about how to resolve them using `names_sep`. This also
   improves errors from functions that use `unpack()`, like `unnest()` and
   `unnest_wider()` (#1425, #1367).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tidyr (development version)
 
+* `unpack()` does a better job of reporting column name duplication issues and
+  gives better advise about how to resolve them using `names_sep`. This also
+  improves errors from functions that use `unpack()`, like `unnest()` and
+  `unnest_wider()` (#1425, #1367).
+
 * `unnest_longer()` now uses `""` in the index column for fully unnamed
   vectors. It also now consistently uses `NA` in the index column for empty
   vectors that are "kept" by `keep_empty = TRUE` (#1442).

--- a/R/pack.R
+++ b/R/pack.R
@@ -178,14 +178,14 @@ check_inner_inner_duplicate <- function(x, error_call = caller_env()) {
   outers <- split$val
 
   bullets <- map2_chr(inners, outers, function(inner, outer) {
-    cli::format_inline("{.code {inner}}, across {.code {outer}}.")
+    cli::format_inline("{.code {inner}}, within {.code {outer}}.")
   })
   bullets <- set_names(bullets, "i")
   bullets <- cli::format_bullets_raw(bullets)
   bullets <- set_names(bullets, " ")
 
   message <- c(
-    "Can't duplicate names across the modified columns.",
+    "Can't duplicate names within the affected columns.",
     x = "These names are duplicated:",
     bullets,
     i = "Use `names_sep` to disambiguate using the column name.",
@@ -217,7 +217,7 @@ check_outer_inner_duplicate <- function(x, outer, error_call = caller_env()) {
   bullets <- set_names(bullets, " ")
 
   message <- c(
-    "Can't duplicate names between the modified columns and the original data.",
+    "Can't duplicate names between the affected columns and the original data.",
     x = "These names are duplicated:",
     bullets,
     i = "Use `names_sep` to disambiguate using the column name.",

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -21,6 +21,67 @@
       Error in `pack()`:
       ! `.names_sep` must be a single string or `NULL`, not the number 1.
 
+# catches across inner name duplication (#1425)
+
+    Code
+      unpack(df, c(x, y))
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names across the modified columns.
+      x These names are duplicated:
+        i `b`, across `x` and `y`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
+---
+
+    Code
+      unpack(df, c(x, y, z))
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names across the modified columns.
+      x These names are duplicated:
+        i `a`, across `x` and `z`.
+        i `b`, across `x`, `y`, and `z`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
+# catches outer / inner name duplication (#1367)
+
+    Code
+      unpack(df, d)
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names between the modified columns and the original data.
+      x These names are duplicated:
+        i `a`, from `d`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
+---
+
+    Code
+      unpack(df, c(d, e, f))
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names between the modified columns and the original data.
+      x These names are duplicated:
+        i `a`, from `d`.
+        i `b` and `c`, from `f`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
+# duplication errors aren't triggered on duplicates within a single column you are unpacking
+
+    Code
+      unpack(df, x)
+    Condition
+      Error in `unpack()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
+      i Use argument `names_repair` to specify repair strategy.
+
 # unpack() validates its inputs
 
     Code

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -27,9 +27,9 @@
       unpack(df, c(x, y))
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names across the modified columns.
+      ! Can't duplicate names within the affected columns.
       x These names are duplicated:
-        i `b`, across `x` and `y`.
+        i `b`, within `x` and `y`.
       i Use `names_sep` to disambiguate using the column name.
       i Or use `names_repair` to specify a repair strategy.
 
@@ -39,10 +39,10 @@
       unpack(df, c(x, y, z))
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names across the modified columns.
+      ! Can't duplicate names within the affected columns.
       x These names are duplicated:
-        i `a`, across `x` and `z`.
-        i `b`, across `x`, `y`, and `z`.
+        i `a`, within `x` and `z`.
+        i `b`, within `x`, `y`, and `z`.
       i Use `names_sep` to disambiguate using the column name.
       i Or use `names_repair` to specify a repair strategy.
 
@@ -52,7 +52,7 @@
       unpack(df, d)
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names between the modified columns and the original data.
+      ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `a`, from `d`.
       i Use `names_sep` to disambiguate using the column name.
@@ -64,7 +64,7 @@
       unpack(df, c(d, e, f))
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names between the modified columns and the original data.
+      ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `a`, from `d`.
         i `b` and `c`, from `f`.

--- a/tests/testthat/_snaps/separate-wider.md
+++ b/tests/testthat/_snaps/separate-wider.md
@@ -149,7 +149,7 @@
       separate_wider_regex(df, y, patterns = c(x = ".", value = "."))
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names between the modified columns and the original data.
+      ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `x`, from `y`.
       i Use `names_sep` to disambiguate using the column name.
@@ -161,10 +161,10 @@
       separate_wider_regex(df, c(x, y), patterns = c(gender = ".", value = "."))
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names across the modified columns.
+      ! Can't duplicate names within the affected columns.
       x These names are duplicated:
-        i `gender`, across `x` and `y`.
-        i `value`, across `x` and `y`.
+        i `gender`, within `x` and `y`.
+        i `value`, within `x` and `y`.
       i Use `names_sep` to disambiguate using the column name.
       i Or use `names_repair` to specify a repair strategy.
 

--- a/tests/testthat/_snaps/separate-wider.md
+++ b/tests/testthat/_snaps/separate-wider.md
@@ -143,6 +143,31 @@
       ! Invalid number of groups.
       i Did you use "()" instead of "(?:)" inside `patterns`?
 
+# separate_wider_regex() advises on outer / inner name duplication (#1425)
+
+    Code
+      separate_wider_regex(df, y, patterns = c(x = ".", value = "."))
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names between the modified columns and the original data.
+      x These names are duplicated:
+        i `x`, from `y`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
+# separate_wider_regex() advises on inner / inner name duplication (#1425)
+
+    Code
+      separate_wider_regex(df, c(x, y), patterns = c(gender = ".", value = "."))
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names across the modified columns.
+      x These names are duplicated:
+        i `gender`, across `x` and `y`.
+        i `value`, across `x` and `y`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
 # separate_wider_regex() validates its inputs
 
     Code

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -52,6 +52,30 @@
       New names:
       * `` -> `...1`
 
+# unnest_wider() advises on outer / inner name duplication (#1367)
+
+    Code
+      unnest_wider(df, y)
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names between the modified columns and the original data.
+      x These names are duplicated:
+        i `x`, from `y`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
+# unnest_wider() advises on inner / inner name duplication (#1367)
+
+    Code
+      unnest_wider(df, c(y, z))
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names across the modified columns.
+      x These names are duplicated:
+        i `a`, across `y` and `z`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
 # unnest_wider() validates its inputs
 
     Code

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -58,7 +58,7 @@
       unnest_wider(df, y)
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names between the modified columns and the original data.
+      ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `x`, from `y`.
       i Use `names_sep` to disambiguate using the column name.
@@ -70,9 +70,9 @@
       unnest_wider(df, c(y, z))
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names across the modified columns.
+      ! Can't duplicate names within the affected columns.
       x These names are duplicated:
-        i `a`, across `y` and `z`.
+        i `a`, within `y` and `z`.
       i Use `names_sep` to disambiguate using the column name.
       i Or use `names_repair` to specify a repair strategy.
 

--- a/tests/testthat/_snaps/unnest.md
+++ b/tests/testthat/_snaps/unnest.md
@@ -34,6 +34,30 @@
       Error in `list_unchop()`:
       ! Can't combine `x[[1]]` <double> and `x[[2]]` <tbl_df>.
 
+# unnest() advises on outer / inner name duplication
+
+    Code
+      unnest(df, y)
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names between the modified columns and the original data.
+      x These names are duplicated:
+        i `x`, from `y`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
+# unnest() advises on inner / inner name duplication
+
+    Code
+      unnest(df, c(x, y))
+    Condition
+      Error in `unpack()`:
+      ! Can't duplicate names across the modified columns.
+      x These names are duplicated:
+        i `a`, across `x` and `y`.
+      i Use `names_sep` to disambiguate using the column name.
+      i Or use `names_repair` to specify a repair strategy.
+
 # cols must go in cols
 
     Code

--- a/tests/testthat/_snaps/unnest.md
+++ b/tests/testthat/_snaps/unnest.md
@@ -40,7 +40,7 @@
       unnest(df, y)
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names between the modified columns and the original data.
+      ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `x`, from `y`.
       i Use `names_sep` to disambiguate using the column name.
@@ -52,9 +52,9 @@
       unnest(df, c(x, y))
     Condition
       Error in `unpack()`:
-      ! Can't duplicate names across the modified columns.
+      ! Can't duplicate names within the affected columns.
       x These names are duplicated:
-        i `a`, across `x` and `y`.
+        i `a`, within `x` and `y`.
       i Use `names_sep` to disambiguate using the column name.
       i Or use `names_repair` to specify a repair strategy.
 

--- a/tests/testthat/test-pack.R
+++ b/tests/testthat/test-pack.R
@@ -91,6 +91,75 @@ test_that("can unpack 1-row but 0-col dataframe (#1189)", {
   expect_identical(unpack(df, x), tibble::new_tibble(list(), nrow = 1L))
 })
 
+test_that("catches across inner name duplication (#1425)", {
+  df <- tibble(
+    x = tibble(a = 3, b = 4),
+    y = tibble(b = 5),
+    z = tibble(a = 6, b = 6)
+  )
+
+  expect_snapshot(error = TRUE, {
+    unpack(df, c(x, y))
+  })
+  expect_snapshot(error = TRUE, {
+    unpack(df, c(x, y, z))
+  })
+})
+
+test_that("catches outer / inner name duplication (#1367)", {
+  df <- tibble(
+    a = 1,
+    b = 2,
+    c = 3,
+    d = tibble(a = 4),
+    e = tibble(d = 5),
+    f = tibble(b = 6, c = 7, g = 8)
+  )
+
+  expect_snapshot(error = TRUE, {
+    unpack(df, d)
+  })
+  expect_snapshot(error = TRUE, {
+    unpack(df, c(d, e, f))
+  })
+})
+
+test_that("duplication error isn't triggered on the names you are unpacking", {
+  df <- tibble(x = tibble(x = 1))
+  expect_identical(unpack(df, x), tibble(x = 1))
+})
+
+test_that("duplication errors aren't triggered if `names_sep` is specified", {
+  df1 <- tibble(
+    x = 1,
+    y = tibble(x = 2)
+  )
+  df2 <- tibble(
+    x = tibble(a = 1),
+    y = tibble(a = 2)
+  )
+
+  expect_identical(
+    unpack(df1, y, names_sep = "_"),
+    tibble(x = 1, y_x = 2)
+  )
+  expect_identical(
+    unpack(df2, c(x, y), names_sep = "_"),
+    tibble(x_a = 1, y_a = 2)
+  )
+})
+
+test_that("duplication errors aren't triggered on duplicates within a single column you are unpacking", {
+  df <- tibble(
+    x = tibble(a = 1, a = 2, .name_repair = "minimal")
+  )
+
+  # `vec_as_names()` handles this one
+  expect_snapshot(error = TRUE, {
+    unpack(df, x)
+  })
+})
+
 test_that("unpack() validates its inputs", {
   df <- tibble(x = 1:2, y = tibble(a = 1:2, b = 1:2))
 

--- a/tests/testthat/test-separate-wider.R
+++ b/tests/testthat/test-separate-wider.R
@@ -234,6 +234,22 @@ test_that("separate_wider_regex() works with empty data frames", {
   expect_equal(out, tibble(y = character(), z = character()))
 })
 
+test_that("separate_wider_regex() advises on outer / inner name duplication (#1425)", {
+  df <- tibble(x = 1, y = "g1")
+
+  expect_snapshot(error = TRUE, {
+    separate_wider_regex(df, y, patterns = c(x = ".", value = "."))
+  })
+})
+
+test_that("separate_wider_regex() advises on inner / inner name duplication (#1425)", {
+  df <- tibble(x = "g1", y = "m2")
+
+  expect_snapshot(error = TRUE, {
+    separate_wider_regex(df, c(x, y), patterns = c(gender = ".", value = "."))
+  })
+})
+
 test_that("separate_wider_regex() validates its inputs", {
   df <- tibble(x = "x")
   expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-unnest-wider.R
+++ b/tests/testthat/test-unnest-wider.R
@@ -232,6 +232,22 @@ test_that("can combine `<list> + <list_of<ptype>>`", {
   expect_identical(out$a, list(1:2, 1L))
 })
 
+test_that("unnest_wider() advises on outer / inner name duplication (#1367)", {
+  df <- tibble(x = 1, y = list(list(x = 2)))
+
+  expect_snapshot(error = TRUE, {
+    unnest_wider(df, y)
+  })
+})
+
+test_that("unnest_wider() advises on inner / inner name duplication (#1367)", {
+  df <- tibble(x = 1, y = list(list(a = 2)), z = list(list(a = 3)))
+
+  expect_snapshot(error = TRUE, {
+    unnest_wider(df, c(y, z))
+  })
+})
+
 test_that("unnest_wider() validates its inputs", {
   df <- tibble(x = list(a = 1:2, b = 3:4))
   expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -117,6 +117,25 @@ test_that("unnesting column of mixed vector / data frame input is an error", {
   expect_snapshot((expect_error(unnest(df, x))))
 })
 
+test_that("unnest() advises on outer / inner name duplication", {
+  df <- tibble(x = 1, y = list(tibble(x = 2)))
+
+  expect_snapshot(error = TRUE, {
+    unnest(df, y)
+  })
+})
+
+test_that("unnest() advises on inner / inner name duplication", {
+  df <- tibble(
+    x = list(tibble(a = 1)),
+    y = list(tibble(a = 2))
+  )
+
+  expect_snapshot(error = TRUE, {
+    unnest(df, c(x, y))
+  })
+})
+
 # other methods -----------------------------------------------------------------
 
 test_that("rowwise_df becomes grouped_df", {


### PR DESCRIPTION
Closes #1425 (Unless we decide otherwise)
Related to #1367

I'd say that this resolves #1425 by giving a much better error message.

It also resolves this comment https://github.com/tidyverse/tidyr/issues/1367#issuecomment-1147998930, again with a much better error message.

It does _not_ resolve the original issue presented in #1367 about using some automatic separator for unnamed elements. I think that is related but can be thought about separately. I've kept that one open.

In general this improves errors for `unpack()`, `unnest()`, `unnest_wider()`, and the `separate_wider_*()` family.

---

There are two types of name duplication issues that can occur when unpacking, which I have called:
- inner / inner duplication (unpacking multiple columns that have duplicate inner names)
- outer / inner duplication (unpacking 1 column that duplicates an outer name)

This PR attempts to give better error messages for both of those cases when `names_sep = NULL` and `names_repair = "check_unique"`, i.e. the user has not attempted to solve these issues themselves yet.

I tried not to mention "unpacking" in the error because these bubble up from other functions.

``` r
library(tidyr)

# inner / inner
df <- tibble(
  x = list(tibble(a = 1)),
  y = list(tibble(a = 2))
)
unnest(df, c(x, y))
#> Error in `unpack()` at tidyr/R/unnest.R:181:2:
#> ! Can't duplicate names across the modified columns.
#> ✖ These names are duplicated:
#>   ℹ `a`, across `x` and `y`.
#> ℹ Use `names_sep` to disambiguate using the column name.
#> ℹ Or use `names_repair` to specify a repair strategy.

# outer / inner
df <- tibble(
  x = 1, 
  y = list(tibble(x = 2))
)
unnest(df, y)
#> Error in `unpack()` at tidyr/R/unnest.R:181:2:
#> ! Can't duplicate names between the modified columns and the original data.
#> ✖ These names are duplicated:
#>   ℹ `x`, from `y`.
#> ℹ Use `names_sep` to disambiguate using the column name.
#> ℹ Or use `names_repair` to specify a repair strategy.
```

You would get more indented bullets if there are additional problems (see tests)
