### PR TITLE
Standardize Posit name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),
     person("Maximilian", "Girlich", role = "aut"),
     person("Kevin", "Ushey", , "kevin@posit.co", role = "ctb"),
-    person("Posit, PBC", role = c("cph", "fnd"))
+    person("Posit Software, PBC", role = c("cph", "fnd"))
   )
 Description: Tools to help to create tidy data, where each column is a
     variable, each row is an observation, and each cell contains a single


### PR DESCRIPTION
I scraped CRAN to find companies that fund R packages, and noticed that Posit is credited 6 different ways (9 if you include RStudio/RStudio PBC/RStudio, PBC). I'm submitting PRs with the official "Posit Software, PBC" name on the few Posit varieties to nip it in the bud.