### PR TITLE
Use tidyselect allow_empty

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     rlang (>= 1.1.1),
     stringr (>= 1.5.0),
     tibble (>= 2.1.1),
-    tidyselect (>= 1.2.0),
+    tidyselect (>= 1.2.1.9000),
     utils,
     vctrs (>= 0.5.2)
 Suggests: 
@@ -45,6 +45,8 @@ LinkingTo:
     cpp11 (>= 0.4.0)
 VignetteBuilder: 
     knitr
+Remotes: 
+    r-lib/tidyselect#350
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -364,13 +364,11 @@ build_longer_spec <- function(data,
     expr = enquo(cols),
     data = data[unique(names(data))],
     allow_rename = FALSE,
+    allow_empty = FALSE,
+    error_arg = "cols",
     error_call = error_call
   )
   cols <- names(cols)
-
-  if (length(cols) == 0) {
-    cli::cli_abort("{.arg cols} must select at least one column.", call = error_call)
-  }
 
   if (is.null(names_prefix)) {
     names <- cols


### PR DESCRIPTION
Just testing if my PR in tidyselect seems to work as expected.

Not to be merged.

Edit: the genuine snapshot failures (caused by the addition of a classed error) actually nods that this change in tidyselect would be useful for tidyr.

For example
```r
    (expect_error(pivot_wider(df, names_from = key, values_from = starts_with("foo")))
    )
  Output
-   <error/rlang_error>
+   <error/tidyselect:::error_disallowed_empty>
    Error in `pivot_wider()`:
    ! Must select at least one item.
```

Could be improved if the `eval_select()` call had `error_arg = "foo"`