### PR TITLE
Add `error_call` and `...` to packing/chopping utilities

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,10 @@
 * `chop()`, `unpack()`, and `unchop()` have all gained `...`, which must be
   empty (#1447).
   
-* `unpack()`, `chop()`, and `unchop()` now all consistently disallow renaming
-  using the `cols` tidyselect argument.
+* `nest()`, `unnest()`, `pack()`, `unpack()`, `chop()`, and `unchop()` now
+  consistently disallow renaming during tidy-selection. Renaming is never
+  meaningful in these functions, and previously either had no effect or caused
+  problems (#1449).
 
 * `pack()`, `unpack()`, `chop()`, and `unchop()` have all gained `error_call`
   arguments, which in turn improves some of the error calls shown in `nest()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # tidyr (development version)
 
+* `chop()`, `unpack()`, and `unchop()` have all gained `...`, which must be
+  empty (#1447).
+  
+* `unpack()`, `chop()`, and `unchop()` now all consistently disallow renaming
+  using the `cols` tidyselect argument.
+
+* `pack()`, `unpack()`, `chop()`, and `unchop()` have all gained `error_call`
+  arguments, which in turn improves some of the error calls shown in `nest()`
+  and various `unnest()` adjacent functions (#1446).
+
 * `unpack()` does a better job of reporting column name duplication issues and
   gives better advice about how to resolve them using `names_sep`. This also
   improves errors from functions that use `unpack()`, like `unnest()` and

--- a/R/chop.R
+++ b/R/chop.R
@@ -22,6 +22,9 @@
 #' the type of its elements, `unchop()` is able to reconstitute the
 #' correct vector type even for empty list-columns.
 #'
+#' @inheritParams rlang::args_dots_empty
+#' @inheritParams rlang::args_error_context
+#'
 #' @param data A data frame.
 #' @param cols <[`tidy-select`][tidyr_tidy_select]> Columns to chop or unchop.
 #'
@@ -62,10 +65,17 @@
 #' df <- tibble(x = 1:3, y = list(NULL, tibble(x = 1), tibble(y = 1:2)))
 #' df %>% unchop(y)
 #' df %>% unchop(y, keep_empty = TRUE)
-chop <- function(data, cols) {
-  check_data_frame(data)
-  check_required(cols)
-  cols <- tidyselect::eval_select(enquo(cols), data, allow_rename = FALSE)
+chop <- function(data, cols, ..., error_call = current_env()) {
+  check_dots_empty0(...)
+  check_data_frame(data, call = error_call)
+  check_required(cols, call = error_call)
+
+  cols <- tidyselect::eval_select(
+    expr = enquo(cols),
+    data = data,
+    allow_rename = FALSE,
+    error_call = error_call
+  )
 
   cols <- tidyr_new_list(data[cols])
   keys <- data[setdiff(names(data), names(cols))]
@@ -79,7 +89,7 @@ chop <- function(data, cols) {
   cols <- map(cols, col_chop, indices = indices)
   cols <- new_data_frame(cols, n = size)
 
-  out <- vec_cbind(keys, cols)
+  out <- vec_cbind(keys, cols, .error_call = error_call)
 
   reconstruct_tibble(data, out)
 }

--- a/R/chop.R
+++ b/R/chop.R
@@ -105,12 +105,23 @@ col_chop <- function(x, indices) {
 
 #' @export
 #' @rdname chop
-unchop <- function(data, cols, keep_empty = FALSE, ptype = NULL) {
-  check_data_frame(data)
-  check_required(cols)
-  check_bool(keep_empty)
+unchop <- function(data,
+                   cols,
+                   ...,
+                   keep_empty = FALSE,
+                   ptype = NULL,
+                   error_call = current_env()) {
+  check_dots_empty0(...)
+  check_data_frame(data, call = error_call)
+  check_required(cols, call = error_call)
+  check_bool(keep_empty, call = error_call)
 
-  sel <- tidyselect::eval_select(enquo(cols), data)
+  sel <- tidyselect::eval_select(
+    expr = enquo(cols),
+    data = data,
+    allow_rename = FALSE,
+    error_call = error_call
+  )
 
   size <- vec_size(data)
   names <- names(data)
@@ -122,7 +133,12 @@ unchop <- function(data, cols, keep_empty = FALSE, ptype = NULL) {
   # Remove unchopped columns to avoid slicing them needlessly later
   out[sel] <- NULL
 
-  result <- df_unchop(cols, ptype = ptype, keep_empty = keep_empty)
+  result <- df_unchop(
+    x = cols,
+    ptype = ptype,
+    keep_empty = keep_empty,
+    error_call = error_call
+  )
   cols <- result$val
   loc <- result$loc
 

--- a/R/nest.R
+++ b/R/nest.R
@@ -139,7 +139,7 @@ nest.tbl_df <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
   error_call <- current_env()
 
   out <- pack(.data, !!!cols, .names_sep = .names_sep, .error_call = error_call)
-  out <- chop(out, cols = all_of(names(cols)))
+  out <- chop(out, cols = all_of(names(cols)), error_call = error_call)
 
   # `nest()` currently doesn't return list-of columns
   for (name in names(cols)) {

--- a/R/nest.R
+++ b/R/nest.R
@@ -125,7 +125,6 @@ nest.data.frame <- function(.data, ..., .names_sep = NULL, .key = deprecated()) 
 
 #' @export
 nest.tbl_df <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
-  check_string(.names_sep, allow_null = TRUE)
   .key <- check_key(.key)
   if (missing(...)) {
     cli::cli_warn(c(
@@ -137,7 +136,9 @@ nest.tbl_df <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
     cols <- enquos(...)
   }
 
-  out <- pack(.data, !!!cols, .names_sep = .names_sep)
+  error_call <- current_env()
+
+  out <- pack(.data, !!!cols, .names_sep = .names_sep, .error_call = error_call)
   out <- chop(out, cols = all_of(names(cols)))
 
   # `nest()` currently doesn't return list-of columns

--- a/R/pack.R
+++ b/R/pack.R
@@ -26,9 +26,12 @@
 #'   `pack()`, the new inner names will have the outer names + `names_sep`
 #'   automatically stripped. This makes `names_sep` roughly symmetric between
 #'   packing and unpacking.
-#' @param ... <[`tidy-select`][tidyr_tidy_select]> Columns to pack, specified
-#'   using name-variable pairs of the form `new_col = c(col1, col2, col3)`.
-#'   The right hand side can be any valid tidy select expression.
+#' @param ... For `pack()`, <[`tidy-select`][tidyr_tidy_select]> columns to
+#'   pack, specified using name-variable pairs of the form
+#'   `new_col = c(col1, col2, col3)`. The right hand side can be any valid tidy
+#'   select expression.
+#'
+#'   For `unpack()`, these dots are for future extensions and must be empty.
 #' @export
 #' @examples
 #' # Packing -------------------------------------------------------------------
@@ -108,15 +111,26 @@ pack <- function(.data, ..., .names_sep = NULL, .error_call = current_env()) {
 #'
 #'   See [vctrs::vec_as_names()] for more details on these terms and the
 #'   strategies used to enforce them.
-unpack <- function(data, cols, names_sep = NULL, names_repair = "check_unique") {
-  check_data_frame(data)
-  check_required(cols)
-  check_string(names_sep, allow_null = TRUE)
+unpack <- function(data,
+                   cols,
+                   ...,
+                   names_sep = NULL,
+                   names_repair = "check_unique",
+                   error_call = current_env()) {
+  check_dots_empty0(...)
+  check_data_frame(data, call = error_call)
+  check_required(cols, call = error_call)
+  check_string(names_sep, allow_null = TRUE, call = error_call)
 
   # Start from first principles to avoid issues in any subclass methods
   out <- tidyr_new_list(data)
 
-  cols <- tidyselect::eval_select(enquo(cols), data)
+  cols <- tidyselect::eval_select(
+    expr = enquo(cols),
+    data = data,
+    allow_rename = FALSE,
+    error_call = error_call
+  )
   cols <- out[cols]
   cols <- cols[map_lgl(cols, is.data.frame)]
 
@@ -125,8 +139,8 @@ unpack <- function(data, cols, names_sep = NULL, names_repair = "check_unique") 
   if (is.null(names_sep) && is_string(names_repair, "check_unique")) {
     # Only perform checks if user hasn't supplied `names_sep` or `names_repair`.
     # We let `vec_as_names()` catch any remaining problems.
-    check_inner_inner_duplicate(cols)
-    check_outer_inner_duplicate(cols, names(data))
+    check_inner_inner_duplicate(cols, error_call = error_call)
+    check_outer_inner_duplicate(cols, names(data), error_call = error_call)
   }
 
   if (!is.null(names_sep)) {
@@ -150,7 +164,8 @@ unpack <- function(data, cols, names_sep = NULL, names_repair = "check_unique") 
   names(out) <- vec_as_names(
     names = names(out),
     repair = names_repair,
-    repair_arg = "names_repair"
+    repair_arg = "names_repair",
+    call = error_call
   )
 
   reconstruct_tibble(data, out)

--- a/R/separate-longer.R
+++ b/R/separate-longer.R
@@ -94,5 +94,12 @@ map_unchop <- function(data, cols, fun, ..., .keep_empty = FALSE, .error_call = 
   for (col in col_names) {
     data[[col]] <- fun(data[[col]], ...)
   }
-  unchop(data, all_of(col_names), keep_empty = .keep_empty, ptype = character())
+
+  unchop(
+    data = data,
+    cols = all_of(col_names),
+    keep_empty = .keep_empty,
+    ptype = character(),
+    error_call = .error_call
+  )
 }

--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -45,12 +45,13 @@ separate_rows.data.frame <- function(data,
   check_bool(convert)
 
   vars <- tidyselect::eval_select(expr(c(...)), data, allow_rename = FALSE)
+  vars <- names(vars)
 
   out <- purrr::modify_at(data, vars, str_split_n, pattern = sep)
-  out <- unchop(as_tibble(out), any_of(vars))
+  out <- unchop(as_tibble(out), any_of(vars), error_call = current_env())
   if (convert) {
     out[vars] <- map(out[vars], type.convert, as.is = TRUE)
   }
 
-  reconstruct_tibble(data, out, names(vars))
+  reconstruct_tibble(data, out, vars)
 }

--- a/R/separate-wider.R
+++ b/R/separate-wider.R
@@ -503,10 +503,11 @@ map_unpack <- function(data, cols, fun, names_sep, names_repair, error_call = ca
   }
 
   unpack(
-    data,
-    all_of(col_names),
+    data = data,
+    cols = all_of(col_names),
     names_sep = names_sep,
-    names_repair = names_repair
+    names_repair = names_repair,
+    error_call = error_call
   )
 }
 

--- a/R/unnest-longer.R
+++ b/R/unnest-longer.R
@@ -129,7 +129,7 @@ unnest_longer <- function(data,
     )
   }
 
-  data <- unchop(data, all_of(col_names))
+  data <- unchop(data, all_of(col_names), error_call = error_call)
 
   for (i in seq_along(cols)) {
     col <- cols[[i]]

--- a/R/unnest-longer.R
+++ b/R/unnest-longer.R
@@ -88,6 +88,8 @@ unnest_longer <- function(data,
   check_bool(indices_include, allow_null = TRUE)
   check_bool(keep_empty)
 
+  error_call <- current_env()
+
   cols <- tidyselect::eval_select(enquo(col), data, allow_rename = FALSE)
   col_names <- names(cols)
   n_col_names <- length(col_names)
@@ -127,7 +129,7 @@ unnest_longer <- function(data,
     )
   }
 
-  data <- unchop(data, all_of(cols))
+  data <- unchop(data, all_of(col_names))
 
   for (i in seq_along(cols)) {
     col <- cols[[i]]
@@ -140,7 +142,12 @@ unnest_longer <- function(data,
     )
   }
 
-  unpack(data, all_of(cols), names_repair = names_repair)
+  unpack(
+    data = data,
+    cols = all_of(col_names),
+    names_repair = names_repair,
+    error_call = error_call
+  )
 }
 
 # Converts a column of any type to a `list_of<tbl>`

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -107,7 +107,7 @@ unnest_wider <- function(data,
     )
   }
 
-  data <- unchop(data, all_of(col_names))
+  data <- unchop(data, all_of(col_names), error_call = error_call)
 
   for (i in seq_along(cols)) {
     col <- cols[[i]]

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -90,6 +90,8 @@ unnest_wider <- function(data,
   check_string(names_sep, allow_null = TRUE)
   check_bool(strict)
 
+  error_call <- current_env()
+
   cols <- tidyselect::eval_select(enquo(col), data, allow_rename = FALSE)
   col_names <- names(cols)
 
@@ -105,7 +107,7 @@ unnest_wider <- function(data,
     )
   }
 
-  data <- unchop(data, all_of(cols))
+  data <- unchop(data, all_of(col_names))
 
   for (i in seq_along(cols)) {
     col <- cols[[i]]
@@ -118,7 +120,12 @@ unnest_wider <- function(data,
     )
   }
 
-  unpack(data, all_of(cols), names_repair = names_repair)
+  unpack(
+    data = data,
+    cols = all_of(col_names),
+    names_repair = names_repair,
+    error_call = error_call
+  )
 }
 
 # Converts a column of any type to a `list_of<tbl>`

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -181,7 +181,13 @@ unnest.data.frame <- function(data,
   cols <- tidyselect::eval_select(enquo(cols), data)
   cols <- unname(cols)
 
-  data <- unchop(data, all_of(cols), keep_empty = keep_empty, ptype = ptype)
+  data <- unchop(
+    data = data,
+    cols = all_of(cols),
+    keep_empty = keep_empty,
+    ptype = ptype,
+    error_call = error_call
+  )
 
   unpack(
     data = data,

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -178,7 +178,11 @@ unnest.data.frame <- function(data,
                               .preserve = "DEPRECATED") {
   error_call <- current_env()
 
-  cols <- tidyselect::eval_select(enquo(cols), data)
+  cols <- tidyselect::eval_select(
+    expr = enquo(cols),
+    data = data,
+    allow_rename = FALSE
+  )
   cols <- unname(cols)
 
   data <- unchop(

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -176,9 +176,20 @@ unnest.data.frame <- function(data,
                               .id = "DEPRECATED",
                               .sep = "DEPRECATED",
                               .preserve = "DEPRECATED") {
+  error_call <- current_env()
+
   cols <- tidyselect::eval_select(enquo(cols), data)
-  data <- unchop(data, any_of(cols), keep_empty = keep_empty, ptype = ptype)
-  unpack(data, any_of(cols), names_sep = names_sep, names_repair = names_repair)
+  cols <- unname(cols)
+
+  data <- unchop(data, all_of(cols), keep_empty = keep_empty, ptype = ptype)
+
+  unpack(
+    data = data,
+    cols = all_of(cols),
+    names_sep = names_sep,
+    names_repair = names_repair,
+    error_call = error_call
+  )
 }
 
 

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -5,7 +5,7 @@
 \alias{unchop}
 \title{Chop and unchop}
 \usage{
-chop(data, cols)
+chop(data, cols, ..., error_call = current_env())
 
 unchop(data, cols, keep_empty = FALSE, ptype = NULL)
 }
@@ -17,6 +17,13 @@ unchop(data, cols, keep_empty = FALSE, ptype = NULL)
 For \code{unchop()}, each column should be a list-column containing generalised
 vectors (e.g. any mix of \code{NULL}s, atomic vector, S3 vectors, a lists,
 or data frames).}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{keep_empty}{By default, you get one row of output for each element
 of the list that you are unchopping/unnesting. This means that if there's a

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -7,7 +7,14 @@
 \usage{
 chop(data, cols, ..., error_call = current_env())
 
-unchop(data, cols, keep_empty = FALSE, ptype = NULL)
+unchop(
+  data,
+  cols,
+  ...,
+  keep_empty = FALSE,
+  ptype = NULL,
+  error_call = current_env()
+)
 }
 \arguments{
 \item{data}{A data frame.}

--- a/man/pack.Rd
+++ b/man/pack.Rd
@@ -5,7 +5,7 @@
 \alias{unpack}
 \title{Pack and unpack}
 \usage{
-pack(.data, ..., .names_sep = NULL)
+pack(.data, ..., .names_sep = NULL, .error_call = current_env())
 
 unpack(data, cols, names_sep = NULL, names_repair = "check_unique")
 }
@@ -13,6 +13,11 @@ unpack(data, cols, names_sep = NULL, names_repair = "check_unique")
 \item{...}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pack, specified
 using name-variable pairs of the form \code{new_col = c(col1, col2, col3)}.
 The right hand side can be any valid tidy select expression.}
+
+\item{.error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{data, .data}{A data frame.}
 

--- a/man/pack.Rd
+++ b/man/pack.Rd
@@ -7,17 +7,22 @@
 \usage{
 pack(.data, ..., .names_sep = NULL, .error_call = current_env())
 
-unpack(data, cols, names_sep = NULL, names_repair = "check_unique")
+unpack(
+  data,
+  cols,
+  ...,
+  names_sep = NULL,
+  names_repair = "check_unique",
+  error_call = current_env()
+)
 }
 \arguments{
-\item{...}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to pack, specified
-using name-variable pairs of the form \code{new_col = c(col1, col2, col3)}.
-The right hand side can be any valid tidy select expression.}
+\item{...}{For \code{pack()}, <\code{\link[=tidyr_tidy_select]{tidy-select}}> columns to
+pack, specified using name-variable pairs of the form
+\code{new_col = c(col1, col2, col3)}. The right hand side can be any valid tidy
+select expression.
 
-\item{.error_call}{The execution environment of a currently
-running function, e.g. \code{caller_env()}. The function will be
-mentioned in error messages as the source of the error. See the
-\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
+For \code{unpack()}, these dots are for future extensions and must be empty.}
 
 \item{data, .data}{A data frame.}
 
@@ -48,6 +53,11 @@ names. Must be one of the following options:
 
 See \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}} for more details on these terms and the
 strategies used to enforce them.}
+
+\item{error_call, .error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \description{
 Packing and unpacking preserve the length of a data frame, changing its

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -2,39 +2,39 @@
 
 ## Failed to check (31)
 
-|package          |version |error |warning |note |
-|:----------------|:-------|:-----|:-------|:----|
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|FAMetA           |0.1.4   |1     |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|genekitr         |?       |      |        |     |
-|ggPMX            |?       |      |        |     |
-|IPEDSuploadables |2.6.5   |1     |        |     |
-|loon.ggplot      |?       |      |        |     |
-|NA               |?       |      |        |     |
-|NA               |?       |      |        |     |
-|MarketMatching   |?       |      |        |     |
-|NA               |?       |      |        |     |
-|numbat           |?       |      |        |     |
-|OlinkAnalyze     |?       |      |        |     |
-|Platypus         |?       |      |        |     |
-|NA               |?       |      |        |     |
-|RVA              |?       |      |        |     |
-|NA               |?       |      |        |     |
-|tinyarray        |?       |      |        |     |
-|vivid            |?       |      |        |     |
-|xpose.nlmixr2    |?       |      |        |     |
+|package        |version |error |warning |note |
+|:--------------|:-------|:-----|:-------|:----|
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|FAMetA         |0.1.4   |1     |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|genekitr       |?       |      |        |     |
+|ggPMX          |?       |      |        |     |
+|loon.ggplot    |?       |      |        |     |
+|NA             |?       |      |        |     |
+|NA             |?       |      |        |     |
+|MarketMatching |?       |      |        |     |
+|NA             |?       |      |        |     |
+|numbat         |?       |      |        |     |
+|OlinkAnalyze   |?       |      |        |     |
+|Platypus       |?       |      |        |     |
+|NA             |?       |      |        |     |
+|RVA            |?       |      |        |     |
+|NA             |?       |      |        |     |
+|tinyarray      |?       |      |        |     |
+|vivid          |?       |      |        |     |
+|NA             |?       |      |        |     |
+|xpose.nlmixr2  |?       |      |        |     |
 
 ## New problems (9)
 
@@ -42,11 +42,11 @@
 |:------------------|:-------|:------|:-------|:----|
 |[faux](problems.md#faux)|1.1.0   |       |__+1__  |     |
 |[ggpubr](problems.md#ggpubr)|0.5.0   |__+1__ |        |     |
-|[gprofiler2](problems.md#gprofiler2)|0.2.1   |       |__+1__  |1    |
+|[gutenbergr](problems.md#gutenbergr)|0.2.3   |__+1__ |        |2    |
 |[hlaR](problems.md#hlar)|0.1.6   |       |__+1__  |     |
 |[mapme.biodiversity](problems.md#mapmebiodiversity)|0.2.1   |__+1__ |        |     |
 |[metaconfoundr](problems.md#metaconfoundr)|0.1.1   |__+2__ |__+1__  |     |
-|[openalexR](problems.md#openalexr)|1.0.0   |       |__+1__  |     |
 |[recipes](problems.md#recipes)|1.0.3   |__+2__ |        |1    |
+|[tidypaleo](problems.md#tidypaleo)|0.1.2   |__+2__ |__+1__  |     |
 |[wpa](problems.md#wpa)|1.8.0   |__+2__ |        |     |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,9 +1,9 @@
 ## revdepcheck results
 
-We checked 1741 reverse dependencies (1723 from CRAN + 18 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 1744 reverse dependencies (1725 from CRAN + 19 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 9 new problems
- * We failed to check 13 packages
+ * We failed to check 12 packages
 
 Issues with CRAN packages are summarised below.
 
@@ -16,8 +16,8 @@ Issues with CRAN packages are summarised below.
 * ggpubr
   checking examples ... ERROR
 
-* gprofiler2
-  checking re-building of vignette outputs ... WARNING
+* gutenbergr
+  checking examples ... ERROR
 
 * hlaR
   checking re-building of vignette outputs ... WARNING
@@ -30,12 +30,14 @@ Issues with CRAN packages are summarised below.
   checking tests ... ERROR
   checking re-building of vignette outputs ... WARNING
 
-* openalexR
-  checking re-building of vignette outputs ... WARNING
-
 * recipes
   checking examples ... ERROR
   checking tests ... ERROR
+
+* tidypaleo
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... WARNING
 
 * wpa
   checking examples ... ERROR
@@ -43,16 +45,15 @@ Issues with CRAN packages are summarised below.
 
 ### Failed to check
 
-* FAMetA           (NA)
-* genekitr         (NA)
-* ggPMX            (NA)
-* IPEDSuploadables (NA)
-* loon.ggplot      (NA)
-* MarketMatching   (NA)
-* numbat           (NA)
-* OlinkAnalyze     (NA)
-* Platypus         (NA)
-* RVA              (NA)
-* tinyarray        (NA)
-* vivid            (NA)
-* xpose.nlmixr2    (NA)
+* FAMetA         (NA)
+* genekitr       (NA)
+* ggPMX          (NA)
+* loon.ggplot    (NA)
+* MarketMatching (NA)
+* numbat         (NA)
+* OlinkAnalyze   (NA)
+* Platypus       (NA)
+* RVA            (NA)
+* tinyarray      (NA)
+* vivid          (NA)
+* xpose.nlmixr2  (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -659,70 +659,6 @@ Status: 1 ERROR, 2 NOTEs
 
 
 ```
-# IPEDSuploadables
-
-<details>
-
-* Version: 2.6.5
-* GitHub: https://github.com/AlisonLanski/IPEDSuploadables
-* Source code: https://github.com/cran/IPEDSuploadables
-* Date/Publication: 2022-12-07 21:02:33 UTC
-* Number of recursive dependencies: 79
-
-Run `cloud_details(, "IPEDSuploadables")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘IPEDSuploadables’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/IPEDSuploadables/new/IPEDSuploadables.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘IPEDSuploadables’ ...
-** package ‘IPEDSuploadables’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘rstudioapi’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘IPEDSuploadables’
-* removing ‘/tmp/workdir/IPEDSuploadables/new/IPEDSuploadables.Rcheck/IPEDSuploadables’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘IPEDSuploadables’ ...
-** package ‘IPEDSuploadables’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘rstudioapi’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘IPEDSuploadables’
-* removing ‘/tmp/workdir/IPEDSuploadables/old/IPEDSuploadables.Rcheck/IPEDSuploadables’
-
-
-```
 # loon.ggplot
 
 <details>
@@ -1458,6 +1394,41 @@ Status: 2 NOTEs
 * checking re-building of vignette outputs ... OK
 * DONE
 Status: 2 NOTEs
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
 
 
 

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -80,36 +80,38 @@ Run `cloud_details(, "ggpubr")` for more info
     Execution halted
     ```
 
-# gprofiler2
+# gutenbergr
 
 <details>
 
-* Version: 0.2.1
-* GitHub: NA
-* Source code: https://github.com/cran/gprofiler2
-* Date/Publication: 2021-08-23 14:00:02 UTC
-* Number of recursive dependencies: 74
+* Version: 0.2.3
+* GitHub: https://github.com/ropensci/gutenbergr
+* Source code: https://github.com/cran/gutenbergr
+* Date/Publication: 2022-12-14 10:00:06 UTC
+* Number of recursive dependencies: 88
 
-Run `cloud_details(, "gprofiler2")` for more info
+Run `cloud_details(, "gutenbergr")` for more info
 
 </details>
 
 ## Newly broken
 
-*   checking re-building of vignette outputs ... WARNING
+*   checking examples ... ERROR
     ```
-    Error(s) in re-building vignettes:
-      ...
-    --- re-building ‘gprofiler2.Rmd’ using rmarkdown
-    Quitting from lines 210-215 (gprofiler2.Rmd) 
-    Error: processing vignette 'gprofiler2.Rmd' failed with diagnostics:
-    Bad request, response code 502
-    --- failed re-building ‘gprofiler2.Rmd’
+    Running examples in ‘gutenbergr-Ex.R’ failed
+    The error most likely occurred in:
     
-    SUMMARY: processing the following file failed:
-      ‘gprofiler2.Rmd’
-    
-    Error: Vignette re-building failed.
+    > ### Name: gutenberg_get_mirror
+    > ### Title: Get the recommended mirror for Gutenberg files
+    > ### Aliases: gutenberg_get_mirror
+    > 
+    > ### ** Examples
+    > 
+    > gutenberg_get_mirror()
+    Determining mirror for Project Gutenberg from https://www.gutenberg.org/robot/harvest
+    Error in open.connection(3L, "rb") : 
+      Timeout was reached: [www.gutenberg.org] Operation timed out after 10001 milliseconds with 0 out of 0 bytes received
+    Calls: gutenberg_get_mirror ... <Anonymous> -> vroom_ -> <Anonymous> -> open.connection
     Execution halted
     ```
 
@@ -117,9 +119,14 @@ Run `cloud_details(, "gprofiler2")` for more info
 
 *   checking installed package size ... NOTE
     ```
-      installed size is  5.5Mb
+      installed size is  5.1Mb
       sub-directories of 1Mb or more:
-        doc   5.3Mb
+        data   4.6Mb
+    ```
+
+*   checking data for non-ASCII characters ... NOTE
+    ```
+      Note: found 18981 marked UTF-8 strings
     ```
 
 # hlaR
@@ -277,39 +284,6 @@ Run `cloud_details(, "metaconfoundr")` for more info
     Execution halted
     ```
 
-# openalexR
-
-<details>
-
-* Version: 1.0.0
-* GitHub: https://github.com/massimoaria/openalexR
-* Source code: https://github.com/cran/openalexR
-* Date/Publication: 2022-10-06 10:40:02 UTC
-* Number of recursive dependencies: 78
-
-Run `cloud_details(, "openalexR")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-      ...
-    --- re-building ‘A_Brief_Introduction_to_openalexR.Rmd’ using rmarkdown
-    Quitting from lines 260-269 (A_Brief_Introduction_to_openalexR.Rmd) 
-    Error: processing vignette 'A_Brief_Introduction_to_openalexR.Rmd' failed with diagnostics:
-    $ operator is invalid for atomic vectors
-    --- failed re-building ‘A_Brief_Introduction_to_openalexR.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘A_Brief_Introduction_to_openalexR.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
-    ```
-
 # recipes
 
 <details>
@@ -378,6 +352,94 @@ Run `cloud_details(, "recipes")` for more info
 *   checking Rd cross-references ... NOTE
     ```
     Packages unavailable to check Rd xrefs: ‘fastICA’, ‘dimRed’
+    ```
+
+# tidypaleo
+
+<details>
+
+* Version: 0.1.2
+* GitHub: https://github.com/paleolimbot/tidypaleo
+* Source code: https://github.com/cran/tidypaleo
+* Date/Publication: 2022-02-24 11:50:02 UTC
+* Number of recursive dependencies: 86
+
+Run `cloud_details(, "tidypaleo")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘tidypaleo-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: layer_dendrogram
+    > ### Title: Add a dendrogram as a layer or facet
+    > ### Aliases: layer_dendrogram plot_layer_dendrogram layer_zone_boundaries
+    > 
+    > ### ** Examples
+    > 
+    > library(ggplot2)
+    ...
+     11.           └─tidyselect::eval_select(...)
+     12.             └─tidyselect:::eval_select_impl(...)
+     13.               ├─tidyselect:::with_subscript_errors(...)
+     14.               │ └─rlang::try_fetch(...)
+     15.               │   └─base::withCallingHandlers(...)
+     16.               └─tidyselect:::vars_select_eval(...)
+     17.                 └─tidyselect:::ensure_named(...)
+     18.                   └─cli::cli_abort(...)
+     19.                     └─rlang::abort(...)
+    Execution halted
+    ```
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+        5.       └─base::lapply(...)
+        6.         └─tidyr (local) FUN(X[[i]], ...)
+        7.           └─tidyselect::eval_select(...)
+        8.             └─tidyselect:::eval_select_impl(...)
+        9.               ├─tidyselect:::with_subscript_errors(...)
+       10.               │ └─rlang::try_fetch(...)
+       11.               │   └─base::withCallingHandlers(...)
+       12.               └─tidyselect:::vars_select_eval(...)
+       13.                 └─tidyselect:::ensure_named(...)
+       14.                   └─cli::cli_abort(...)
+       15.                     └─rlang::abort(...)
+      
+      [ FAIL 18 | WARN 1 | SKIP 12 | PASS 134 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+*   checking re-building of vignette outputs ... WARNING
+    ```
+    Error(s) in re-building vignettes:
+      ...
+    --- re-building ‘age_depth.Rmd’ using rmarkdown
+    --- finished re-building ‘age_depth.Rmd’
+    
+    --- re-building ‘nested_analysis.Rmd’ using rmarkdown
+    Quitting from lines 44-53 (nested_analysis.Rmd) 
+    Error: processing vignette 'nested_analysis.Rmd' failed with diagnostics:
+    Can't rename variables in this context.
+    --- failed re-building ‘nested_analysis.Rmd’
+    ...
+    Quitting from lines 250-257 (strat_diagrams.Rmd) 
+    Error: processing vignette 'strat_diagrams.Rmd' failed with diagnostics:
+    Can't rename variables in this context.
+    --- failed re-building ‘strat_diagrams.Rmd’
+    
+    SUMMARY: processing the following files failed:
+      ‘nested_analysis.Rmd’ ‘strat_diagrams.Rmd’
+    
+    Error: Vignette re-building failed.
+    Execution halted
     ```
 
 # wpa

--- a/tests/testthat/_snaps/chop.md
+++ b/tests/testthat/_snaps/chop.md
@@ -29,6 +29,14 @@
       Error in `unchop()`:
       ! In row 1, can't recycle input of size 0 to size 2.
 
+# unchop disallows renaming
+
+    Code
+      unchop(df, c(y = x))
+    Condition
+      Error in `unchop()`:
+      ! Can't rename variables in this context.
+
 # unchop validates its inputs
 
     Code

--- a/tests/testthat/_snaps/nest.md
+++ b/tests/testthat/_snaps/nest.md
@@ -7,6 +7,14 @@
       `...` can't be empty for ungrouped data frames.
       i Did you want `data = everything()`?
 
+# nest disallows renaming
+
+    Code
+      nest(df, data = c(a = x))
+    Condition
+      Error in `nest()`:
+      ! Can't rename variables in this context.
+
 # validates its inputs
 
     Code

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -98,6 +98,14 @@
         * "a" at locations 1 and 2.
       i Use argument `names_repair` to specify repair strategy.
 
+# unpack disallows renaming
+
+    Code
+      unpack(df, c(y = x))
+    Condition
+      Error in `unpack()`:
+      ! Can't rename variables in this context.
+
 # unpack() validates its inputs
 
     Code

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -1,3 +1,19 @@
+# pack disallows renaming
+
+    Code
+      pack(df, data = c(a = x))
+    Condition
+      Error in `pack()`:
+      ! Can't rename variables in this context.
+
+---
+
+    Code
+      pack(df, data1 = x, data2 = c(a = y))
+    Condition
+      Error in `pack()`:
+      ! Can't rename variables in this context.
+
 # pack validates its inputs
 
     Code
@@ -9,12 +25,12 @@
       pack(df, c(a1, a2), c(b1, b2))
     Condition
       Error in `pack()`:
-      ! All elements of `...` must be named
+      ! All elements of `...` must be named.
     Code
       pack(df, a = c(a1, a2), c(b1, b2))
     Condition
       Error in `pack()`:
-      ! All elements of `...` must be named
+      ! All elements of `...` must be named.
     Code
       pack(df, a = c(a1, a2), .names_sep = 1)
     Condition

--- a/tests/testthat/_snaps/separate-wider.md
+++ b/tests/testthat/_snaps/separate-wider.md
@@ -148,7 +148,7 @@
     Code
       separate_wider_regex(df, y, patterns = c(x = ".", value = "."))
     Condition
-      Error in `unpack()`:
+      Error in `separate_wider_regex()`:
       ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `x`, from `y`.
@@ -160,7 +160,7 @@
     Code
       separate_wider_regex(df, c(x, y), patterns = c(gender = ".", value = "."))
     Condition
-      Error in `unpack()`:
+      Error in `separate_wider_regex()`:
       ! Can't duplicate names within the affected columns.
       x These names are duplicated:
         i `gender`, within `x` and `y`.

--- a/tests/testthat/_snaps/unnest-longer.md
+++ b/tests/testthat/_snaps/unnest-longer.md
@@ -12,7 +12,7 @@
     Code
       unnest_longer(df, c(a, b))
     Condition
-      Error in `unchop()`:
+      Error in `unnest_longer()`:
       ! In row 1, can't recycle input of size 0 to size 2.
 
 # can't mix `indices_to` with `indices_include = FALSE`

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -57,7 +57,7 @@
     Code
       unnest_wider(df, y)
     Condition
-      Error in `unpack()`:
+      Error in `unnest_wider()`:
       ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `x`, from `y`.
@@ -69,7 +69,7 @@
     Code
       unnest_wider(df, c(y, z))
     Condition
-      Error in `unpack()`:
+      Error in `unnest_wider()`:
       ! Can't duplicate names within the affected columns.
       x These names are duplicated:
         i `a`, within `y` and `z`.

--- a/tests/testthat/_snaps/unnest.md
+++ b/tests/testthat/_snaps/unnest.md
@@ -39,7 +39,7 @@
     Code
       unnest(df, y)
     Condition
-      Error in `unpack()`:
+      Error in `unnest()`:
       ! Can't duplicate names between the affected columns and the original data.
       x These names are duplicated:
         i `x`, from `y`.
@@ -51,7 +51,7 @@
     Code
       unnest(df, c(x, y))
     Condition
-      Error in `unpack()`:
+      Error in `unnest()`:
       ! Can't duplicate names within the affected columns.
       x These names are duplicated:
         i `a`, within `x` and `y`.

--- a/tests/testthat/_snaps/unnest.md
+++ b/tests/testthat/_snaps/unnest.md
@@ -58,6 +58,14 @@
       i Use `names_sep` to disambiguate using the column name.
       i Or use `names_repair` to specify a repair strategy.
 
+# unnest() disallows renaming
+
+    Code
+      unnest(df, c(y = x))
+    Condition
+      Error in `unnest()`:
+      ! Can't rename variables in this context.
+
 # cols must go in cols
 
     Code

--- a/tests/testthat/_snaps/unnest.md
+++ b/tests/testthat/_snaps/unnest.md
@@ -13,7 +13,7 @@
       (expect_error(unnest(df, c(x, y))))
     Output
       <error/rlang_error>
-      Error in `unchop()`:
+      Error in `unnest()`:
       ! In row 1, can't recycle input of size 2 to size 3.
 
 ---
@@ -22,7 +22,7 @@
       (expect_error(unnest(df, c(x, y))))
     Output
       <error/rlang_error>
-      Error in `unchop()`:
+      Error in `unnest()`:
       ! In row 1, can't recycle input of size 2 to size 3.
 
 # unnesting column of mixed vector / data frame input is an error

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -309,6 +309,14 @@ test_that("unchopping drops outer names", {
   expect_named(out$col, NULL)
 })
 
+test_that("unchop disallows renaming", {
+  df <- tibble(x = list(1))
+
+  expect_snapshot(error = TRUE, {
+    unchop(df, c(y = x))
+  })
+})
+
 test_that("unchop validates its inputs", {
   df <- tibble(col = list(a = 1, b = 2:3))
 

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -97,6 +97,14 @@ test_that("nesting no columns nests all inputs", {
   expect_equal(out$data[[1]], df)
 })
 
+test_that("nest disallows renaming", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(error = TRUE, {
+    nest(df, data = c(a = x))
+  })
+})
+
 test_that("validates its inputs", {
   df <- tibble(x = c(1, 1, 1), ya = 1:3, yb = 4:6)
   expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-pack.R
+++ b/tests/testthat/test-pack.R
@@ -171,6 +171,14 @@ test_that("duplication errors aren't triggered on duplicates within a single col
   })
 })
 
+test_that("unpack disallows renaming", {
+  df <- tibble(x = tibble(a = 1))
+
+  expect_snapshot(error = TRUE, {
+    unpack(df, c(y = x))
+  })
+})
+
 test_that("unpack() validates its inputs", {
   df <- tibble(x = 1:2, y = tibble(a = 1:2, b = 1:2))
 

--- a/tests/testthat/test-pack.R
+++ b/tests/testthat/test-pack.R
@@ -28,6 +28,17 @@ test_that("grouping is preserved", {
   expect_equal(dplyr::group_vars(out), "g1")
 })
 
+test_that("pack disallows renaming", {
+  df <- tibble(x = 1, y = 2)
+
+  expect_snapshot(error = TRUE, {
+    pack(df, data = c(a = x))
+  })
+  expect_snapshot(error = TRUE, {
+    pack(df, data1 = x, data2 = c(a = y))
+  })
+})
+
 test_that("pack validates its inputs", {
   df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
 

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -136,6 +136,14 @@ test_that("unnest() advises on inner / inner name duplication", {
   })
 })
 
+test_that("unnest() disallows renaming", {
+  df <- tibble(x = list(tibble(a = 1)))
+
+  expect_snapshot(error = TRUE, {
+    unnest(df, c(y = x))
+  })
+})
+
 # other methods -----------------------------------------------------------------
 
 test_that("rowwise_df becomes grouped_df", {


### PR DESCRIPTION
Closes #1447 
Closes #1446 

- Added `error_call` to the "backend" functions of `pack()`, `unpack()`, `chop()`, and `unchop()`
- Added empty `...` to `unpack()`, `unchop()`, and `chop()`
- Disallowed renaming in all 6 of: `nest()`, `unnest()`, `pack()`, `unpack()`, `chop()`, and `unchop()`

`"8c16af6a-b91e-47df-9707-5270b389ec14"`

One change in revdeps from tidypaleo which was accidentally passing a named tidyselection through to `unnest()`. I'm happy to fix that one to get all 6 of these functions working consistently.