### PR TITLE
Fix typo in definition of tidy data in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 
 The goal of tidyr is to help you create __tidy data__. Tidy data is data where:
 
-1. Every column is variable.
+1. Every column is a variable.
 1. Every row is an observation.
 1. Every cell is a single value.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ coverage](https://codecov.io/gh/tidyverse/tidyr/branch/main/graph/badge.svg)](ht
 The goal of tidyr is to help you create **tidy data**. Tidy data is data
 where:
 
-1.  Every column is variable.
+1.  Every column is a variable.
 2.  Every row is an observation.
 3.  Every cell is a single value.
 


### PR DESCRIPTION
The `README` (`README.md` and `README.Rmd`) files have a typo in the definition of tidy data. I changed the text from "Every column is variable" to "Every column is a variable".

It's a very minor change but important because these sentences have different meanings. Without the "a", it is more difficult to understand what tidy data is, and this is the first thing you see when you go to `tidyr`'s homepage.