### PR TITLE
Fix error messages for `separate_wider_*()` functions' `too_few` argument

### DIFF
--- a/R/separate-wider.R
+++ b/R/separate-wider.R
@@ -319,7 +319,7 @@ str_separate_wider_position <- function(x,
     too_many = too_many,
     advice_short = c(
       i = 'Use `too_few = "debug"` to diagnose the problem.',
-      i = 'Use `too_few = "start"` to silence this message.'
+      i = 'Use `too_few = "align_start"` to silence this message.'
     ),
     advice_long = c(
       i = 'Use `too_many = "debug"` to diagnose the problem.',
@@ -443,7 +443,7 @@ str_separate_wider_regex <- function(x,
         "Expected each value of {.var {col}} to match the pattern, the whole pattern, and nothing but the pattern.",
         "!" = "{length(no_match)} value{?s} {?has/have} problem{?s}.",
         i = 'Use {.code too_few = "debug"} to diagnose the problem.',
-        i = 'Use {.code too_few = "start"} to silence this message.'
+        i = 'Use {.code too_few = "align_start"} to silence this message.'
       ), call = error_call)
     }
 

--- a/tests/testthat/_snaps/separate-wider.md
+++ b/tests/testthat/_snaps/separate-wider.md
@@ -73,7 +73,7 @@
       ! Expected 3 characters in each element of `x`.
       ! 1 value was too short.
       i Use `too_few = "debug"` to diagnose the problem.
-      i Use `too_few = "start"` to silence this message.
+      i Use `too_few = "align_start"` to silence this message.
       ! 1 value was too long.
       i Use `too_many = "debug"` to diagnose the problem.
       i Use `too_many = "drop"` to silence this message.
@@ -124,7 +124,7 @@
       ! Expected each value of `x` to match the pattern, the whole pattern, and nothing but the pattern.
       ! 1 value has problem.
       i Use `too_few = "debug"` to diagnose the problem.
-      i Use `too_few = "start"` to silence this message.
+      i Use `too_few = "align_start"` to silence this message.
 
 # separate_wider_regex() can diagnose errors
 


### PR DESCRIPTION
Fixes #1475. The `separate_wider_position()` and `separate_wider_regex()` functions provide the `too_few` argument to control their behavior when one or more of the strings cannot be separated into as many pieces as the user specifies. When this happens, the error message that is displayed recommends specifying `too_few` as "start", rather than the valid value "align_start".