### PR TITLE
value_to -> values_to in `values_drop_na` docs

### DIFF
--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -72,7 +72,7 @@
 #'   and the name of the value column will be derived from part of the
 #'   existing column names.
 #' @param values_drop_na If `TRUE`, will drop rows that contain only `NA`s
-#'   in the `value_to` column. This effectively converts explicit missing values
+#'   in the `values_to` column. This effectively converts explicit missing values
 #'   to implicit missing values, and should generally be used only when missing
 #'   values in `data` were created by its structure.
 #' @param names_transform,values_transform Optionally, a list of column

--- a/man/pivot_longer.Rd
+++ b/man/pivot_longer.Rd
@@ -110,7 +110,7 @@ and the name of the value column will be derived from part of the
 existing column names.}
 
 \item{values_drop_na}{If \code{TRUE}, will drop rows that contain only \code{NA}s
-in the \code{value_to} column. This effectively converts explicit missing values
+in the \code{values_to} column. This effectively converts explicit missing values
 to implicit missing values, and should generally be used only when missing
 values in \code{data} were created by its structure.}
 }

--- a/man/pivot_longer_spec.Rd
+++ b/man/pivot_longer_spec.Rd
@@ -66,7 +66,7 @@ de-duplicated by adding numeric suffixes. See \code{\link[vctrs:vec_as_names]{vc
 for more options.}
 
 \item{values_drop_na}{If \code{TRUE}, will drop rows that contain only \code{NA}s
-in the \code{value_to} column. This effectively converts explicit missing values
+in the \code{values_to} column. This effectively converts explicit missing values
 to implicit missing values, and should generally be used only when missing
 values in \code{data} were created by its structure.}
 


### PR DESCRIPTION
In the documentation for `values_drop_na`, there is a reference to a `value_to` column, it should be `values_to`.