### PR TITLE
Improve error message for `pivot_wider()`

### DIFF
--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -676,17 +676,17 @@ rethrow_missing_cols_oob <- function(cnd, missing_name, missing_value, call) {
   check_string(i, .internal = TRUE)
 
   if (missing_name && i == "name") {
-    inform_missing("names_from", parent = cnd, call = call)
+    stop_inform_missing(i, "names_from", parent = cnd, call = call)
   } else if (missing_value && i == "value") {
-    inform_missing("values_from", parent = cnd, call = call)
+    stop_inform_missing(i, "values_from", parent = cnd, call = call)
   } else {
     # Zap this special handler, throw the normal condition
     zap()
   }
 }
 
-inform_missing <- function(arg, parent, call) {
-  msg <- c(`!` = "Have you supplied {.var {arg}}?")
+stop_inform_missing <- function(i, arg, parent, call) {
+  msg <- c(`i` = "Column {.var {i}} is the default for {.var {arg}}.")
   cli::cli_abort(msg, parent = parent, call = call)
 }
 

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -686,8 +686,10 @@ rethrow_missing_cols_oob <- function(cnd, missing_name, missing_value, call) {
 }
 
 stop_inform_missing <- function(i, arg, parent, call) {
-  msg <- c(`i` = "Column {.var {i}} is the default for {.var {arg}}.")
-  cli::cli_abort(msg, parent = parent, call = call)
+  cli::cli_abort(
+    c(`i` = "Column {.var {i}} is the default for the {.var {arg}} argument."),
+    parent = parent, call = call
+  )
 }
 
 rethrow_id_cols_oob <- function(cnd, names_from_cols, values_from_cols, call) {

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -676,15 +676,18 @@ rethrow_missing_cols_oob <- function(cnd, missing_name, missing_value, call) {
   check_string(i, .internal = TRUE)
 
   if (missing_name && i == "name") {
-    msg <- c(`!` = "Have you supplied {.var names_from}?")
-    cli::cli_abort(msg, parent = cnd, call = call)
+    inform_missing("names_from", parent = cnd, call = call)
   } else if (missing_value && i == "value") {
-    msg <- c(`!` = "Have you supplied {.var values_from}?")
-    cli::cli_abort(msg, parent = cnd, call = call)
+    inform_missing("values_from", parent = cnd, call = call)
   } else {
     # Zap this special handler, throw the normal condition
     zap()
   }
+}
+
+inform_missing <- function(arg, parent, call) {
+  msg <- c(`!` = "Have you supplied {.var {arg}}?")
+  cli::cli_abort(msg, parent = parent, call = call)
 }
 
 rethrow_id_cols_oob <- function(cnd, names_from_cols, values_from_cols, call) {

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -196,20 +196,28 @@ pivot_wider.data.frame <- function(
   values_fn = NULL,
   unused_fn = NULL
 ) {
+  missing_name <- missing(names_from)
+  missing_value <- missing(values_from)
+
   names_from <- enquo(names_from)
   values_from <- enquo(values_from)
 
-  spec <- build_wider_spec(
-    data = data,
-    names_from = !!names_from,
-    values_from = !!values_from,
-    names_prefix = names_prefix,
-    names_sep = names_sep,
-    names_glue = names_glue,
-    names_sort = names_sort,
-    names_vary = names_vary,
-    names_expand = names_expand,
-    error_call = current_env()
+  spec <- try_fetch(
+      build_wider_spec(
+      data = data,
+      names_from = !!names_from,
+      values_from = !!values_from,
+      names_prefix = names_prefix,
+      names_sep = names_sep,
+      names_glue = names_glue,
+      names_sort = names_sort,
+      names_vary = names_vary,
+      names_expand = names_expand,
+      error_call = current_env()
+    ),
+    vctrs_error_subscript_oob = function(cnd) {
+      rethrow_missing_cols_oob(cnd, missing_name, missing_value, current_env())
+    }
   )
 
   id_cols <- compat_id_cols(
@@ -514,19 +522,31 @@ build_wider_spec <- function(
 ) {
   check_dots_empty0(...)
 
-  names_from <- tidyselect::eval_select(
-    enquo(names_from),
-    data,
-    allow_rename = FALSE,
-    allow_empty = FALSE,
-    error_call = error_call
+  missing_name <- missing(names_from)
+  missing_value <- missing(values_from)
+  vctrs_error_subscript_oob <- function(cnd) {
+    rethrow_missing_cols_oob(cnd, missing_name, missing_value, error_call)
+  }
+
+  names_from <- try_fetch(
+    tidyselect::eval_select(
+      enquo(names_from),
+      data,
+      allow_rename = FALSE,
+      allow_empty = FALSE,
+      error_call = error_call
+    ),
+    vctrs_error_subscript_oob = vctrs_error_subscript_oob
   )
-  values_from <- tidyselect::eval_select(
-    enquo(values_from),
-    data,
-    allow_rename = FALSE,
-    allow_empty = FALSE,
-    error_call = error_call
+  values_from <- try_fetch(
+    tidyselect::eval_select(
+      enquo(values_from),
+      data,
+      allow_rename = FALSE,
+      allow_empty = FALSE,
+      error_call = error_call
+    ),
+    vctrs_error_subscript_oob = vctrs_error_subscript_oob
   )
 
   check_string(names_prefix, call = error_call)
@@ -648,6 +668,23 @@ select_wider_id_cols <- function(
   )
 
   names(id_cols)
+}
+
+rethrow_missing_cols_oob <- function(cnd, missing_name, missing_value, call) {
+  i <- cnd[["i"]]
+
+  check_string(i, .internal = TRUE)
+
+  if (missing_name && i == "name") {
+    msg <- c(`!` = "Have you supplied {.var names_from}?")
+    cli::cli_abort(msg, parent = cnd, call = call)
+  } else if (missing_value && i == "value") {
+    msg <- c(`!` = "Have you supplied {.var values_from}?")
+    cli::cli_abort(msg, parent = cnd, call = call)
+  } else {
+    # Zap this special handler, throw the normal condition
+    zap()
+  }
 }
 
 rethrow_id_cols_oob <- function(cnd, names_from_cols, values_from_cols, call) {

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -32,7 +32,7 @@
       pivot_wider(df, values_from = val)
     Condition
       Error in `pivot_wider()`:
-      ! Have you supplied `names_from`?
+      i Column `name` is the default for `names_from`.
       Caused by error in `pivot_wider()`:
       ! Can't select columns that don't exist.
       x Column `name` doesn't exist.
@@ -43,7 +43,7 @@
       pivot_wider(df, names_from = key)
     Condition
       Error in `pivot_wider()`:
-      ! Have you supplied `values_from`?
+      i Column `value` is the default for `values_from`.
       Caused by error in `pivot_wider()`:
       ! Can't select columns that don't exist.
       x Column `value` doesn't exist.

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -32,6 +32,8 @@
       pivot_wider(df, values_from = val)
     Condition
       Error in `pivot_wider()`:
+      ! Have you supplied `names_from`?
+      Caused by error in `pivot_wider()`:
       ! Can't select columns that don't exist.
       x Column `name` doesn't exist.
 
@@ -41,6 +43,8 @@
       pivot_wider(df, names_from = key)
     Condition
       Error in `pivot_wider()`:
+      ! Have you supplied `values_from`?
+      Caused by error in `pivot_wider()`:
       ! Can't select columns that don't exist.
       x Column `value` doesn't exist.
 

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -32,7 +32,7 @@
       pivot_wider(df, values_from = val)
     Condition
       Error in `pivot_wider()`:
-      i Column `name` is the default for `names_from`.
+      i Column `name` is the default for the `names_from` argument.
       Caused by error in `pivot_wider()`:
       ! Can't select columns that don't exist.
       x Column `name` doesn't exist.
@@ -43,7 +43,7 @@
       pivot_wider(df, names_from = key)
     Condition
       Error in `pivot_wider()`:
-      i Column `value` is the default for `values_from`.
+      i Column `value` is the default for the `values_from` argument.
       Caused by error in `pivot_wider()`:
       ! Can't select columns that don't exist.
       x Column `value` doesn't exist.


### PR DESCRIPTION
Fixes #1593.

Supplies an additional message to `vctrs_error_subscript_oob` if the user does not supply `names_from` or `values_from` to `pivot_wider()` or `build_wider_spec()`.

```r
pivot_wider(us_rent_income)
```
Before:
```
Error in `pivot_wider()`:
! Can't select columns that don't exist.
✖ Column `name` doesn't exist.
Run `rlang::last_trace()` to see where the error occurred.
```
After:
```
Error in `pivot_wider()`:
ℹ Column `name` is the default for the `names_from` argument.
Caused by error in `pivot_wider()`:
! Can't select columns that don't exist.
✖ Column `name` doesn't exist.
Run `rlang::last_trace()` to see where the error occurred.
```