### PR TITLE
Error on unnamed values if `names_sep` isn't provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # tidyr (development version)
 
+* `unnest_wider()` now generates automatic names for _partially_ unnamed
+  vectors. Previously it only generated them for fully unnamed vectors,
+  resulting in a strange mix of automatic names and name-repaired names (#1367).
+
+* `unnest_wider()` now errors if any values being unnested are unnamed and
+  `names_sep` is not provided (#1367).
+
 * `nest()` has gained a new argument, `.by`, which allows you to specify the
   columns to nest by (rather than the columns to nest, i.e. through `...`).
   Additionally, the `.key` argument is no longer deprecated, and is used

--- a/man/unnest_wider.Rd
+++ b/man/unnest_wider.Rd
@@ -27,9 +27,10 @@ to their common size.}
 as is. If a string, the outer and inner names will be pasted together using
 \code{names_sep} as a separator.
 
-If the values being unnested are unnamed and \code{names_sep} is supplied, the
-inner names will be automatically generated as an increasing sequence of
-integers.}
+If any values being unnested are unnamed, then \code{names_sep} must be
+supplied, otherwise an error is thrown. When \code{names_sep} is supplied,
+names are automatically generated for unnamed values as an increasing
+sequence of integers.}
 
 \item{simplify}{If \code{TRUE}, will attempt to simplify lists of
 length-1 vectors to an atomic vector. Can also be a named list containing
@@ -119,7 +120,7 @@ df <- tibble(
   x = 1:3,
   y = list(NULL, 1:3, 4:5)
 )
-# where you'll usually want to provide names_sep:
+# but you must supply `names_sep` to do so, which generates automatic names:
 df \%>\% unnest_wider(y, names_sep = "_")
 
 # 0-length elements ---------------------------------------------------------

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -7,50 +7,61 @@
       Error in `unnest_wider()`:
       ! List-column `y` must contain only vectors.
 
-# can unnest a vector with a mix of named/unnamed elements (#1200 comment)
+# can't unnest unnamed elements without `names_sep` (#1367)
 
     Code
-      out <- unnest_wider(df, x, names_sep = "_")
-    Message
-      New names:
-      * `` -> `...1`
-
-# unique name repair is done on the elements before applying `names_sep` (#1200 comment)
-
-    Code
-      out <- unnest_wider(df, col, names_sep = "_")
-    Message
-      New names:
-      * `` -> `...1`
+      unnest_wider(df, col)
+    Condition
+      Error in `unnest_wider()`:
+      ! Can't unnest elements with missing names.
+      i Supply `names_sep` to generate automatic names.
 
 ---
 
     Code
-      out <- unnest_wider(df, col, names_sep = "_")
-    Message
-      New names:
-      * `` -> `...1`
-      * `` -> `...2`
-
-# output structure is the same whether or not `names_sep` is applied (#1200 comment)
-
-    Code
-      out1 <- unnest_wider(df, col)
-    Message
-      New names:
-      * `` -> `...1`
-      New names:
-      * `` -> `...1`
+      unnest_wider(df, col)
+    Condition
+      Error in `unnest_wider()`:
+      ! Can't unnest elements with missing names.
+      i Supply `names_sep` to generate automatic names.
 
 ---
 
     Code
-      out2 <- unnest_wider(df, col, names_sep = "_")
+      unnest_wider(df, col)
+    Condition
+      Error in `unnest_wider()`:
+      ! Can't unnest elements with missing names.
+      i Supply `names_sep` to generate automatic names.
+
+---
+
+    Code
+      unnest_wider(df, col)
+    Condition
+      Error in `unnest_wider()`:
+      ! Can't unnest elements with missing names.
+      i Supply `names_sep` to generate automatic names.
+
+# catches duplicate inner names in the same vector
+
+    Code
+      unnest_wider(df, col)
+    Condition
+      Error in `unnest_wider()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
+      i Use argument `names_repair` to specify repair strategy.
+
+---
+
+    Code
+      out <- unnest_wider(df, col, names_repair = "unique")
     Message
       New names:
-      * `` -> `...1`
-      New names:
-      * `` -> `...1`
+      * `a` -> `a...1`
+      * `a` -> `a...2`
 
 # unnest_wider() advises on outer / inner name duplication (#1367)
 


### PR DESCRIPTION
Closes https://github.com/tidyverse/tidyr/issues/1367

So now we get:

``` r
library(tidyr)

df <- tribble(
  ~x, ~y,
  1, c(11, 12, 13),
  2, 21
)
df |> unnest_wider(y)
#> Error in `unnest_wider()`:
#> ! Can't unnest elements with missing names.
#> ℹ Supply `names_sep` to generate automatic names.
```

Also fixes an issue where partially unnamed elements weren't being patched with automatic names. Instead they were getting name-repaired by vctrs, which ended up generating a strange (and not useful) combination of names.

``` r
library(tidyr)

df <- tribble(
  ~x, ~y,
  1, c(11, b = 12, 13),
  2, 21
)

# before
df |> unnest_wider(y, names_sep = "_")
#> New names:
#> • `` -> `...1`
#> • `` -> `...3`
#> # A tibble: 2 × 5
#>       x y_...1   y_b y_...3   y_1
#>   <dbl>  <dbl> <dbl>  <dbl> <dbl>
#> 1     1     11    12     13    NA
#> 2     2     NA    NA     NA    21

# after
df |> unnest_wider(y, names_sep = "_")
#> # A tibble: 2 × 4
#>       x   y_1   y_b   y_3
#>   <dbl> <dbl> <dbl> <dbl>
#> 1     1    11    12    13
#> 2     2    21    NA    NA
```

<sup>Created on 2023-01-12 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>