### PR TITLE
Use `vec_expand_grid()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     tibble (>= 2.1.1),
     tidyselect (>= 1.2.0),
     utils,
-    vctrs (>= 0.5.0)
+    vctrs (>= 0.5.1.9000)
 Suggests: 
     covr,
     data.table,
@@ -52,3 +52,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 SystemRequirements: C++11
+Remotes:
+    r-lib/vctrs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     tibble (>= 2.1.1),
     tidyselect (>= 1.2.0),
     utils,
-    vctrs (>= 0.5.1.9000)
+    vctrs (>= 0.5.2)
 Suggests: 
     covr,
     data.table,
@@ -52,5 +52,3 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 SystemRequirements: C++11
-Remotes:
-    r-lib/vctrs

--- a/NEWS.md
+++ b/NEWS.md
@@ -91,7 +91,7 @@
 
 * All built in datasets are now standard tibbles (#1459).
 
-* rlang >=1.0.2 and vctrs >=0.4.1 are now required (#1344).
+* rlang >=1.0.4 and vctrs >=0.5.2 are now required (#1344, #1470).
 
 * Removed dependency on ellipsis in favor of equivalent functions in rlang
   (#1314).


### PR DESCRIPTION
We can wait to merge until after vctrs is on CRAN.

`vec_expand_grid()` doesn't splice unnamed data frames. It requires all inputs to be named. So this requires a little tweaking to account for that. 

I really don't know if splicing unnamed data frames is a particularly useful feature, so I tried to be more conservative in `vec_expand_grid()` and didn't allow that for now. I think it makes the `vec_expand_grid()` implementation simpler since this is a feature I don't feel particularly strongly about.

- [x] Bump vctrs version and remove Remote