### PR TITLE
In README, replace `separate()` and `extract()` with superseding functions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -69,9 +69,10 @@ tidyr functions fall into five main categories:
   single row containing a nested data frame, and unnesting does the opposite.
   See `nest()`, `unnest()`, and  `vignette("nest")` for more details.
 
-* Splitting and combining character columns. Use `separate()` and `extract()` 
-  to pull a single character column into multiple columns; use `unite()` to
-  combine multiple columns into a single character column.
+* Splitting and combining character columns. Use `separate_wider_delim()`,
+  `separate_wider_position()`, and `separate_wider_regex()` to pull a single
+  character column into multiple columns; use `unite()` to combine multiple
+  columns into a single character column.
 
 * Make implicit missing values explicit with `complete()`; make explicit 
   missing values implicit with `drop_na()`; replace missing values with

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ tidyr functions fall into five main categories:
   opposite. See `nest()`, `unnest()`, and `vignette("nest")` for more
   details.
 
-- Splitting and combining character columns. Use `separate()` and
-  `extract()` to pull a single character column into multiple columns;
-  use `unite()` to combine multiple columns into a single character
-  column.
+- Splitting and combining character columns. Use `separate_wider_delim()`,
+  `separate_wider_position()`, and `separate_wider_regex()` to pull a single
+  character column into multiple columns; use `unite()` to combine multiple
+  columns into a single character column.
 
 - Make implicit missing values explicit with `complete()`; make explicit
   missing values implicit with `drop_na()`; replace missing values with

--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ tidyr functions fall into five main categories:
   opposite. See `nest()`, `unnest()`, and `vignette("nest")` for more
   details.
 
-- Splitting and combining character columns. Use `separate_wider_delim()`,
-  `separate_wider_position()`, and `separate_wider_regex()` to pull a single
-  character column into multiple columns; use `unite()` to combine multiple
-  columns into a single character column.
+- Splitting and combining character columns. Use
+  `separate_wider_delim()`, `separate_wider_position()`, and
+  `separate_wider_regex()` to pull a single character column into
+  multiple columns; use `unite()` to combine multiple columns into a
+  single character column.
 
 - Make implicit missing values explicit with `complete()`; make explicit
   missing values implicit with `drop_na()`; replace missing values with


### PR DESCRIPTION
The README currently recommends using the `separate()` and `extract()` functions to transform a single character column into multiple character columns. `separate()` has been superseded by `separate_wider_delim()` and `separate_wider_position()`, and `extract()` has been superseded by `separate_wider_regex()`. This commit updates the README to reflect this.