### PR TITLE
Rethrow purrr index errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     glue,
     lifecycle (>= 1.0.3),
     magrittr,
-    purrr (>= 1.0.0),
+    purrr (>= 1.0.1),
     rlang (>= 1.0.4),
     stringr (>= 1.5.0),
     tibble (>= 2.1.1),

--- a/R/extract.R
+++ b/R/extract.R
@@ -103,7 +103,7 @@ str_match_first <- function(string, regex) {
   loc <- regexpr(regex, string, perl = TRUE)
   loc <- group_loc(loc)
 
-  out <- lapply(
+  out <- map(
     seq_len(loc$matches),
     function(i) substr(string, loc$start[, i], loc$end[, i])
   )

--- a/R/nest.R
+++ b/R/nest.R
@@ -245,14 +245,18 @@ nest_info <- function(.data,
     warn_unused_key(error_call = .error_call)
   }
 
-  cols <- lapply(cols, function(col) {
-    names(tidyselect::eval_select(
-      expr = col,
-      data = .data,
-      allow_rename = FALSE,
-      error_call = .error_call
-    ))
-  })
+  cols <- with_indexed_errors(
+    map(cols, function(col) {
+      names(tidyselect::eval_select(
+        expr = col,
+        data = .data,
+        allow_rename = FALSE,
+        error_call = NULL
+      ))
+    }),
+    message = "In expression named {.arg {cnd$name}}:",
+    error_call = .error_call
+  )
 
   names <- names(.data)
 

--- a/R/nest.R
+++ b/R/nest.R
@@ -254,7 +254,9 @@ nest_info <- function(.data,
         error_call = NULL
       ))
     }),
-    message = "In expression named {.arg {cnd$name}}:",
+    message = function(cnd) {
+      cli::format_inline("In expression named {.arg {cnd$name}}:")
+    },
     error_call = .error_call
   )
 

--- a/R/nest.R
+++ b/R/nest.R
@@ -257,7 +257,7 @@ nest_info <- function(.data,
     message = function(cnd) {
       cli::format_inline("In expression named {.arg {cnd$name}}:")
     },
-    error_call = .error_call
+    .error_call = .error_call
   )
 
   names <- names(.data)

--- a/R/pack.R
+++ b/R/pack.R
@@ -82,7 +82,7 @@ pack <- function(.data, ..., .names_sep = NULL, .error_call = current_env()) {
     message = function(cnd) {
       cli::format_inline("In expression named {.arg {cnd$name}}:")
     },
-    error_call = .error_call
+    .error_call = .error_call
   )
 
   unpacked <- setdiff(names(.data), unlist(map(cols, names)))

--- a/R/pack.R
+++ b/R/pack.R
@@ -70,15 +70,18 @@ pack <- function(.data, ..., .names_sep = NULL, .error_call = current_env()) {
   }
   check_string(.names_sep, allow_null = TRUE, call = .error_call)
 
-  # TODO: Switch back to `map()` in purrr 1.0.1
-  cols <- lapply(cols, function(col) {
-    tidyselect::eval_select(
-      expr = col,
-      data = .data,
-      allow_rename = FALSE,
-      error_call = .error_call
-    )
-  })
+  cols <- with_indexed_errors(
+    map(cols, function(col) {
+      tidyselect::eval_select(
+        expr = col,
+        data = .data,
+        allow_rename = FALSE,
+        error_call = NULL
+      )
+    }),
+    message = "In expression named {.arg {cnd$name}}:",
+    error_call = .error_call
+  )
 
   unpacked <- setdiff(names(.data), unlist(map(cols, names)))
   unpacked <- .data[unpacked]

--- a/R/pack.R
+++ b/R/pack.R
@@ -79,7 +79,9 @@ pack <- function(.data, ..., .names_sep = NULL, .error_call = current_env()) {
         error_call = NULL
       )
     }),
-    message = "In expression named {.arg {cnd$name}}:",
+    message = function(cnd) {
+      cli::format_inline("In expression named {.arg {cnd$name}}:")
+    },
     error_call = .error_call
   )
 

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -278,7 +278,7 @@ pivot_longer_spec <- function(data,
     val_cols[-col_id] <- list(rep(NA, nrow(data)))
 
     if (has_name(values_transform, value)) {
-      val_cols <- lapply(val_cols, values_transform[[value]])
+      val_cols <- map(val_cols, values_transform[[value]])
     }
 
     # Name inputs that came from `data`, just for good error messages when

--- a/R/separate-longer.R
+++ b/R/separate-longer.R
@@ -75,7 +75,7 @@ str_split_length <- function(x, width = 1) {
   idx <- seq(1, max_length, by = width)
 
   pieces <- stringr::str_sub_all(x, cbind(idx, length = width))
-  pieces <- lapply(pieces, function(x) x[x != ""])
+  pieces <- map(pieces, function(x) x[x != ""])
   pieces
 }
 

--- a/R/separate-wider.R
+++ b/R/separate-wider.R
@@ -235,7 +235,7 @@ str_separate_wider_delim <- function(
   if (too_few == "debug" || too_many == "debug") {
     separate_warn_debug(col, names_sep, c("ok", "pieces", "remainder"))
     sep_loc <- stringr::str_locate_all(x, delim)
-    sep_last <- lapply(sep_loc, function(x) if (nrow(x) < p) NA else x[p, "start"])
+    sep_last <- map(sep_loc, function(x) if (nrow(x) < p) NA else x[p, "start"])
     remainder <- stringr::str_sub(x, sep_last)
     remainder[is.na(remainder) & !is.na(x)] <- ""
 
@@ -333,7 +333,7 @@ str_separate_wider_position <- function(x,
   names <- names(widths)[!skip]
 
   pieces <- stringr::str_sub_all(x, from)
-  pieces <- lapply(pieces, function(x) x[x != ""])
+  pieces <- map(pieces, function(x) x[x != ""])
 
   out <- df_align(
     x = pieces,

--- a/R/separate.R
+++ b/R/separate.R
@@ -176,7 +176,7 @@ str_split_n <- function(x, pattern, n_max = -1) {
   }
   m <- gregexpr(pattern, x, perl = TRUE)
   if (n_max > 0) {
-    m <- lapply(m, function(x) slice_match(x, seq_along(x) < n_max))
+    m <- map(m, function(x) slice_match(x, seq_along(x) < n_max))
   }
   regmatches(x, m, invert = TRUE)
 }

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -146,15 +146,22 @@ col_to_wide <- function(col, name, strict, names_sep, error_call = caller_env())
   # Avoid expensive dispatch from `[[.list_of`
   out <- tidyr_new_list(col)
 
-  out <- lapply(
-    out,
-    function(x) elt_to_wide(
-      x = x,
-      name = name,
-      strict = strict,
-      names_sep = names_sep,
-      error_call = error_call
-    )
+  out <- with_indexed_errors(
+    map(
+      out,
+      function(x) elt_to_wide(
+        x = x,
+        name = name,
+        strict = strict,
+        names_sep = names_sep,
+        error_call = NULL
+      )
+    ),
+    message = c(
+      i = "In column: {.code {name}}.",
+      i = "In row: {cnd$location}."
+    ),
+    error_call = error_call
   )
 
   # In the sole case of a list_of<data_frame>, we can be sure that the
@@ -196,7 +203,7 @@ elt_to_wide <- function(x, name, strict, names_sep, error_call = caller_env()) {
 
   if (!vec_is(x)) {
     cli::cli_abort(
-      "List-column {.var {name}} must contain only vectors.",
+      "List-column must only contain vectors.",
       call = error_call
     )
   }

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -157,10 +157,12 @@ col_to_wide <- function(col, name, strict, names_sep, error_call = caller_env())
         error_call = NULL
       )
     ),
-    message = c(
-      i = "In column: {.code {name}}.",
-      i = "In row: {cnd$location}."
-    ),
+    message = function(cnd) {
+      c(
+        i = cli::format_inline("In column: {.code {name}}."),
+        i = cli::format_inline("In row: {cnd$location}.")
+      )
+    },
     error_call = error_call
   )
 

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -163,7 +163,7 @@ col_to_wide <- function(col, name, strict, names_sep, error_call = caller_env())
         i = cli::format_inline("In row: {cnd$location}.")
       )
     },
-    error_call = error_call
+    .error_call = error_call
   )
 
   # In the sole case of a list_of<data_frame>, we can be sure that the

--- a/R/utils.R
+++ b/R/utils.R
@@ -331,12 +331,12 @@ check_list_of_bool <- function(x, names, arg = caller_arg(x), call = caller_env(
 with_indexed_errors <- function(expr,
                                 message,
                                 error_call = caller_env(),
-                                envir = caller_env()) {
+                                env = caller_env()) {
   try_fetch(
     expr,
     purrr_error_indexed = function(cnd) {
-      envir <- new_environment(list(cnd = cnd), parent = envir)
-      cli::cli_abort(message, call = error_call, parent = cnd$parent, .envir = envir)
+      message <- message(cnd)
+      cli::cli_abort(message, call = error_call, parent = cnd$parent, .envir = env)
     }
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -328,6 +328,19 @@ check_list_of_bool <- function(x, names, arg = caller_arg(x), call = caller_env(
   }
 }
 
+with_indexed_errors <- function(expr,
+                                message,
+                                error_call = caller_env(),
+                                envir = caller_env()) {
+  try_fetch(
+    expr,
+    purrr_error_indexed = function(cnd) {
+      envir <- new_environment(list(cnd = cnd), parent = envir)
+      cli::cli_abort(message, call = error_call, parent = cnd$parent, .envir = envir)
+    }
+  )
+}
+
 int_max <- function(x, default = -Inf) {
   if (length(x) == 0) {
     default

--- a/R/utils.R
+++ b/R/utils.R
@@ -330,13 +330,14 @@ check_list_of_bool <- function(x, names, arg = caller_arg(x), call = caller_env(
 
 with_indexed_errors <- function(expr,
                                 message,
-                                error_call = caller_env(),
-                                env = caller_env()) {
+                                ...,
+                                .error_call = caller_env(),
+                                .frame = caller_env()) {
   try_fetch(
     expr,
     purrr_error_indexed = function(cnd) {
       message <- message(cnd)
-      cli::cli_abort(message, call = error_call, parent = cnd$parent, .envir = env)
+      abort(message, ..., call = .error_call, parent = cnd$parent, .frame = .frame)
     }
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -302,13 +302,14 @@ check_list_of_functions <- function(x, names, arg = caller_arg(x), call = caller
   }
 
   check_unique_names(x, arg = arg, call = call)
+  x_names <- names(x)
 
-  x <- lapply(set_names(seq_along(x), names(x)), function(i) {
-    as_function(x[[i]], arg = glue("{arg}[[{i}]]"), call = call)
-  })
+  for (i in seq_along(x)) {
+    x[[i]] <- as_function(x[[i]], arg = glue("{arg}${x_names[[i]]}"), call = call)
+  }
 
   # Silently drop user supplied names not found in the data
-  x <- x[intersect(names(x), names)]
+  x <- x[intersect(x_names, names)]
 
   x
 }

--- a/tests/testthat/_snaps/nest.md
+++ b/tests/testthat/_snaps/nest.md
@@ -4,6 +4,8 @@
       nest(df, data = c(a = x))
     Condition
       Error in `nest()`:
+      ! In expression named `data`:
+      Caused by error:
       ! Can't rename variables in this context.
 
 ---

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -4,6 +4,8 @@
       pack(df, data = c(a = x))
     Condition
       Error in `pack()`:
+      ! In expression named `data`:
+      Caused by error:
       ! Can't rename variables in this context.
 
 ---
@@ -12,6 +14,8 @@
       pack(df, data1 = x, data2 = c(a = y))
     Condition
       Error in `pack()`:
+      ! In expression named `data2`:
+      Caused by error:
       ! Can't rename variables in this context.
 
 # pack validates its inputs

--- a/tests/testthat/_snaps/unnest-helper.md
+++ b/tests/testthat/_snaps/unnest-helper.md
@@ -71,7 +71,7 @@
     Output
       <error/rlang_error>
       Error:
-      ! Can't convert `transform[[1]]`, a number, to a function.
+      ! Can't convert `transform$x`, a number, to a function.
     Code
       (expect_error(df_simplify(data.frame(), transform = list(x = 1, x = 1))))
     Output

--- a/tests/testthat/_snaps/unnest-wider.md
+++ b/tests/testthat/_snaps/unnest-wider.md
@@ -5,7 +5,10 @@
     Output
       <error/rlang_error>
       Error in `unnest_wider()`:
-      ! List-column `y` must contain only vectors.
+      i In column: `y`.
+      i In row: 1.
+      Caused by error:
+      ! List-column must only contain vectors.
 
 # can't unnest unnamed elements without `names_sep` (#1367)
 
@@ -13,6 +16,9 @@
       unnest_wider(df, col)
     Condition
       Error in `unnest_wider()`:
+      i In column: `col`.
+      i In row: 1.
+      Caused by error:
       ! Can't unnest elements with missing names.
       i Supply `names_sep` to generate automatic names.
 
@@ -22,6 +28,9 @@
       unnest_wider(df, col)
     Condition
       Error in `unnest_wider()`:
+      i In column: `col`.
+      i In row: 1.
+      Caused by error:
       ! Can't unnest elements with missing names.
       i Supply `names_sep` to generate automatic names.
 
@@ -31,6 +40,9 @@
       unnest_wider(df, col)
     Condition
       Error in `unnest_wider()`:
+      i In column: `col`.
+      i In row: 1.
+      Caused by error:
       ! Can't unnest elements with missing names.
       i Supply `names_sep` to generate automatic names.
 
@@ -40,6 +52,9 @@
       unnest_wider(df, col)
     Condition
       Error in `unnest_wider()`:
+      i In column: `col`.
+      i In row: 2.
+      Caused by error:
       ! Can't unnest elements with missing names.
       i Supply `names_sep` to generate automatic names.
 


### PR DESCRIPTION
Closes #1440

- Required purrr 1.0.1
- Switched from `lapply()` to `map()` everywhere
- Added `with_indexed_errors()` to ease rethrowing with a custom message

@hadley, @lionel- what do you think of this rethrowing pattern in `with_indexed_errors()`? It seems useful to expose `message` so the caller of `with_indexed_errors()` can customize as needed, and I've fiddled with the environment so that cli interpolation works as usual AND you get access to `cnd` when the `message` is eventually interpolated.