### PR TITLE
Implement `nest(.by = )` and revive `.key`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tidyr (development version)
 
+* `nest()` has gained a new argument, `.by`, which allows you to specify the
+  columns to nest by (rather than the columns to nest, i.e. through `...`).
+  Additionally, the `.key` argument is no longer deprecated, and is used
+  whenever `...` isn't specified (#1458).
+
 * All built in datasets are now standard tibbles (#1459).
 
 * `unnest()`, `unchop()`, `unnest_longer()`, and `unnest_wider()` better handle

--- a/R/nest.R
+++ b/R/nest.R
@@ -76,14 +76,10 @@
 #' @examples
 #' df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
 #'
+#' # Specify variables to nest using name-variable pairs.
 #' # Note that we get one row of output for each unique combination of
-#' # non-nested variables
+#' # non-nested variables.
 #' df %>% nest(data = c(y, z))
-#' # `chop()` does something similar, but retains individual columns
-#' df %>% chop(c(y, z))
-#'
-#' # Use tidyselect syntax and helpers, just like in `dplyr::select()`
-#' df %>% nest(data = any_of(c("y", "z")))
 #'
 #' # Specify variables to nest by (rather than variables to nest) using `.by`
 #' df %>% nest(.by = x)
@@ -92,6 +88,9 @@
 #' # name with `.key`
 #' df %>% nest(.by = x, .key = "cols")
 #'
+#' # Use tidyselect syntax and helpers, just like in `dplyr::select()`
+#' df %>% nest(data = any_of(c("y", "z")))
+#'
 #' # `...` and `.by` can be used together to drop columns you no longer need,
 #' # or to include the columns you are nesting by in the inner data frame too.
 #' # This drops `z`:
@@ -99,9 +98,7 @@
 #' # This includes `x` in the inner data frame:
 #' df %>% nest(data = everything(), .by = x)
 #'
-#' iris %>% nest(.by = Species)
-#' nest_vars <- names(iris)[1:4]
-#' iris %>% nest(data = any_of(nest_vars))
+#' # Multiple nesting structures can be specified at once
 #' iris %>%
 #'   nest(petal = starts_with("Petal"), sepal = starts_with("Sepal"))
 #' iris %>%

--- a/R/nest.R
+++ b/R/nest.R
@@ -125,11 +125,6 @@ nest <- function(.data,
                  .by = NULL,
                  .key = NULL,
                  .names_sep = NULL) {
-  if (identical(.key, deprecated())) {
-    # Temporary support for S3 method authors that set `.key = deprecated()`
-    return(nest(.data, ..., .by = {{ .by }}, .key = NULL, .names_sep = .names_sep))
-  }
-
   cols <- enquos(...)
   empty <- names2(cols) == ""
 
@@ -244,7 +239,7 @@ nest_info <- function(.data,
 
   key <- check_key(.key, error_call = .error_call)
 
-  if (n_cols != 0L && !is.null(.key)) {
+  if (n_cols != 0L && !is_default_key(.key)) {
     warn_unused_key(error_call = .error_call)
   }
 
@@ -302,10 +297,20 @@ warn_unused_key <- function(error_call = caller_env()) {
 }
 
 check_key <- function(key, error_call = caller_env()) {
-  if (is.null(key)) {
+  if (is_default_key(key)) {
     "data"
   } else {
     check_string(key, allow_empty = FALSE, arg = ".key", call = error_call)
     key
   }
+}
+
+is_default_key <- function(key) {
+  if (identical(maybe_missing(key), deprecated())) {
+    # Temporary support for S3 method authors that set `.key = deprecated()`.
+    # Remove this entire helper all methods have been updated.
+    key <- NULL
+  }
+
+  is.null(key)
 }

--- a/R/nest.R
+++ b/R/nest.R
@@ -9,10 +9,14 @@
 #'
 #' Learn more in `vignette("nest")`.
 #'
+#' @details
+#' If neither `...` nor `.by` are supplied, `nest()` will nest all variables,
+#' and will use the column name supplied through `.key`.
+#'
 #' @section New syntax:
 #' tidyr 1.0.0 introduced a new syntax for `nest()` and `unnest()` that's
 #' designed to be more similar to other functions. Converting to the new syntax
-#' should be straightforward (guided by the message you'll recieve) but if
+#' should be straightforward (guided by the message you'll receive) but if
 #' you just need to run an old analysis, you can easily revert to the previous
 #' behaviour using [nest_legacy()] and [unnest_legacy()] as follows:
 #'
@@ -24,44 +28,78 @@
 #'
 #' @section Grouped data frames:
 #' `df %>% nest(data = c(x, y))` specifies the columns to be nested; i.e. the
-#' columns that will appear in the inner data frame. Alternatively, you can
-#' `nest()` a grouped data frame created by [dplyr::group_by()]. The grouping
-#' variables remain in the outer data frame and the others are nested. The
-#' result preserves the grouping of the input.
+#' columns that will appear in the inner data frame. `df %>% nest(.by = c(x,
+#' y))` specifies the columns to nest _by_; i.e. the columns that will remain in
+#' the outer data frame. An alternative way to achieve the latter is to `nest()`
+#' a grouped data frame created by [dplyr::group_by()]. The grouping variables
+#' remain in the outer data frame and the others are nested. The result
+#' preserves the grouping of the input.
 #'
 #' Variables supplied to `nest()` will override grouping variables so that
 #' `df %>% group_by(x, y) %>% nest(data = !z)` will be equivalent to
 #' `df %>% nest(data = !z)`.
 #'
+#' You can't supply `.by` with a grouped data frame, as the groups already
+#' represent what you are nesting by.
+#'
 #' @param .data A data frame.
-#' @param ... <[`tidy-select`][tidyr_tidy_select]> Columns to nest, specified
-#'   using name-variable pairs of the form `new_col = c(col1, col2, col3)`.
-#'   The right hand side can be any valid tidyselect expression.
+#' @param ... <[`tidy-select`][tidyr_tidy_select]> Columns to nest; these will
+#'   appear in the inner data frames.
+#'
+#'   Specified using name-variable pairs of the form
+#'   `new_col = c(col1, col2, col3)`. The right hand side can be any valid
+#'   tidyselect expression.
+#'
+#'   If not supplied, then `...` is derived as all columns _not_ selected by
+#'   `.by`, and will use the column name from `.key`.
 #'
 #'   `r lifecycle::badge("deprecated")`:
 #'   previously you could write `df %>% nest(x, y, z)`.
 #'   Convert to `df %>% nest(data = c(x, y, z))`.
+#' @param .by <[`tidy-select`][tidyr_tidy_select]> Columns to nest _by_; these
+#'   will remain in the outer data frame.
+#'
+#'   `.by` can be used in place of or in conjunction with columns supplied
+#'   through `...`.
+#'
+#'   If not supplied, then `.by` is derived as all columns _not_ selected by
+#'   `...`.
+#' @param .key The name of the resulting nested column. Only applicable when
+#'   `...` isn't specified, i.e. in the case of `df %>% nest(.by = x)`.
+#'
+#'   If `NULL`, then `"data"` will be used by default.
 #' @param .names_sep If `NULL`, the default, the inner names will come from
 #'   the former outer names. If a string, the  new inner names will use the
 #'   outer names with `names_sep` automatically stripped. This makes
 #'   `names_sep` roughly symmetric between nesting and unnesting.
-#' @param .key
-#'   `r lifecycle::badge("deprecated")`:
-#'   No longer needed because of the new `new_col = c(col1, col2,
-#'   col3)` syntax.
 #' @export
 #' @examples
 #' df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
+#'
 #' # Note that we get one row of output for each unique combination of
 #' # non-nested variables
 #' df %>% nest(data = c(y, z))
-#' # chop does something similar, but retains individual columns
+#' # `chop()` does something similar, but retains individual columns
 #' df %>% chop(c(y, z))
 #'
-#' # use tidyselect syntax and helpers, just like in dplyr::select()
+#' # Use tidyselect syntax and helpers, just like in `dplyr::select()`
 #' df %>% nest(data = any_of(c("y", "z")))
 #'
-#' iris %>% nest(data = !Species)
+#' # Specify variables to nest by (rather than variables to nest) using `.by`
+#' df %>% nest(.by = x)
+#'
+#' # In this case, since `...` isn't used you can specify the resulting column
+#' # name with `.key`
+#' df %>% nest(.by = x, .key = "cols")
+#'
+#' # `...` and `.by` can be used together to drop columns you no longer need,
+#' # or to include the columns you are nesting by in the inner data frame too.
+#' # This drops `z`:
+#' df %>% nest(data = y, .by = x)
+#' # This includes `x` in the inner data frame:
+#' df %>% nest(data = everything(), .by = x)
+#'
+#' iris %>% nest(.by = Species)
 #' nest_vars <- names(iris)[1:4]
 #' iris %>% nest(data = any_of(nest_vars))
 #' iris %>%
@@ -74,20 +112,32 @@
 #'   dplyr::group_by(fish) %>%
 #'   nest()
 #'
+#' # That is similar to `nest(.by = )`, except here the result isn't grouped
+#' fish_encounters %>%
+#'   nest(.by = fish)
+#'
 #' # Nesting is often useful for creating per group models
 #' mtcars %>%
-#'   dplyr::group_by(cyl) %>%
-#'   nest() %>%
+#'   nest(.by = cyl) %>%
 #'   dplyr::mutate(models = lapply(data, function(df) lm(mpg ~ wt, data = df)))
-nest <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
-  cols <- enquos(...)
+nest <- function(.data,
+                 ...,
+                 .by = NULL,
+                 .key = NULL,
+                 .names_sep = NULL) {
+  if (identical(.key, deprecated())) {
+    # Temporary support for S3 method authors that set `.key = deprecated()`
+    return(nest(.data, ..., .by = {{ .by }}, .key = NULL, .names_sep = .names_sep))
+  }
 
+  cols <- enquos(...)
   empty <- names2(cols) == ""
+
   if (any(empty)) {
     cols_good <- cols[!empty]
     cols_bad <- cols[empty]
 
-    .key <- if (missing(.key)) "data" else as.character(ensym(.key))
+    .key <- check_key(.key)
 
     if (length(cols_bad) == 1L) {
       cols_bad <- cols_bad[[1]]
@@ -106,39 +156,52 @@ nest <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
       i = "Did you want `{(.key)} = {cols_fixed_label}`?"
     ))
 
-    return(nest(.data, !!!cols))
+    return(nest(.data, !!!cols, .by = {{ .by }}))
   }
 
   UseMethod("nest")
 }
 
 #' @export
-nest.data.frame <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
+nest.data.frame <- function(.data,
+                            ...,
+                            .by = NULL,
+                            .key = NULL,
+                            .names_sep = NULL) {
   # The data frame print handles nested data frames poorly, so we want to
   # convert data frames (but not subclasses) to tibbles
   if (identical(class(.data), "data.frame")) {
     .data <- as_tibble(.data)
   }
 
-  nest.tbl_df(.data, ..., .names_sep = .names_sep, .key = .key)
+  nest.tbl_df(
+    .data,
+    ...,
+    .by = {{ .by }},
+    .key = .key,
+    .names_sep = .names_sep
+  )
 }
 
 #' @export
-nest.tbl_df <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
-  .key <- check_key(.key)
-  if (missing(...)) {
-    cli::cli_warn(c(
-      "`...` can't be empty for ungrouped data frames.",
-      i = "Did you want `{(.key)} = everything()`?"
-    ))
-    cols <- quos(!!.key := everything())
-  } else {
-    cols <- enquos(...)
-  }
-
+nest.tbl_df <- function(.data,
+                        ...,
+                        .by = NULL,
+                        .key = NULL,
+                        .names_sep = NULL) {
   error_call <- current_env()
 
-  out <- pack(.data, !!!cols, .names_sep = .names_sep, .error_call = error_call)
+  info <- nest_info(.data, ..., .by = {{ .by }}, .key = .key)
+  cols <- info$cols
+  inner <- info$inner
+  outer <- info$outer
+
+  inner <- .data[inner]
+  inner <- pack(inner, !!!cols, .names_sep = .names_sep, .error_call = error_call)
+
+  out <- .data[outer]
+  out <- vec_cbind(out, inner, .name_repair = "check_unique", .error_call = error_call)
+  out <- reconstruct_tibble(.data, out)
   out <- chop(out, cols = all_of(names(cols)), error_call = error_call)
 
   # `nest()` currently doesn't return list-of columns
@@ -150,21 +213,99 @@ nest.tbl_df <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
 }
 
 #' @export
-nest.grouped_df <- function(.data, ..., .names_sep = NULL, .key = deprecated()) {
+nest.grouped_df <- function(.data,
+                            ...,
+                            .by = NULL,
+                            .key = NULL,
+                            .names_sep = NULL) {
+  by <- enquo(.by)
+  if (!quo_is_null(by)) {
+    cli::cli_abort("Can't supply {.arg .by} when {.arg .data} is a grouped data frame.")
+  }
+
   if (missing(...)) {
     .key <- check_key(.key)
     cols <- setdiff(names(.data), dplyr::group_vars(.data))
     nest.tbl_df(.data, !!.key := all_of(cols), .names_sep = .names_sep)
   } else {
-    NextMethod()
+    nest.tbl_df(.data, ..., .key = .key, .names_sep = .names_sep)
   }
 }
 
-check_key <- function(.key) {
-  if (!is_missing(.key)) {
-    warn("`.key` is deprecated")
-    .key
-  } else {
+nest_info <- function(.data,
+                      ...,
+                      .by = NULL,
+                      .key = NULL,
+                      .error_call = caller_env()) {
+  by <- enquo(.by)
+
+  cols <- enquos(...)
+  n_cols <- length(cols)
+
+  key <- check_key(.key, error_call = .error_call)
+
+  if (n_cols != 0L && !is.null(.key)) {
+    warn_unused_key(error_call = .error_call)
+  }
+
+  cols <- lapply(cols, function(col) {
+    names(tidyselect::eval_select(
+      expr = col,
+      data = .data,
+      allow_rename = FALSE,
+      error_call = .error_call
+    ))
+  })
+
+  names <- names(.data)
+
+  outer <- names(tidyselect::eval_select(
+    expr = by,
+    data = .data,
+    allow_rename = FALSE,
+    error_call = .error_call
+  ))
+
+  inner <- list_unchop(cols, ptype = character(), name_spec = zap())
+  inner <- vec_unique(inner)
+
+  if (n_cols == 0L) {
+    # Derive `inner` names from `.by`
+    inner <- setdiff(names, outer)
+    cols <- list2(!!key := inner)
+  }
+
+  if (quo_is_null(by)) {
+    # Derive `outer` names from `...`
+    outer <- setdiff(names, inner)
+  }
+
+  # Regenerate quosures for `pack()`
+  cols <- map(cols, function(col) {
+    quo(all_of(!!col))
+  })
+  cols <- new_quosures(cols)
+
+  list(
+    cols = cols,
+    inner = inner,
+    outer = outer
+  )
+}
+
+warn_unused_key <- function(error_call = caller_env()) {
+  message <- c(
+    "Can't supply both {.arg .key} and {.arg ...}.",
+    i = "{.arg .key} will be ignored."
+  )
+  cli::cli_warn(message, call = error_call)
+}
+
+check_key <- function(key, error_call = caller_env()) {
+  if (is.null(key)) {
     "data"
+  } else {
+    check_string(key, allow_empty = FALSE, arg = ".key", call = error_call)
+    key
   }
 }

--- a/man/nest.Rd
+++ b/man/nest.Rd
@@ -4,26 +4,43 @@
 \alias{nest}
 \title{Nest rows into a list-column of data frames}
 \usage{
-nest(.data, ..., .names_sep = NULL, .key = deprecated())
+nest(.data, ..., .by = NULL, .key = NULL, .names_sep = NULL)
 }
 \arguments{
 \item{.data}{A data frame.}
 
-\item{...}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to nest, specified
-using name-variable pairs of the form \code{new_col = c(col1, col2, col3)}.
-The right hand side can be any valid tidyselect expression.
+\item{...}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to nest; these will
+appear in the inner data frames.
+
+Specified using name-variable pairs of the form
+\code{new_col = c(col1, col2, col3)}. The right hand side can be any valid
+tidyselect expression.
+
+If not supplied, then \code{...} is derived as all columns \emph{not} selected by
+\code{.by}, and will use the column name from \code{.key}.
 
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}:
 previously you could write \code{df \%>\% nest(x, y, z)}.
 Convert to \code{df \%>\% nest(data = c(x, y, z))}.}
 
+\item{.by}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to nest \emph{by}; these
+will remain in the outer data frame.
+
+\code{.by} can be used in place of or in conjunction with columns supplied
+through \code{...}.
+
+If not supplied, then \code{.by} is derived as all columns \emph{not} selected by
+\code{...}.}
+
+\item{.key}{The name of the resulting nested column. Only applicable when
+\code{...} isn't specified, i.e. in the case of \code{df \%>\% nest(.by = x)}.
+
+If \code{NULL}, then \code{"data"} will be used by default.}
+
 \item{.names_sep}{If \code{NULL}, the default, the inner names will come from
 the former outer names. If a string, the  new inner names will use the
 outer names with \code{names_sep} automatically stripped. This makes
 \code{names_sep} roughly symmetric between nesting and unnesting.}
-
-\item{.key}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}:
-No longer needed because of the new \code{new_col = c(col1, col2, col3)} syntax.}
 }
 \description{
 Nesting creates a list-column of data frames; unnesting flattens it back out
@@ -34,11 +51,15 @@ notably models.
 
 Learn more in \code{vignette("nest")}.
 }
+\details{
+If neither \code{...} nor \code{.by} are supplied, \code{nest()} will nest all variables,
+and will use the column name supplied through \code{.key}.
+}
 \section{New syntax}{
 
 tidyr 1.0.0 introduced a new syntax for \code{nest()} and \code{unnest()} that's
 designed to be more similar to other functions. Converting to the new syntax
-should be straightforward (guided by the message you'll recieve) but if
+should be straightforward (guided by the message you'll receive) but if
 you just need to run an old analysis, you can easily revert to the previous
 behaviour using \code{\link[=nest_legacy]{nest_legacy()}} and \code{\link[=unnest_legacy]{unnest_legacy()}} as follows:
 
@@ -51,28 +72,47 @@ unnest <- unnest_legacy
 \section{Grouped data frames}{
 
 \code{df \%>\% nest(data = c(x, y))} specifies the columns to be nested; i.e. the
-columns that will appear in the inner data frame. Alternatively, you can
-\code{nest()} a grouped data frame created by \code{\link[dplyr:group_by]{dplyr::group_by()}}. The grouping
-variables remain in the outer data frame and the others are nested. The
-result preserves the grouping of the input.
+columns that will appear in the inner data frame. \code{df \%>\% nest(.by = c(x, y))} specifies the columns to nest \emph{by}; i.e. the columns that will remain in
+the outer data frame. An alternative way to achieve the latter is to \code{nest()}
+a grouped data frame created by \code{\link[dplyr:group_by]{dplyr::group_by()}}. The grouping variables
+remain in the outer data frame and the others are nested. The result
+preserves the grouping of the input.
 
 Variables supplied to \code{nest()} will override grouping variables so that
 \code{df \%>\% group_by(x, y) \%>\% nest(data = !z)} will be equivalent to
 \code{df \%>\% nest(data = !z)}.
+
+You can't supply \code{.by} with a grouped data frame, as the groups already
+represent what you are nesting by.
 }
 
 \examples{
 df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
+
 # Note that we get one row of output for each unique combination of
 # non-nested variables
 df \%>\% nest(data = c(y, z))
-# chop does something similar, but retains individual columns
+# `chop()` does something similar, but retains individual columns
 df \%>\% chop(c(y, z))
 
-# use tidyselect syntax and helpers, just like in dplyr::select()
+# Use tidyselect syntax and helpers, just like in `dplyr::select()`
 df \%>\% nest(data = any_of(c("y", "z")))
 
-iris \%>\% nest(data = !Species)
+# Specify variables to nest by (rather than variables to nest) using `.by`
+df \%>\% nest(.by = x)
+
+# In this case, since `...` isn't used you can specify the resulting column
+# name with `.key`
+df \%>\% nest(.by = x, .key = "cols")
+
+# `...` and `.by` can be used together to drop columns you no longer need,
+# or to include the columns you are nesting by in the inner data frame too.
+# This drops `z`:
+df \%>\% nest(data = y, .by = x)
+# This includes `x` in the inner data frame:
+df \%>\% nest(data = everything(), .by = x)
+
+iris \%>\% nest(.by = Species)
 nest_vars <- names(iris)[1:4]
 iris \%>\% nest(data = any_of(nest_vars))
 iris \%>\%
@@ -85,9 +125,12 @@ fish_encounters \%>\%
   dplyr::group_by(fish) \%>\%
   nest()
 
+# That is similar to `nest(.by = )`, except here the result isn't grouped
+fish_encounters \%>\%
+  nest(.by = fish)
+
 # Nesting is often useful for creating per group models
 mtcars \%>\%
-  dplyr::group_by(cyl) \%>\%
-  nest() \%>\%
+  nest(.by = cyl) \%>\%
   dplyr::mutate(models = lapply(data, function(df) lm(mpg ~ wt, data = df)))
 }

--- a/man/nest.Rd
+++ b/man/nest.Rd
@@ -89,14 +89,10 @@ represent what you are nesting by.
 \examples{
 df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
 
+# Specify variables to nest using name-variable pairs.
 # Note that we get one row of output for each unique combination of
-# non-nested variables
+# non-nested variables.
 df \%>\% nest(data = c(y, z))
-# `chop()` does something similar, but retains individual columns
-df \%>\% chop(c(y, z))
-
-# Use tidyselect syntax and helpers, just like in `dplyr::select()`
-df \%>\% nest(data = any_of(c("y", "z")))
 
 # Specify variables to nest by (rather than variables to nest) using `.by`
 df \%>\% nest(.by = x)
@@ -105,6 +101,9 @@ df \%>\% nest(.by = x)
 # name with `.key`
 df \%>\% nest(.by = x, .key = "cols")
 
+# Use tidyselect syntax and helpers, just like in `dplyr::select()`
+df \%>\% nest(data = any_of(c("y", "z")))
+
 # `...` and `.by` can be used together to drop columns you no longer need,
 # or to include the columns you are nesting by in the inner data frame too.
 # This drops `z`:
@@ -112,9 +111,7 @@ df \%>\% nest(data = y, .by = x)
 # This includes `x` in the inner data frame:
 df \%>\% nest(data = everything(), .by = x)
 
-iris \%>\% nest(.by = Species)
-nest_vars <- names(iris)[1:4]
-iris \%>\% nest(data = any_of(nest_vars))
+# Multiple nesting structures can be specified at once
 iris \%>\%
   nest(petal = starts_with("Petal"), sepal = starts_with("Sepal"))
 iris \%>\%

--- a/man/unnest.Rd
+++ b/man/unnest.Rd
@@ -82,7 +82,7 @@ Unnest expands a list-column containing data frames into rows and columns.
 
 tidyr 1.0.0 introduced a new syntax for \code{nest()} and \code{unnest()} that's
 designed to be more similar to other functions. Converting to the new syntax
-should be straightforward (guided by the message you'll recieve) but if
+should be straightforward (guided by the message you'll receive) but if
 you just need to run an old analysis, you can easily revert to the previous
 behaviour using \code{\link[=nest_legacy]{nest_legacy()}} and \code{\link[=unnest_legacy]{unnest_legacy()}} as follows:
 

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,9 +1,10 @@
 # Revdeps
 
-## Failed to check (31)
+## Failed to check (33)
 
 |package        |version |error |warning |note |
 |:--------------|:-------|:-----|:-------|:----|
+|amanida        |0.2.3   |1     |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
@@ -15,7 +16,7 @@
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
-|FAMetA         |0.1.4   |1     |        |     |
+|FAMetA         |0.1.5   |1     |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
 |genekitr       |?       |      |        |     |
@@ -30,23 +31,25 @@
 |Platypus       |?       |      |        |     |
 |NA             |?       |      |        |     |
 |RVA            |?       |      |        |     |
+|SCpubr         |?       |      |        |     |
 |NA             |?       |      |        |     |
 |tinyarray      |?       |      |        |     |
 |vivid          |?       |      |        |     |
 |NA             |?       |      |        |     |
 |xpose.nlmixr2  |?       |      |        |     |
 
-## New problems (9)
+## New problems (10)
 
 |package            |version |error  |warning |note |
 |:------------------|:-------|:------|:-------|:----|
+|[expstudy](problems.md#expstudy)|1.0.3   |__+1__ |        |     |
 |[faux](problems.md#faux)|1.1.0   |       |__+1__  |     |
 |[ggpubr](problems.md#ggpubr)|0.5.0   |__+1__ |        |     |
-|[gutenbergr](problems.md#gutenbergr)|0.2.3   |__+1__ |        |2    |
-|[hlaR](problems.md#hlar)|0.1.6   |       |__+1__  |     |
+|[gompertztrunc](problems.md#gompertztrunc)|0.1.1   |__+1__ |        |     |
 |[mapme.biodiversity](problems.md#mapmebiodiversity)|0.2.1   |__+1__ |        |     |
 |[metaconfoundr](problems.md#metaconfoundr)|0.1.1   |__+2__ |__+1__  |     |
-|[recipes](problems.md#recipes)|1.0.3   |__+2__ |        |1    |
+|[openalexR](problems.md#openalexr)|1.0.0   |       |__+1__  |     |
+|[panelr](problems.md#panelr)|0.7.6   |__+1__ |        |1    |
 |[tidypaleo](problems.md#tidypaleo)|0.1.2   |__+2__ |__+1__  |     |
 |[wpa](problems.md#wpa)|1.8.0   |__+2__ |        |     |
 

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,13 +1,13 @@
 # Revdeps
 
-## Failed to check (33)
+## Failed to check (34)
 
 |package        |version |error |warning |note |
 |:--------------|:-------|:-----|:-------|:----|
-|amanida        |0.2.3   |1     |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
+|cities         |0.1.0   |1     |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
@@ -21,6 +21,7 @@
 |NA             |?       |      |        |     |
 |genekitr       |?       |      |        |     |
 |ggPMX          |?       |      |        |     |
+|ggsector       |1.6.6   |1     |        |     |
 |loon.ggplot    |?       |      |        |     |
 |NA             |?       |      |        |     |
 |NA             |?       |      |        |     |
@@ -38,17 +39,15 @@
 |NA             |?       |      |        |     |
 |xpose.nlmixr2  |?       |      |        |     |
 
-## New problems (10)
+## New problems (8)
 
 |package            |version |error  |warning |note |
 |:------------------|:-------|:------|:-------|:----|
-|[expstudy](problems.md#expstudy)|1.0.3   |__+1__ |        |     |
 |[faux](problems.md#faux)|1.1.0   |       |__+1__  |     |
 |[ggpubr](problems.md#ggpubr)|0.5.0   |__+1__ |        |     |
-|[gompertztrunc](problems.md#gompertztrunc)|0.1.1   |__+1__ |        |     |
+|[gutenbergr](problems.md#gutenbergr)|0.2.3   |__+1__ |        |2    |
 |[mapme.biodiversity](problems.md#mapmebiodiversity)|0.2.1   |__+1__ |        |     |
 |[metaconfoundr](problems.md#metaconfoundr)|0.1.1   |__+2__ |__+1__  |     |
-|[openalexR](problems.md#openalexr)|1.0.0   |       |__+1__  |     |
 |[panelr](problems.md#panelr)|0.7.6   |__+1__ |        |1    |
 |[tidypaleo](problems.md#tidypaleo)|0.1.2   |__+2__ |__+1__  |     |
 |[wpa](problems.md#wpa)|1.8.0   |__+2__ |        |     |

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,14 +1,17 @@
 ## revdepcheck results
 
-We checked 1744 reverse dependencies (1725 from CRAN + 19 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 1743 reverse dependencies (1724 from CRAN + 19 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 9 new problems
- * We failed to check 12 packages
+ * We saw 10 new problems
+ * We failed to check 14 packages
 
 Issues with CRAN packages are summarised below.
 
 ### New problems
 (This reports the first line of each new failure)
+
+* expstudy
+  checking tests ... ERROR
 
 * faux
   checking re-building of vignette outputs ... WARNING
@@ -16,11 +19,8 @@ Issues with CRAN packages are summarised below.
 * ggpubr
   checking examples ... ERROR
 
-* gutenbergr
+* gompertztrunc
   checking examples ... ERROR
-
-* hlaR
-  checking re-building of vignette outputs ... WARNING
 
 * mapme.biodiversity
   checking tests ... ERROR
@@ -30,8 +30,10 @@ Issues with CRAN packages are summarised below.
   checking tests ... ERROR
   checking re-building of vignette outputs ... WARNING
 
-* recipes
-  checking examples ... ERROR
+* openalexR
+  checking re-building of vignette outputs ... WARNING
+
+* panelr
   checking tests ... ERROR
 
 * tidypaleo
@@ -45,6 +47,7 @@ Issues with CRAN packages are summarised below.
 
 ### Failed to check
 
+* amanida        (NA)
 * FAMetA         (NA)
 * genekitr       (NA)
 * ggPMX          (NA)
@@ -54,6 +57,7 @@ Issues with CRAN packages are summarised below.
 * OlinkAnalyze   (NA)
 * Platypus       (NA)
 * RVA            (NA)
+* SCpubr         (NA)
 * tinyarray      (NA)
 * vivid          (NA)
 * xpose.nlmixr2  (NA)

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -2,16 +2,13 @@
 
 We checked 1743 reverse dependencies (1724 from CRAN + 19 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 10 new problems
- * We failed to check 14 packages
+ * We saw 8 new problems
+ * We failed to check 15 packages
 
 Issues with CRAN packages are summarised below.
 
 ### New problems
 (This reports the first line of each new failure)
-
-* expstudy
-  checking tests ... ERROR
 
 * faux
   checking re-building of vignette outputs ... WARNING
@@ -19,7 +16,7 @@ Issues with CRAN packages are summarised below.
 * ggpubr
   checking examples ... ERROR
 
-* gompertztrunc
+* gutenbergr
   checking examples ... ERROR
 
 * mapme.biodiversity
@@ -28,9 +25,6 @@ Issues with CRAN packages are summarised below.
 * metaconfoundr
   checking examples ... ERROR
   checking tests ... ERROR
-  checking re-building of vignette outputs ... WARNING
-
-* openalexR
   checking re-building of vignette outputs ... WARNING
 
 * panelr
@@ -47,10 +41,11 @@ Issues with CRAN packages are summarised below.
 
 ### Failed to check
 
-* amanida        (NA)
+* cities         (NA)
 * FAMetA         (NA)
 * genekitr       (NA)
 * ggPMX          (NA)
+* ggsector       (NA)
 * loon.ggplot    (NA)
 * MarketMatching (NA)
 * numbat         (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,23 +1,128 @@
-# amanida
+# NA
 
 <details>
 
-* Version: 0.2.3
-* GitHub: https://github.com/mariallr/amanida
-* Source code: https://github.com/cran/amanida
-* Date/Publication: 2022-03-30 06:50:05 UTC
-* Number of recursive dependencies: 156
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
 
-Run `cloud_details(, "amanida")` for more info
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# cities
+
+<details>
+
+* Version: 0.1.0
+* GitHub: NA
+* Source code: https://github.com/cran/cities
+* Date/Publication: 2022-10-17 09:22:35 UTC
+* Number of recursive dependencies: 84
+
+Run `cloud_details(, "cities")` for more info
 
 </details>
 
 ## In both
 
-*   checking whether package ‘amanida’ can be installed ... ERROR
+*   checking whether package ‘cities’ can be installed ... ERROR
     ```
     Installation failed.
-    See ‘/tmp/workdir/amanida/new/amanida.Rcheck/00install.out’ for details.
+    See ‘/tmp/workdir/cities/new/cities.Rcheck/00install.out’ for details.
     ```
 
 ## Installation
@@ -25,145 +130,36 @@ Run `cloud_details(, "amanida")` for more info
 ### Devel
 
 ```
-* installing *source* package ‘amanida’ ...
-** package ‘amanida’ successfully unpacked and MD5 sums checked
+* installing *source* package ‘cities’ ...
+** package ‘cities’ successfully unpacked and MD5 sums checked
 ** using staged installation
 ** R
-** data
-*** moving datasets to lazyload DB
 ** inst
 ** byte-compile and prepare package for lazy loading
-Error: .onLoad failed in loadNamespace() for 'broom', details:
-  call: loadNamespace(x)
-  error: there is no package called ‘backports’
+Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  there is no package called ‘viridisLite’
+Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
 Execution halted
-ERROR: lazy loading failed for package ‘amanida’
-* removing ‘/tmp/workdir/amanida/new/amanida.Rcheck/amanida’
+ERROR: lazy loading failed for package ‘cities’
+* removing ‘/tmp/workdir/cities/new/cities.Rcheck/cities’
 
 
 ```
 ### CRAN
 
 ```
-* installing *source* package ‘amanida’ ...
-** package ‘amanida’ successfully unpacked and MD5 sums checked
+* installing *source* package ‘cities’ ...
+** package ‘cities’ successfully unpacked and MD5 sums checked
 ** using staged installation
 ** R
-** data
-*** moving datasets to lazyload DB
 ** inst
 ** byte-compile and prepare package for lazy loading
-Error: .onLoad failed in loadNamespace() for 'broom', details:
-  call: loadNamespace(x)
-  error: there is no package called ‘backports’
+Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  there is no package called ‘viridisLite’
+Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
 Execution halted
-ERROR: lazy loading failed for package ‘amanida’
-* removing ‘/tmp/workdir/amanida/old/amanida.Rcheck/amanida’
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
+ERROR: lazy loading failed for package ‘cities’
+* removing ‘/tmp/workdir/cities/old/cities.Rcheck/cities’
 
 
 ```
@@ -720,6 +716,64 @@ Status: 1 ERROR, 2 NOTEs
 
 
 
+
+
+```
+# ggsector
+
+<details>
+
+* Version: 1.6.6
+* GitHub: https://github.com/yanpd01/ggsector
+* Source code: https://github.com/cran/ggsector
+* Date/Publication: 2022-12-05 15:20:02 UTC
+* Number of recursive dependencies: 155
+
+Run `cloud_details(, "ggsector")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘ggsector’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/ggsector/new/ggsector.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ggsector’ ...
+** package ‘ggsector’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘ggplot2’ in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
+ there is no package called ‘gtable’
+Execution halted
+ERROR: lazy loading failed for package ‘ggsector’
+* removing ‘/tmp/workdir/ggsector/new/ggsector.Rcheck/ggsector’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ggsector’ ...
+** package ‘ggsector’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘ggplot2’ in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
+ there is no package called ‘gtable’
+Execution halted
+ERROR: lazy loading failed for package ‘ggsector’
+* removing ‘/tmp/workdir/ggsector/old/ggsector.Rcheck/ggsector’
 
 
 ```

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,3 +1,67 @@
+# amanida
+
+<details>
+
+* Version: 0.2.3
+* GitHub: https://github.com/mariallr/amanida
+* Source code: https://github.com/cran/amanida
+* Date/Publication: 2022-03-30 06:50:05 UTC
+* Number of recursive dependencies: 156
+
+Run `cloud_details(, "amanida")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘amanida’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/amanida/new/amanida.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘amanida’ ...
+** package ‘amanida’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: .onLoad failed in loadNamespace() for 'broom', details:
+  call: loadNamespace(x)
+  error: there is no package called ‘backports’
+Execution halted
+ERROR: lazy loading failed for package ‘amanida’
+* removing ‘/tmp/workdir/amanida/new/amanida.Rcheck/amanida’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘amanida’ ...
+** package ‘amanida’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: .onLoad failed in loadNamespace() for 'broom', details:
+  call: loadNamespace(x)
+  error: there is no package called ‘backports’
+Execution halted
+ERROR: lazy loading failed for package ‘amanida’
+* removing ‘/tmp/workdir/amanida/old/amanida.Rcheck/amanida’
+
+
+```
 # NA
 
 <details>
@@ -387,10 +451,10 @@ Run `cloud_details(, "NA")` for more info
 
 <details>
 
-* Version: 0.1.4
+* Version: 0.1.5
 * GitHub: NA
 * Source code: https://github.com/cran/FAMetA
-* Date/Publication: 2022-03-01 15:40:23 UTC
+* Date/Publication: 2023-01-11 09:33:11 UTC
 * Number of recursive dependencies: 90
 
 Run `cloud_details(, "FAMetA")` for more info
@@ -906,11 +970,11 @@ Run `cloud_details(, "NA")` for more info
 
 <details>
 
-* Version: 1.1.0
+* Version: 1.2.1
 * GitHub: https://github.com/kharchenkolab/numbat
 * Source code: https://github.com/cran/numbat
-* Date/Publication: 2022-11-29 18:30:02 UTC
-* Number of recursive dependencies: 183
+* Date/Publication: 2023-01-11 00:20:02 UTC
+* Number of recursive dependencies: 132
 
 Run `cloud_details(, "numbat")` for more info
 
@@ -927,7 +991,7 @@ Run `cloud_details(, "numbat")` for more info
 * using session charset: UTF-8
 * using option ‘--no-manual’
 * checking for file ‘numbat/DESCRIPTION’ ... OK
-* this is package ‘numbat’ version ‘1.1.0’
+* this is package ‘numbat’ version ‘1.2.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
@@ -952,7 +1016,7 @@ Status: 1 ERROR
 * using session charset: UTF-8
 * using option ‘--no-manual’
 * checking for file ‘numbat/DESCRIPTION’ ... OK
-* this is package ‘numbat’ version ‘1.1.0’
+* this is package ‘numbat’ version ‘1.2.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
@@ -1215,6 +1279,82 @@ See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
 * DONE
 Status: 1 ERROR
+
+
+
+
+
+```
+# SCpubr
+
+<details>
+
+* Version: 1.1.1
+* GitHub: https://github.com/enblacar/SCpubr
+* Source code: https://github.com/cran/SCpubr
+* Date/Publication: 2023-01-12 11:30:02 UTC
+* Number of recursive dependencies: 289
+
+Run `cloud_details(, "SCpubr")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/SCpubr/new/SCpubr.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘SCpubr/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘SCpubr’ version ‘1.1.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+  [ FAIL 1 | WARN 0 | SKIP 347 | PASS 320 ]
+  Error: Test failures
+  Execution halted
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘reference_manual.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 ERROR, 1 WARNING, 2 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/SCpubr/old/SCpubr.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘SCpubr/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘SCpubr’ version ‘1.1.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+  [ FAIL 1 | WARN 0 | SKIP 347 | PASS 320 ]
+  Error: Test failures
+  Execution halted
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘reference_manual.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 ERROR, 1 WARNING, 2 NOTEs
 
 
 

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,41 +1,3 @@
-# expstudy
-
-<details>
-
-* Version: 1.0.3
-* GitHub: https://github.com/cb12991/expstudy
-* Source code: https://github.com/cran/expstudy
-* Date/Publication: 2022-12-08 19:20:02 UTC
-* Number of recursive dependencies: 61
-
-Run `cloud_details(, "expstudy")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      > 
-      > test_check("expstudy")
-      [ FAIL 1 | WARN 2 | SKIP 0 | PASS 110 ]
-      
-      ══ Failed tests ════════════════════════════════════════════════════════════════
-      ── Error ('test-tidyr.R:34'): nest method preserves metadata ───────────────────
-      <purrr_error_indexed/rlang_error/error/condition>
-      Error in `map(.x, .f, ..., .progress = .progress)`: i In index: 1.
-      Caused by error in `nest()`:
-      ! `nest()` for lazy data.tables doesn't support the `.key` argument.
-      i Use a name in the `...` argument instead.
-      
-      [ FAIL 1 | WARN 2 | SKIP 0 | PASS 110 ]
-      Error: Test failures
-      Execution halted
-    ```
-
 # faux
 
 <details>
@@ -118,17 +80,17 @@ Run `cloud_details(, "ggpubr")` for more info
     Execution halted
     ```
 
-# gompertztrunc
+# gutenbergr
 
 <details>
 
-* Version: 0.1.1
-* GitHub: NA
-* Source code: https://github.com/cran/gompertztrunc
-* Date/Publication: 2022-12-23 19:20:02 UTC
-* Number of recursive dependencies: 122
+* Version: 0.2.3
+* GitHub: https://github.com/ropensci/gutenbergr
+* Source code: https://github.com/cran/gutenbergr
+* Date/Publication: 2022-12-14 10:00:06 UTC
+* Number of recursive dependencies: 88
 
-Run `cloud_details(, "gompertztrunc")` for more info
+Run `cloud_details(, "gutenbergr")` for more info
 
 </details>
 
@@ -136,27 +98,35 @@ Run `cloud_details(, "gompertztrunc")` for more info
 
 *   checking examples ... ERROR
     ```
-    Running examples in ‘gompertztrunc-Ex.R’ failed
+    Running examples in ‘gutenbergr-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: diagnostic_plot
-    > ### Title: Create diagnostic plots
-    > ### Aliases: diagnostic_plot
+    > ### Name: gutenberg_get_mirror
+    > ### Title: Get the recommended mirror for Gutenberg files
+    > ### Aliases: gutenberg_get_mirror
     > 
     > ### ** Examples
     > 
-    > # Create a single-cohort data set
-    ...
-    > gradient <- gompertztrunc::gompertz_mle(formula = death_age ~ finished_hs,
-    + left_trunc = 1988, right_trunc = 2005, data = numident_c1920)
-    > 
-    > # Create diagnostic histogram plot using model outcome
-    > gompertztrunc::diagnostic_plot(object = gradient, data = numident_c1920,
-    + covar = "finished_hs", xlim = c(60, 95))
-    Error in .shallow(x, cols = cols, retain.key = TRUE) : 
-      attempt to set index 0/0 in SET_VECTOR_ELT
-    Calls: <Anonymous> ... names<- -> names<-.data.table -> shallow -> .shallow
+    > gutenberg_get_mirror()
+    Determining mirror for Project Gutenberg from https://www.gutenberg.org/robot/harvest
+    Error in open.connection(3L, "rb") : 
+      Timeout was reached: [www.gutenberg.org] Connection timed out after 10001 milliseconds
+    Calls: gutenberg_get_mirror ... <Anonymous> -> vroom_ -> <Anonymous> -> open.connection
     Execution halted
+    ```
+
+## In both
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is  5.1Mb
+      sub-directories of 1Mb or more:
+        data   4.6Mb
+    ```
+
+*   checking data for non-ASCII characters ... NOTE
+    ```
+      Note: found 18981 marked UTF-8 strings
     ```
 
 # mapme.biodiversity
@@ -273,39 +243,6 @@ Run `cloud_details(, "metaconfoundr")` for more info
     
     SUMMARY: processing the following file failed:
       ‘intro-to-metaconfoundr.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
-    ```
-
-# openalexR
-
-<details>
-
-* Version: 1.0.0
-* GitHub: https://github.com/massimoaria/openalexR
-* Source code: https://github.com/cran/openalexR
-* Date/Publication: 2022-10-06 10:40:02 UTC
-* Number of recursive dependencies: 78
-
-Run `cloud_details(, "openalexR")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-      ...
-    --- re-building ‘A_Brief_Introduction_to_openalexR.Rmd’ using rmarkdown
-    Quitting from lines 342-354 (A_Brief_Introduction_to_openalexR.Rmd) 
-    Error: processing vignette 'A_Brief_Introduction_to_openalexR.Rmd' failed with diagnostics:
-    missing value where TRUE/FALSE needed
-    --- failed re-building ‘A_Brief_Introduction_to_openalexR.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘A_Brief_Introduction_to_openalexR.Rmd’
     
     Error: Vignette re-building failed.
     Execution halted

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,3 +1,41 @@
+# expstudy
+
+<details>
+
+* Version: 1.0.3
+* GitHub: https://github.com/cb12991/expstudy
+* Source code: https://github.com/cran/expstudy
+* Date/Publication: 2022-12-08 19:20:02 UTC
+* Number of recursive dependencies: 61
+
+Run `cloud_details(, "expstudy")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      > 
+      > test_check("expstudy")
+      [ FAIL 1 | WARN 2 | SKIP 0 | PASS 110 ]
+      
+      ══ Failed tests ════════════════════════════════════════════════════════════════
+      ── Error ('test-tidyr.R:34'): nest method preserves metadata ───────────────────
+      <purrr_error_indexed/rlang_error/error/condition>
+      Error in `map(.x, .f, ..., .progress = .progress)`: i In index: 1.
+      Caused by error in `nest()`:
+      ! `nest()` for lazy data.tables doesn't support the `.key` argument.
+      i Use a name in the `...` argument instead.
+      
+      [ FAIL 1 | WARN 2 | SKIP 0 | PASS 110 ]
+      Error: Test failures
+      Execution halted
+    ```
+
 # faux
 
 <details>
@@ -80,17 +118,17 @@ Run `cloud_details(, "ggpubr")` for more info
     Execution halted
     ```
 
-# gutenbergr
+# gompertztrunc
 
 <details>
 
-* Version: 0.2.3
-* GitHub: https://github.com/ropensci/gutenbergr
-* Source code: https://github.com/cran/gutenbergr
-* Date/Publication: 2022-12-14 10:00:06 UTC
-* Number of recursive dependencies: 88
+* Version: 0.1.1
+* GitHub: NA
+* Source code: https://github.com/cran/gompertztrunc
+* Date/Publication: 2022-12-23 19:20:02 UTC
+* Number of recursive dependencies: 122
 
-Run `cloud_details(, "gutenbergr")` for more info
+Run `cloud_details(, "gompertztrunc")` for more info
 
 </details>
 
@@ -98,70 +136,26 @@ Run `cloud_details(, "gutenbergr")` for more info
 
 *   checking examples ... ERROR
     ```
-    Running examples in ‘gutenbergr-Ex.R’ failed
+    Running examples in ‘gompertztrunc-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: gutenberg_get_mirror
-    > ### Title: Get the recommended mirror for Gutenberg files
-    > ### Aliases: gutenberg_get_mirror
+    > ### Name: diagnostic_plot
+    > ### Title: Create diagnostic plots
+    > ### Aliases: diagnostic_plot
     > 
     > ### ** Examples
     > 
-    > gutenberg_get_mirror()
-    Determining mirror for Project Gutenberg from https://www.gutenberg.org/robot/harvest
-    Error in open.connection(3L, "rb") : 
-      Timeout was reached: [www.gutenberg.org] Operation timed out after 10001 milliseconds with 0 out of 0 bytes received
-    Calls: gutenberg_get_mirror ... <Anonymous> -> vroom_ -> <Anonymous> -> open.connection
-    Execution halted
-    ```
-
-## In both
-
-*   checking installed package size ... NOTE
-    ```
-      installed size is  5.1Mb
-      sub-directories of 1Mb or more:
-        data   4.6Mb
-    ```
-
-*   checking data for non-ASCII characters ... NOTE
-    ```
-      Note: found 18981 marked UTF-8 strings
-    ```
-
-# hlaR
-
-<details>
-
-* Version: 0.1.6
-* GitHub: https://github.com/LarsenLab/hlaR
-* Source code: https://github.com/cran/hlaR
-* Date/Publication: 2022-12-20 23:30:02 UTC
-* Number of recursive dependencies: 151
-
-Run `cloud_details(, "hlaR")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-      ...
-    --- re-building ‘allele-haplotype.Rmd’ using rmarkdown
-    --- finished re-building ‘allele-haplotype.Rmd’
-    
-    --- re-building ‘eplet-mm.Rmd’ using rmarkdown
-    Quitting from lines 70-87 (eplet-mm.Rmd) 
-    Error: processing vignette 'eplet-mm.Rmd' failed with diagnostics:
-    'x' must be numeric
-    --- failed re-building ‘eplet-mm.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘eplet-mm.Rmd’
-    
-    Error: Vignette re-building failed.
+    > # Create a single-cohort data set
+    ...
+    > gradient <- gompertztrunc::gompertz_mle(formula = death_age ~ finished_hs,
+    + left_trunc = 1988, right_trunc = 2005, data = numident_c1920)
+    > 
+    > # Create diagnostic histogram plot using model outcome
+    > gompertztrunc::diagnostic_plot(object = gradient, data = numident_c1920,
+    + covar = "finished_hs", xlim = c(60, 95))
+    Error in .shallow(x, cols = cols, retain.key = TRUE) : 
+      attempt to set index 0/0 in SET_VECTOR_ELT
+    Calls: <Anonymous> ... names<- -> names<-.data.table -> shallow -> .shallow
     Execution halted
     ```
 
@@ -284,65 +278,73 @@ Run `cloud_details(, "metaconfoundr")` for more info
     Execution halted
     ```
 
-# recipes
+# openalexR
 
 <details>
 
-* Version: 1.0.3
-* GitHub: https://github.com/tidymodels/recipes
-* Source code: https://github.com/cran/recipes
-* Date/Publication: 2022-11-09 16:50:02 UTC
-* Number of recursive dependencies: 134
+* Version: 1.0.0
+* GitHub: https://github.com/massimoaria/openalexR
+* Source code: https://github.com/cran/openalexR
+* Date/Publication: 2022-10-06 10:40:02 UTC
+* Number of recursive dependencies: 78
 
-Run `cloud_details(, "recipes")` for more info
+Run `cloud_details(, "openalexR")` for more info
 
 </details>
 
 ## Newly broken
 
-*   checking examples ... ERROR
+*   checking re-building of vignette outputs ... WARNING
     ```
-    Running examples in ‘recipes-Ex.R’ failed
-    The error most likely occurred in:
+    Error(s) in re-building vignettes:
+      ...
+    --- re-building ‘A_Brief_Introduction_to_openalexR.Rmd’ using rmarkdown
+    Quitting from lines 342-354 (A_Brief_Introduction_to_openalexR.Rmd) 
+    Error: processing vignette 'A_Brief_Introduction_to_openalexR.Rmd' failed with diagnostics:
+    missing value where TRUE/FALSE needed
+    --- failed re-building ‘A_Brief_Introduction_to_openalexR.Rmd’
     
-    > ### Name: step_naomit
-    > ### Title: Remove observations with missing values
-    > ### Aliases: step_naomit
-    > 
-    > ### ** Examples
-    > 
-    > 
-    ...
-     10.       └─tidyselect::eval_select(expr(c(!!!dots)), data, allow_rename = FALSE)
-     11.         └─tidyselect:::eval_select_impl(...)
-     12.           ├─tidyselect:::with_subscript_errors(...)
-     13.           │ └─rlang::try_fetch(...)
-     14.           │   └─base::withCallingHandlers(...)
-     15.           └─tidyselect:::vars_select_eval(...)
-     16.             └─tidyselect:::ensure_named(...)
-     17.               └─cli::cli_abort(...)
-     18.                 └─rlang::abort(...)
+    SUMMARY: processing the following file failed:
+      ‘A_Brief_Introduction_to_openalexR.Rmd’
+    
+    Error: Vignette re-building failed.
     Execution halted
     ```
+
+# panelr
+
+<details>
+
+* Version: 0.7.6
+* GitHub: https://github.com/jacob-long/panelr
+* Source code: https://github.com/cran/panelr
+* Date/Publication: 2021-12-17 07:40:02 UTC
+* Number of recursive dependencies: 169
+
+Run `cloud_details(, "panelr")` for more info
+
+</details>
+
+## Newly broken
 
 *   checking tests ... ERROR
     ```
       Running ‘testthat.R’
     Running the tests in ‘tests/testthat.R’ failed.
     Last 13 lines of output:
-        9.     ├─tidyr::drop_na(new_data, object$columns)
-       10.     └─tidyr:::drop_na.data.frame(new_data, object$columns)
-       11.       └─tidyselect::eval_select(expr(c(!!!dots)), data, allow_rename = FALSE)
-       12.         └─tidyselect:::eval_select_impl(...)
-       13.           ├─tidyselect:::with_subscript_errors(...)
-       14.           │ └─rlang::try_fetch(...)
-       15.           │   └─base::withCallingHandlers(...)
-       16.           └─tidyselect:::vars_select_eval(...)
-       17.             └─tidyselect:::ensure_named(...)
-       18.               └─cli::cli_abort(...)
-       19.                 └─rlang::abort(...)
+        5.     └─panelr:::detrend(e$data, pf, dt_order, balance_correction, dt_random)
+        6.       ├─tidyr::nest(data)
+        7.       └─tidyr:::nest.grouped_df(data)
+        8.         └─tidyr:::nest.tbl_df(.data, `:=`(!!.key, all_of(cols)), .names_sep = .names_sep)
+        9.           └─vctrs::vec_cbind(out, inner, .name_repair = "check_unique", .error_call = error_call)
+       10.             └─vctrs (local) `<fn>`()
+       11.               └─vctrs:::validate_unique(names = names, arg = arg, call = call)
+       12.                 └─vctrs:::stop_names_must_be_unique(names, arg, call = call)
+       13.                   └─vctrs:::stop_names(...)
+       14.                     └─vctrs:::stop_vctrs(...)
+       15.                       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = vctrs_error_call(call))
       
-      [ FAIL 2 | WARN 2 | SKIP 401 | PASS 1889 ]
+      [ FAIL 2 | WARN 1 | SKIP 0 | PASS 240 ]
       Error: Test failures
       Execution halted
     ```
@@ -351,7 +353,7 @@ Run `cloud_details(, "recipes")` for more info
 
 *   checking Rd cross-references ... NOTE
     ```
-    Packages unavailable to check Rd xrefs: ‘fastICA’, ‘dimRed’
+    Package unavailable to check Rd xrefs: ‘AER’
     ```
 
 # tidypaleo

--- a/tests/testthat/_snaps/nest.md
+++ b/tests/testthat/_snaps/nest.md
@@ -1,12 +1,3 @@
-# nesting no columns nests all inputs
-
-    Code
-      out <- nest(df)
-    Condition
-      Warning:
-      `...` can't be empty for ungrouped data frames.
-      i Did you want `data = everything()`?
-
 # nest disallows renaming
 
     Code
@@ -15,6 +6,24 @@
       Error in `nest()`:
       ! Can't rename variables in this context.
 
+---
+
+    Code
+      nest(df, .by = c(a = x))
+    Condition
+      Error in `nest()`:
+      ! Can't rename variables in this context.
+
+# catches when `...` overwrites an existing column
+
+    Code
+      nest(df, x = y)
+    Condition
+      Error in `nest()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
+
 # validates its inputs
 
     Code
@@ -22,6 +31,40 @@
     Condition
       Error in `nest()`:
       ! `.names_sep` must be a single string or `NULL`, not the number 1.
+
+---
+
+    Code
+      nest(df, y = ya:yb, .key = 1)
+    Condition
+      Error in `nest()`:
+      ! `.key` must be a single string, not the number 1.
+
+# warns if `.key` is supplied alongside `...`
+
+    Code
+      out <- nest_info(df, data = 2, .key = "foo")
+    Condition
+      Warning:
+      Can't supply both `.key` and `...`.
+      i `.key` will be ignored.
+
+---
+
+    Code
+      out <- nest(df, data = 2, .key = "foo")
+    Condition
+      Warning in `nest()`:
+      Can't supply both `.key` and `...`.
+      i `.key` will be ignored.
+
+# `.by` isn't allowed for grouped data frames
+
+    Code
+      nest(df, .by = x)
+    Condition
+      Error in `nest()`:
+      ! Can't supply `.by` when `.data` is a grouped data frame.
 
 # warn about old style interface
 
@@ -40,6 +83,24 @@
       Warning:
       All elements of `...` must be named.
       i Did you want `data = -y`?
+
+# can use `.by` with old style interface
+
+    Code
+      out <- nest(df, y, .by = x)
+    Condition
+      Warning:
+      All elements of `...` must be named.
+      i Did you want `data = y`?
+
+---
+
+    Code
+      out <- nest(df, y, .by = x, .key = "foo")
+    Condition
+      Warning:
+      All elements of `...` must be named.
+      i Did you want `foo = y`?
 
 # only warn about unnamed inputs (#1175)
 
@@ -68,19 +129,12 @@
       All elements of `...` must be named.
       i Did you want `y = y`?
 
-# can control output column name when nested
-
-    Code
-      out <- nest(df, .key = "y")
-    Condition
-      Warning:
-      `.key` is deprecated
-
 # .key gets warning with new interface
 
     Code
-      out <- nest(df, y = y, .key = "y")
+      out <- nest(df, y = y, .key = "foo")
     Condition
-      Warning:
-      `.key` is deprecated
+      Warning in `nest()`:
+      Can't supply both `.key` and `...`.
+      i `.key` will be ignored.
 

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -90,11 +90,48 @@ test_that("can nest multiple columns", {
 })
 
 test_that("nesting no columns nests all inputs", {
-  # included only for backward compatibility
   df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
-  expect_snapshot(out <- nest(df))
+  out <- nest(df)
   expect_named(out, "data")
   expect_equal(out$data[[1]], df)
+})
+
+test_that("can control output column name when nesting all inputs", {
+  df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
+  out <- nest(df, .key = "foo")
+  expect_named(out, "foo")
+  expect_equal(out$foo[[1]], df)
+})
+
+test_that("can control output column name when only supplying `.by`", {
+  df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
+  out <- nest(df, .by = a2, .key = "foo")
+  expect_named(out, c("a2", "foo"))
+  expect_equal(out$foo[[1]], df[c("a1", "b1", "b2")])
+})
+
+test_that("can control output column name when nesting by groups", {
+  df <- dplyr::group_by(tibble(x = c(1, 1, 1), y = 1:3), x)
+  out <- nest(df, .key = "y")
+  expect_named(out, c("x", "y"))
+})
+
+test_that("can nest `.by` columns", {
+  df <- tibble(x = c(1, 1, 1, 2, 2), y = c(2, 1, 2, 3, 4), z = 1:5)
+
+  expect_identical(
+    nest(df, .by = c(x, y)),
+    nest(df, data = z)
+  )
+})
+
+test_that("can combine `.by` with `...`", {
+  df <- tibble(x = c(1, 1, 1, 2, 2), y = c(2, 1, 2, 3, 4), z = 1:5)
+
+  expect_identical(
+    nest(df, data = x, .by = y),
+    nest(dplyr::select(df, -z), data = x)
+  )
 })
 
 test_that("nest disallows renaming", {
@@ -103,12 +140,106 @@ test_that("nest disallows renaming", {
   expect_snapshot(error = TRUE, {
     nest(df, data = c(a = x))
   })
+  expect_snapshot(error = TRUE, {
+    nest(df, .by = c(a = x))
+  })
+})
+
+test_that("catches when `...` overwrites an existing column", {
+  df <- tibble(x = 1, y = 2)
+
+  # Hardcoded as an error.
+  # Name repair would likely break internal usage of `chop()`.
+  expect_snapshot(error = TRUE, {
+    nest(df, x = y)
+  })
 })
 
 test_that("validates its inputs", {
   df <- tibble(x = c(1, 1, 1), ya = 1:3, yb = 4:6)
   expect_snapshot(error = TRUE, {
     nest(df, y = ya:yb, .names_sep = 1)
+  })
+  expect_snapshot(error = TRUE, {
+    nest(df, y = ya:yb, .key = 1)
+  })
+})
+
+# nest_info() / .by -------------------------------------------------------
+
+test_that("Supplied `...` + No `.by` works", {
+  df <- tibble(x = 1, y = 2, z = 3)
+
+  out <- nest_info(df, data = c(x, z), data2 = x)
+
+  expect_identical(out$inner, c("x", "z"))
+  expect_identical(out$outer, "y")
+
+  expect_identical(quo_get_expr(out$cols$data), expr(all_of(!!c("x", "z"))))
+  expect_identical(quo_get_expr(out$cols$data2), expr(all_of(!!"x")))
+})
+
+test_that("Supplied `...` + Supplied `.by` works", {
+  df <- tibble(x = 1, y = 2, z = 3)
+
+  out <- nest_info(df, data = c(x, y), .by = y)
+  expect_identical(out$inner, c("x", "y"))
+  expect_identical(out$outer, "y")
+})
+
+test_that("No `...` + Supplied `.by` works", {
+  df <- tibble(x = 1, y = 2, z = 3)
+
+  out <- nest_info(df, .by = y)
+  expect_identical(out$inner, c("x", "z"))
+  expect_identical(out$outer, "y")
+})
+
+test_that("No `...` + No `.by` works", {
+  df <- tibble(x = 1, y = 2, z = 3)
+
+  # We define this to mean "nest everything" rather than "nest by everything",
+  # as the former is generally more useful and is backwards compatible
+  out <- nest_info(df)
+  expect_identical(out$inner, c("x", "y", "z"))
+  expect_identical(out$outer, character())
+})
+
+test_that("`everything()` always selects from full data", {
+  df <- tibble(x = 1, y = 2, z = 3)
+
+  out <- nest_info(df, data = everything(), .by = everything())
+
+  expect_identical(out$inner, c("x", "y", "z"))
+  expect_identical(out$outer, c("x", "y", "z"))
+})
+
+test_that("`.key` can alter the implied inner name", {
+  df <- tibble(x = 1, y = 2, z = 3)
+
+  out <- nest_info(df, .key = "foo")
+  expect_named(out$cols, "foo")
+
+  out <- nest_info(df, .by = x, .key = "foo")
+  expect_named(out$cols, "foo")
+})
+
+test_that("warns if `.key` is supplied alongside `...`", {
+  df <- tibble(x = 1, y = 2)
+
+  expect_snapshot(out <- nest_info(df, data = 2, .key = "foo"))
+  expect_named(out$cols, "data")
+
+  # Checking for warning at top level too
+  expect_snapshot(out <- nest(df, data = 2, .key = "foo"))
+})
+
+test_that("`.by` isn't allowed for grouped data frames", {
+  df <- tibble(g = 1, x = 2)
+  df <- dplyr::group_by(df, g)
+
+  expect_snapshot(error = TRUE, {
+    nest(df, .by = x)
   })
 })
 
@@ -123,6 +254,17 @@ test_that("warn about old style interface", {
 
   expect_snapshot(out <- nest(df, -y))
   expect_named(out, c("y", "data"))
+})
+
+test_that("can use `.by` with old style interface", {
+  df <- tibble(x = c(1, 1, 1), y = 1:3, z = 1:3)
+
+  expect_snapshot(out <- nest(df, y, .by = x))
+  expect_identical(out, nest(df, data = y, .by = x))
+
+  # Notably, no warning about using `...` and `.key` together
+  expect_snapshot(out <- nest(df, y, .by = x, .key = "foo"))
+  expect_identical(out, nest(df, foo = y, .by = x))
 })
 
 test_that("only warn about unnamed inputs (#1175)", {
@@ -143,14 +285,18 @@ test_that("can control output column name", {
   expect_named(out, c("x", "y"))
 })
 
-test_that("can control output column name when nested", {
-  df <- dplyr::group_by(tibble(x = c(1, 1, 1), y = 1:3), x)
-  expect_snapshot(out <- nest(df, .key = "y"))
-  expect_named(out, c("x", "y"))
-})
-
 test_that(".key gets warning with new interface", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
-  expect_snapshot(out <- nest(df, y = y, .key = "y"))
+  expect_snapshot(out <- nest(df, y = y, .key = "foo"))
   expect_named(df, c("x", "y"))
+})
+
+test_that("old usage of `.key = deprecated()` is translated to `.key = NULL`", {
+  # For `nest()` S3 method authors that did this
+  df <- tibble(x = c(1, 1, 2))
+
+  expect_identical(
+    nest(df, data = x, .key = deprecated()),
+    nest(df, data = x)
+  )
 })


### PR DESCRIPTION
Closes #1458 

``` r
df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)

# Can now do this
nest(df, .by = x)
#> # A tibble: 3 × 2
#>       x data            
#>   <dbl> <list>          
#> 1     1 <tibble [3 × 2]>
#> 2     2 <tibble [2 × 2]>
#> 3     3 <tibble [1 × 2]>

# Rather than either of these:
# nest(df, data = -x)
# nest(df, data = c(y, z))
```

Also has these two cool new features:

``` r
# Implicit `select(df, -z)`
nest(df, data = y, .by = x)
#> # A tibble: 3 × 2
#>       x data            
#>   <dbl> <list>          
#> 1     1 <tibble [3 × 1]>
#> 2     2 <tibble [2 × 1]>
#> 3     3 <tibble [1 × 1]>

# Include `x` in the inner nesting as well
nest(df, data = everything(), .by = x)
#> # A tibble: 3 × 2
#>       x data            
#>   <dbl> <list>          
#> 1     1 <tibble [3 × 3]>
#> 2     2 <tibble [2 × 3]>
#> 3     3 <tibble [1 × 3]>
```

This also revives the `.key` argument, with a default of `NULL`. This is a bit tricky because it used to be `deprecated()`, and if S3 method authors updated their methods to also say `.key = deprecated()` as the default, then their code may break. I've handled this by silently converting `deprecated()` to `NULL`.

`.key` is used whenever `...` isn't specified. This happens in 3 ways:
- `nest(df)` where we nest everything
- `nest(df, .by = x)` where we specify columns to nest by
- `df %>% group_by(x) %>% nest()` where columns to nest by are implied by the groups

If both `...` and `.key` are specified, a warning is thrown saying `.key` is ignored.

---

The only revdep that breaks because of these changes is panelr, because they have sticky `[` methods and we now use `df[cols]` in `nest()`. I can send them a PR after we merge this.
