### PR TITLE
fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -673,7 +673,7 @@ Packing and chopping are interesting primarily because they are the atomic opera
 
 * `crossing()`, `nesting()`, and `expand()` have been rewritten to use 
   the vctrs package. This should not affect much existing code, but
-  considerably simplies the implementation and ensures that these functions 
+  considerably simplifies the implementation and ensures that these functions 
   work consistently across all generalised vectors (#557). As part of this
   alignment, these functions now only drop `NULL` inputs, not any 0-length
   vector.

--- a/tests/testthat/test-nest-legacy.R
+++ b/tests/testthat/test-nest-legacy.R
@@ -99,7 +99,7 @@ test_that("unnesting combines atomic vectors", {
   expect_equal(unnest_legacy(df)$x, 1:10)
 })
 
-test_that("unesting combines augmented vectors", {
+test_that("unnesting combines augmented vectors", {
   df <- tibble::tibble(x = as.list(as.factor(letters[1:3])))
   expect_equal(unnest_legacy(df)$x, factor(letters[1:3]))
 })

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -25,7 +25,7 @@ test_that("bad inputs generate errors", {
   expect_snapshot((expect_error(unnest(df, y))))
 })
 
-test_that("unesting combines augmented vectors", {
+test_that("unnesting combines augmented vectors", {
   df <- tibble(x = as.list(as.factor(letters[1:3])))
   expect_equal(unnest(df, x)$x, factor(letters[1:3]))
 })
@@ -213,7 +213,7 @@ test_that("unnesting typed lists of NULLs retains ptype", {
   expect_identical(out, tibble(x = integer(), a = integer()))
 })
 
-test_that("ptype can be overriden manually (#1158)", {
+test_that("ptype can be overridden manually (#1158)", {
   df <- tibble(
     a = list("a", c("b", "c")),
     b = list(1, c(2, 3)),

--- a/vignettes/pivot.Rmd
+++ b/vignettes/pivot.Rmd
@@ -189,7 +189,7 @@ who %>%
 )
 ```
 
-Doing it this way is a little more efficient than doing a mutate after the fact, `pivot_longer()` only has to transform one occurence of each name where a `mutate()` would need to transform many repetitions.
+Doing it this way is a little more efficient than doing a mutate after the fact, `pivot_longer()` only has to transform one occurrence of each name where a `mutate()` would need to transform many repetitions.
 
 ### Multiple observations per row
 

--- a/vignettes/rectangle.Rmd
+++ b/vignettes/rectangle.Rmd
@@ -148,7 +148,7 @@ chars2 %>%
 
 ## Geocoding with google
 
-Next we'll tackle a more complex form of data that comes from Google's geocoding service, stored in the repurssive package
+Next we'll tackle a more complex form of data that comes from Google's geocoding service, stored in the repurrrsive package
 
 ```{r}
 repurrrsive::gmaps_cities


### PR DESCRIPTION
Closes https://github.com/tidyverse/tidyr/issues/1563

Another NEWS.md typo will be fixed via the merging of `#1554`