### PR TITLE
Retain row names of data.frames in `df_append()`

### DIFF
--- a/R/append.R
+++ b/R/append.R
@@ -22,6 +22,7 @@
 #' @noRd
 df_append <- function(x, y, after = NULL, remove = FALSE) {
   size <- vec_size(x)
+  row_names <- .row_names_info(x, type = 0L)
 
   x <- tidyr_new_list(x)
   y <- tidyr_new_list(y)
@@ -52,7 +53,7 @@ df_append <- function(x, y, after = NULL, remove = FALSE) {
   rhs <- setdiff(x_names[rhs], y_names)
 
   out <- vec_c(x[lhs], y, x[rhs])
-  out <- new_data_frame(out, n = size)
+  out <- new_data_frame(out, n = size, row.names = row_names)
 
   out
 }

--- a/tests/testthat/test-append.R
+++ b/tests/testthat/test-append.R
@@ -41,6 +41,17 @@ test_that("always returns a bare data frame", {
   expect_identical(df_append(df1, df2), data.frame(x = 1, y = 2))
 })
 
+test_that("retains row names of data.frame `x` (#1454)", {
+  # These can't be restored by `reconstruct_tibble()`, so it is reasonable to
+  # retain them. `dplyr:::dplyr_col_modify()` works similarly.
+  df <- data.frame(x = 1:2, row.names = c("a", "b"))
+  cols <- list(y = 3:4, z = 5:6)
+
+  expect_identical(row.names(df_append(df, cols)), c("a", "b"))
+  expect_identical(row.names(df_append(df, cols, after = 0)), c("a", "b"))
+  expect_identical(row.names(df_append(df, cols, remove = TRUE)), c("a", "b"))
+})
+
 test_that("can append at any integer position", {
   df1 <- data.frame(x = 1, y = 2)
   df2 <- data.frame(a = 1)

--- a/tests/testthat/test-unite.R
+++ b/tests/testthat/test-unite.R
@@ -27,6 +27,11 @@ test_that("drops grouping when needed", {
   expect_equal(dplyr::group_vars(rs), character())
 })
 
+test_that("preserves row names of data.frames (#1454)", {
+  df <- data.frame(x = c("1", "2"), y = c("3", "4"), row.names = c("a", "b"))
+  expect_identical(row.names(unite(df, "xy", x, y)), c("a", "b"))
+})
+
 test_that("empty var spec uses all vars", {
   df <- tibble(x = "a", y = "b")
   expect_equal(unite(df, "z"), tibble(z = "a_b"))


### PR DESCRIPTION
This seems reasonable because `reconstruct_tibble()` has no way to restore these, and the number of rows will never change here. `dplyr:::dplyr_col_modify()` does a similar thing. The hlaR package actually relies on this, as they expect row names to persist on a data.frame after a call to `unite()`.