### PR TITLE
Tweak `expand()` dots documentation to mention `complete()`

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -21,11 +21,11 @@
 #' @inheritParams expand_grid
 #' @param data A data frame.
 #' @param ... <[`data-masking`][tidyr_data_masking]> Specification of columns
-#'   to expand. Columns can be atomic vectors or lists.
+#'   to expand or complete. Columns can be atomic vectors or lists.
 #'
 #'   * To find all unique combinations of `x`, `y` and `z`, including those not
 #'     present in the data, supply each variable as a separate argument:
-#'     `expand(df, x, y, z)`.
+#'     `expand(df, x, y, z)` or `complete(df, x, y, z)`.
 #'   * To find only the combinations that occur in the
 #'     data, use `nesting`: `expand(df, nesting(x, y, z))`.
 #'   * You can combine the two forms. For example,
@@ -33,9 +33,9 @@
 #'     a row for each present school-student combination for all possible
 #'     dates.
 #'
-#'   When used with factors, `expand()` uses the full set of levels, not just
-#'   those that appear in the data. If you want to use only the values seen in
-#'   the data, use `forcats::fct_drop()`.
+#'   When used with factors, [expand()] and [complete()] use the full set of
+#'   levels, not just those that appear in the data. If you want to use only the
+#'   values seen in the data, use `forcats::fct_drop()`.
 #'
 #'   When used with continuous variables, you may need to fill in values
 #'   that do not appear in the data: to do so use expressions like

--- a/man/complete.Rd
+++ b/man/complete.Rd
@@ -10,11 +10,11 @@ complete(data, ..., fill = list(), explicit = TRUE)
 \item{data}{A data frame.}
 
 \item{...}{<\code{\link[=tidyr_data_masking]{data-masking}}> Specification of columns
-to expand. Columns can be atomic vectors or lists.
+to expand or complete. Columns can be atomic vectors or lists.
 \itemize{
 \item To find all unique combinations of \code{x}, \code{y} and \code{z}, including those not
 present in the data, supply each variable as a separate argument:
-\code{expand(df, x, y, z)}.
+\code{expand(df, x, y, z)} or \code{complete(df, x, y, z)}.
 \item To find only the combinations that occur in the
 data, use \code{nesting}: \code{expand(df, nesting(x, y, z))}.
 \item You can combine the two forms. For example,
@@ -23,9 +23,9 @@ a row for each present school-student combination for all possible
 dates.
 }
 
-When used with factors, \code{expand()} uses the full set of levels, not just
-those that appear in the data. If you want to use only the values seen in
-the data, use \code{forcats::fct_drop()}.
+When used with factors, \code{\link[=expand]{expand()}} and \code{\link[=complete]{complete()}} use the full set of
+levels, not just those that appear in the data. If you want to use only the
+values seen in the data, use \code{forcats::fct_drop()}.
 
 When used with continuous variables, you may need to fill in values
 that do not appear in the data: to do so use expressions like

--- a/man/deprecated-se.Rd
+++ b/man/deprecated-se.Rd
@@ -87,11 +87,11 @@ unnest_(...)
 use instead of \code{NA} for missing combinations.}
 
 \item{...}{<\code{\link[=tidyr_data_masking]{data-masking}}> Specification of columns
-to expand. Columns can be atomic vectors or lists.
+to expand or complete. Columns can be atomic vectors or lists.
 \itemize{
 \item To find all unique combinations of \code{x}, \code{y} and \code{z}, including those not
 present in the data, supply each variable as a separate argument:
-\code{expand(df, x, y, z)}.
+\code{expand(df, x, y, z)} or \code{complete(df, x, y, z)}.
 \item To find only the combinations that occur in the
 data, use \code{nesting}: \code{expand(df, nesting(x, y, z))}.
 \item You can combine the two forms. For example,
@@ -100,9 +100,9 @@ a row for each present school-student combination for all possible
 dates.
 }
 
-When used with factors, \code{expand()} uses the full set of levels, not just
-those that appear in the data. If you want to use only the values seen in
-the data, use \code{forcats::fct_drop()}.
+When used with factors, \code{\link[=expand]{expand()}} and \code{\link[=complete]{complete()}} use the full set of
+levels, not just those that appear in the data. If you want to use only the
+values seen in the data, use \code{forcats::fct_drop()}.
 
 When used with continuous variables, you may need to fill in values
 that do not appear in the data: to do so use expressions like

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -16,11 +16,11 @@ nesting(..., .name_repair = "check_unique")
 \item{data}{A data frame.}
 
 \item{...}{<\code{\link[=tidyr_data_masking]{data-masking}}> Specification of columns
-to expand. Columns can be atomic vectors or lists.
+to expand or complete. Columns can be atomic vectors or lists.
 \itemize{
 \item To find all unique combinations of \code{x}, \code{y} and \code{z}, including those not
 present in the data, supply each variable as a separate argument:
-\code{expand(df, x, y, z)}.
+\code{expand(df, x, y, z)} or \code{complete(df, x, y, z)}.
 \item To find only the combinations that occur in the
 data, use \code{nesting}: \code{expand(df, nesting(x, y, z))}.
 \item You can combine the two forms. For example,
@@ -29,9 +29,9 @@ a row for each present school-student combination for all possible
 dates.
 }
 
-When used with factors, \code{expand()} uses the full set of levels, not just
-those that appear in the data. If you want to use only the values seen in
-the data, use \code{forcats::fct_drop()}.
+When used with factors, \code{\link[=expand]{expand()}} and \code{\link[=complete]{complete()}} use the full set of
+levels, not just those that appear in the data. If you want to use only the
+values seen in the data, use \code{forcats::fct_drop()}.
 
 When used with continuous variables, you may need to fill in values
 that do not appear in the data: to do so use expressions like


### PR DESCRIPTION
Closes #1456

Since one is _always_ inherited from the other, and you typically learn about both around the same time, it feels fine to mention both here since it makes the `complete()` docs easier to understand