### PR TITLE
Use tidyselect `error_arg` argument to yield better messages when `allow_rename = FALSE` or `allow_empty = FALSE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,9 +30,11 @@ Imports:
     rlang (>= 1.1.1),
     stringr (>= 1.5.0),
     tibble (>= 2.1.1),
-    tidyselect (>= 1.2.1),
+    tidyselect (>= 1.2.1.9000),
     utils,
     vctrs (>= 0.5.2)
+Remotes:
+    r-lib/tidyselect#358
 Suggests:
     covr,
     data.table,

--- a/R/drop-na.R
+++ b/R/drop-na.R
@@ -32,7 +32,7 @@ drop_na.data.frame <- function(data, ...) {
     # Use all columns if no `...` are supplied
     cols <- data
   } else {
-    vars <- tidyselect::eval_select(expr(c(!!!dots)), data, allow_rename = FALSE)
+    vars <- tidyselect::eval_select(expr(c(!!!dots)), data, allow_rename = FALSE, error_arg = "...")
     cols <- data[vars]
   }
 

--- a/R/fill.R
+++ b/R/fill.R
@@ -114,7 +114,8 @@ fill.data.frame <- function(data,
   vars <- names(tidyselect::eval_select(
     expr = expr(c(...)),
     data = data,
-    allow_rename = FALSE
+    allow_rename = FALSE,
+    error_arg = "..."
   ))
 
   .direction <- arg_match0(

--- a/R/pack.R
+++ b/R/pack.R
@@ -134,6 +134,7 @@ unpack <- function(data,
     expr = enquo(cols),
     data = data,
     allow_rename = FALSE,
+    error_arg = "cols",
     error_call = error_call
   )
   cols <- out[cols]

--- a/R/pivot-long.R
+++ b/R/pivot-long.R
@@ -364,13 +364,11 @@ build_longer_spec <- function(data,
     expr = enquo(cols),
     data = data[unique(names(data))],
     allow_rename = FALSE,
+    allow_empty = FALSE,
+    error_arg = "cols",
     error_call = error_call
   )
   cols <- names(cols)
-
-  if (length(cols) == 0) {
-    cli::cli_abort("{.arg cols} must select at least one column.", call = error_call)
-  }
 
   if (is.null(names_prefix)) {
     names <- cols

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -486,6 +486,7 @@ build_wider_spec <- function(data,
     data,
     allow_rename = FALSE,
     allow_empty = FALSE,
+    error_arg = "names_from",
     error_call = error_call
   )
   values_from <- tidyselect::eval_select(
@@ -493,6 +494,7 @@ build_wider_spec <- function(data,
     data,
     allow_rename = FALSE,
     allow_empty = FALSE,
+    error_arg = "values_from",
     error_call = error_call
   )
 
@@ -562,6 +564,7 @@ build_wider_id_cols_expr <- function(data,
     enquo(names_from),
     data,
     allow_rename = FALSE,
+    error_arg = "names_from",
     error_call = error_call
   )
 
@@ -569,6 +572,7 @@ build_wider_id_cols_expr <- function(data,
     enquo(values_from),
     data,
     allow_rename = FALSE,
+    error_arg = "values_from",
     error_call = error_call
   )
 
@@ -603,6 +607,7 @@ select_wider_id_cols <- function(data,
       enquo(id_cols),
       data,
       allow_rename = FALSE,
+      error_arg = "id_cols",
       error_call = error_call
     ),
     vctrs_error_subscript_oob = function(cnd) {
@@ -631,7 +636,7 @@ rethrow_id_cols_oob <- function(cnd, names_from_cols, values_from_cols, call) {
 stop_id_cols_oob <- function(i, arg, call) {
   cli::cli_abort(
     c(
-      "`id_cols` can't select a column already selected by `{arg}`.",
+      "{.arg id_cols} can't select a column already selected by `{arg}`.",
       i = "Column `{i}` has already been selected."
     ),
     parent = NA,

--- a/R/separate-longer.R
+++ b/R/separate-longer.R
@@ -87,6 +87,7 @@ map_unchop <- function(data, cols, fun, ..., .keep_empty = FALSE, .error_call = 
     data = data,
     allow_rename = FALSE,
     allow_empty = FALSE,
+    error_arg = "cols",
     error_call = .error_call
   )
   col_names <- names(cols)

--- a/R/separate-rows.R
+++ b/R/separate-rows.R
@@ -44,7 +44,12 @@ separate_rows.data.frame <- function(data,
   check_string(sep)
   check_bool(convert)
 
-  vars <- tidyselect::eval_select(expr(c(...)), data, allow_rename = FALSE)
+  vars <- tidyselect::eval_select(
+    expr(c(...)),
+    data,
+    allow_rename = FALSE,
+    error_arg = "..."
+  )
   vars <- names(vars)
 
   out <- purrr::modify_at(data, vars, str_split_n, pattern = sep)

--- a/R/separate-wider.R
+++ b/R/separate-wider.R
@@ -495,6 +495,7 @@ map_unpack <- function(data, cols, fun, names_sep, names_repair, error_call = ca
     data = data,
     allow_rename = FALSE,
     allow_empty = FALSE,
+    error_arg = "cols",
     error_call = error_call
   )
   col_names <- names(cols)

--- a/R/unite.R
+++ b/R/unite.R
@@ -48,7 +48,7 @@ unite.data.frame <- function(data, col, ..., sep = "_", remove = TRUE, na.rm = F
   if (dots_n(...) == 0) {
     selection <- set_names(seq_along(data), names(data))
   } else {
-    selection <- tidyselect::eval_select(expr(c(...)), data, allow_rename = FALSE)
+    selection <- tidyselect::eval_select(expr(c(...)), data, allow_rename = FALSE, error_arg = "...")
   }
 
   empty_selection <- length(selection) == 0L

--- a/R/unnest-longer.R
+++ b/R/unnest-longer.R
@@ -90,7 +90,7 @@ unnest_longer <- function(data,
 
   error_call <- current_env()
 
-  cols <- tidyselect::eval_select(enquo(col), data, allow_rename = FALSE)
+  cols <- tidyselect::eval_select(enquo(col), data, allow_rename = FALSE, error_arg = "col")
   col_names <- names(cols)
   n_col_names <- length(col_names)
 

--- a/R/unnest-wider.R
+++ b/R/unnest-wider.R
@@ -93,7 +93,7 @@ unnest_wider <- function(data,
 
   error_call <- current_env()
 
-  cols <- tidyselect::eval_select(enquo(col), data, allow_rename = FALSE)
+  cols <- tidyselect::eval_select(enquo(col), data, allow_rename = FALSE, error_arg = "col")
   col_names <- names(cols)
 
   for (i in seq_along(cols)) {

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -181,7 +181,8 @@ unnest.data.frame <- function(data,
   cols <- tidyselect::eval_select(
     expr = enquo(cols),
     data = data,
-    allow_rename = FALSE
+    allow_rename = FALSE,
+    error_arg = "cols"
   )
   cols <- unname(cols)
 

--- a/tests/testthat/_snaps/pack.md
+++ b/tests/testthat/_snaps/pack.md
@@ -109,6 +109,7 @@
     Condition
       Error in `unpack()`:
       ! Can't rename variables in this context.
+      i `cols` can't be renamed.
 
 # unpack() validates its inputs
 

--- a/tests/testthat/_snaps/pivot-long.md
+++ b/tests/testthat/_snaps/pivot-long.md
@@ -69,7 +69,7 @@
     Code
       (expect_error(pivot_longer(iris, matches("foo"))))
     Output
-      <error/rlang_error>
+      <error/tidyselect_error_empty_selection>
       Error in `pivot_longer()`:
       ! `cols` must select at least one column.
 
@@ -80,6 +80,7 @@
     Condition
       Error in `pivot_longer()`:
       ! Can't rename variables in this context.
+      i `cols` can't be renamed.
 
 # `names_to` is validated
 

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -53,9 +53,9 @@
       (expect_error(pivot_wider(df, names_from = starts_with("foo"), values_from = val))
       )
     Output
-      <error/rlang_error>
+      <error/tidyselect_error_empty_selection>
       Error in `pivot_wider()`:
-      ! Must select at least one item.
+      ! `names_from` must select at least one column.
 
 # `values_from` must identify at least 1 column (#1240)
 
@@ -63,9 +63,9 @@
       (expect_error(pivot_wider(df, names_from = key, values_from = starts_with("foo")))
       )
     Output
-      <error/rlang_error>
+      <error/tidyselect_error_empty_selection>
       Error in `pivot_wider()`:
-      ! Must select at least one item.
+      ! `values_from` must select at least one column.
 
 # `values_fn` emits an informative error when it doesn't result in unique values (#1238)
 
@@ -183,6 +183,7 @@
     Condition
       Error in `pivot_wider()`:
       ! Can't rename variables in this context.
+      i `id_cols` can't be renamed.
 
 # `id_expand` is validated
 

--- a/tests/testthat/_snaps/unnest.md
+++ b/tests/testthat/_snaps/unnest.md
@@ -65,6 +65,7 @@
     Condition
       Error in `unnest()`:
       ! Can't rename variables in this context.
+      i `cols` can't be renamed.
 
 # cols must go in cols
 


### PR DESCRIPTION
@lionel- , @DavisVaughan. Do you think this is good enough for https://github.com/r-lib/tidyselect/issues/336. https://github.com/r-lib/tidyselect/issues/327

If so, we can merge https://github.com/r-lib/tidyselect/pull/358 and then merge this one when tidyselect hits CRAN.

FWIW, r-lib/tidyselect#350 is already merged.