### PR TITLE
Re-enable autocompletion for pivot_wider and pivot_longer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,4 +50,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -154,6 +154,7 @@ pivot_longer <- function(data,
 }
 
 #' @export
+#' @rdname pivot_longer
 pivot_longer.data.frame <- function(data,
                                     cols,
                                     ...,

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -176,6 +176,7 @@ pivot_wider <- function(data,
 }
 
 #' @export
+#' @rdname pivot_wider
 pivot_wider.data.frame <- function(data,
                                    ...,
                                    id_cols = NULL,

--- a/man/hoist.Rd
+++ b/man/hoist.Rd
@@ -97,8 +97,8 @@ df \%>\% hoist(metadata,
 }
 \seealso{
 Other rectangling: 
+\code{\link{unnest}()},
 \code{\link{unnest_longer}()},
-\code{\link{unnest_wider}()},
-\code{\link{unnest}()}
+\code{\link{unnest_wider}()}
 }
 \concept{rectangling}

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -2,9 +2,28 @@
 % Please edit documentation in R/pivot-long.R
 \name{pivot_longer}
 \alias{pivot_longer}
+\alias{pivot_longer.data.frame}
 \title{Pivot data from wide to long}
 \usage{
 pivot_longer(
+  data,
+  cols,
+  ...,
+  cols_vary = "fastest",
+  names_to = "name",
+  names_prefix = NULL,
+  names_sep = NULL,
+  names_pattern = NULL,
+  names_ptypes = NULL,
+  names_transform = NULL,
+  names_repair = "check_unique",
+  values_to = "value",
+  values_drop_na = FALSE,
+  values_ptypes = NULL,
+  values_transform = NULL
+)
+
+\method{pivot_longer}{data.frame}(
   data,
   cols,
   ...,

--- a/man/pivot_wider.Rd
+++ b/man/pivot_wider.Rd
@@ -2,9 +2,29 @@
 % Please edit documentation in R/pivot-wide.R
 \name{pivot_wider}
 \alias{pivot_wider}
+\alias{pivot_wider.data.frame}
 \title{Pivot data from long to wide}
 \usage{
 pivot_wider(
+  data,
+  ...,
+  id_cols = NULL,
+  id_expand = FALSE,
+  names_from = name,
+  names_prefix = "",
+  names_sep = "_",
+  names_glue = NULL,
+  names_sort = FALSE,
+  names_vary = "fastest",
+  names_expand = FALSE,
+  names_repair = "check_unique",
+  values_from = value,
+  values_fill = NULL,
+  values_fn = NULL,
+  unused_fn = NULL
+)
+
+\method{pivot_wider}{data.frame}(
   data,
   ...,
   id_cols = NULL,

--- a/man/unnest_longer.Rd
+++ b/man/unnest_longer.Rd
@@ -140,7 +140,7 @@ df \%>\%
 \seealso{
 Other rectangling: 
 \code{\link{hoist}()},
-\code{\link{unnest_wider}()},
-\code{\link{unnest}()}
+\code{\link{unnest}()},
+\code{\link{unnest_wider}()}
 }
 \concept{rectangling}

--- a/man/unnest_wider.Rd
+++ b/man/unnest_wider.Rd
@@ -142,7 +142,7 @@ df \%>\%
 \seealso{
 Other rectangling: 
 \code{\link{hoist}()},
-\code{\link{unnest_longer}()},
-\code{\link{unnest}()}
+\code{\link{unnest}()},
+\code{\link{unnest_longer}()}
 }
 \concept{rectangling}


### PR DESCRIPTION
Autocompletion text in RStudio doesn't currently work for `pivot_longer()` and `pivot_wider()`. It seems to be due to the fact that the S3 method is not present in the Rd file.

This PR seems to fix that. I am not sure if this is the right fix, or it is with roxygen2 or RStudio itself..

I installed this version locally and it works.

![image](https://github.com/tidyverse/tidyr/assets/52606734/4fa29c97-6b69-42d0-9e1d-d29b68f3c0e1)

With the current cran version, when tidyr is loaded, the autocompletion doesn't show any text, only the parameters
![image](https://github.com/tidyverse/tidyr/assets/52606734/e8b93b08-1898-4fd0-b4a3-2090f6c250f6)


It seems that if the method is not in an Rd, RStudio doesn't know where to look for the help text.

If I typed F1 (help) before this PR, I would get the message:
```r
No documentation for ‘pivot_wider.data.frame’ in specified packages and libraries:
you could try ‘??pivot_wider.data.frame’
```